### PR TITLE
Remove the need of creating extra file to be able to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,6 @@ Building
 
 Git pull should get you almost all you need, as long as you have a working [Android build system][4]
 
-You'll need to create the following files:
-
-1. `gradle.properties`, with the value `IAP_KEY` set to something (this is used for the in-app purchase).
-2. `app/keystore.properties` with the values `store`, `alias`, `pass`, `storePass` set. This is for signing the release build. Alternatively, comment the `signingConfigs` in `app/build.gradle`.
-
-
 Credits
 -------
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,6 +14,10 @@ android {
         buildConfigField("String", "IAP_KEY", "\"${rootProject.property("IAP_KEY")}\"")
     }
 
+    lintOptions {
+        abortOnError false
+    }
+
     signingConfigs {
         release {
             def Properties keyProps = new Properties()

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,12 @@ android {
         versionCode 7
         versionName "1.1.0"
 
-        buildConfigField("String", "IAP_KEY", "\"${rootProject.property("IAP_KEY")}\"")
+        if(rootProject.hasProperty("IAP_KEY")) {
+            buildConfigField("String", "IAP_KEY", "\"${rootProject.property("IAP_KEY")}\"")
+        } else {
+            buildConfigField("String", "IAP_KEY", "\"\"")
+        }
+
     }
 
     lintOptions {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,17 +18,7 @@ android {
         abortOnError false
     }
 
-    signingConfigs {
-        release {
-            def Properties keyProps = new Properties()
-            keyProps.load(new FileInputStream(file('keystore.properties')))
-
-            storeFile file(keyProps["store"])
-            keyAlias keyProps["alias"]
-            storePassword keyProps["storePass"]
-            keyPassword keyProps["pass"]
-        }
-    }
+    signingConfigs { release }
 
     buildTypes {
 //        debug {
@@ -71,4 +61,17 @@ dependencies {
     compile 'com.melnykov:floatingactionbutton:1.1.0'
 
     compile fileTree(dir: 'libs', include: ['*.jar'])
+}
+
+File propFile = file('signing.properties');
+if (propFile.exists()) {
+    def Properties props = new Properties()
+    props.load(new FileInputStream(propFile))
+
+    android.signingConfigs.release.storeFile = file(props['store'])
+    android.signingConfigs.release.storePassword = props['storePass']
+    android.signingConfigs.release.keyAlias = props['alias']
+    android.signingConfigs.release.keyPassword = props['pass']
+} else {
+    android.buildTypes.release.signingConfig = null
 }


### PR DESCRIPTION
Setting the `IAP_KEY` varaible and creating the `app/keystore.properties` file are not needed anymore with this set of patch.
This make it easier to build a debug version of the app.