### PR TITLE
FIX: draw selector on host selection (non-touch usage)

### DIFF
--- a/app/src/main/res/drawable/selector.xml
+++ b/app/src/main/res/drawable/selector.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@android:drawable/list_selector_background" android:state_focused="true"/>
+    <item android:drawable="@android:color/transparent"/>
+</selector>

--- a/app/src/main/res/layout/fragment_add_host_zeroconf.xml
+++ b/app/src/main/res/layout/fragment_add_host_zeroconf.xml
@@ -51,6 +51,7 @@
             android:layout_marginBottom="@dimen/remote_content_hmargin"
             android:choiceMode="singleChoice"
             style="@style/Widget.GridView"
+            android:listSelector="@drawable/selector"
             android:layout_below="@id/search_host_message"/>
 
         <ProgressBar

--- a/app/src/main/res/layout/grid_item_host.xml
+++ b/app/src/main/res/layout/grid_item_host.xml
@@ -1,71 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-   Copyright 2015 Synced Synapse. All rights reserved.
+    <!--
+       Copyright 2015 Synced Synapse. All rights reserved.
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+          http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
--->
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+    -->
 
-<android.support.v7.widget.CardView
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:card_view="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    card_view:cardElevation="@dimen/default_card_elevation"
-    card_view:cardBackgroundColor="?attr/appCardBackgroundColor">
-
-    <RelativeLayout
-        android:layout_width="match_parent"
+    <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:card_view="http://schemas.android.com/apk/res-auto"
         android:layout_height="wrap_content"
-        android:padding="@dimen/default_padding">
+        android:layout_width="match_parent"
+        >
 
-        <ImageView
-            android:id="@+id/status_indicator"
-            android:layout_width="@dimen/default_icon_size"
-            android:layout_height="@dimen/default_icon_size"
-            android:padding="@dimen/default_icon_padding"
-            android:layout_alignParentStart="true"
-            android:layout_alignParentLeft="true"
-            android:src="?attr/iconHosts"/>
-
-        <ImageView
-            android:id="@+id/list_context_menu"
-            android:layout_width="@dimen/default_icon_size"
-            android:layout_height="@dimen/default_icon_size"
-            android:padding="@dimen/default_icon_padding"
-            android:layout_alignTop="@id/status_indicator"
-            android:layout_alignParentRight="true"
-            style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconOverflow"
-            android:contentDescription="@string/action_options"/>
-
-        <TextView
-            android:id="@+id/host_name"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_toRightOf="@id/status_indicator"
-            android:layout_toLeftOf="@id/list_context_menu"
-            android:layout_alignTop="@id/status_indicator"
-            android:layout_alignWithParentIfMissing="true"
-            style="@style/TextAppearance.HostName"/>
-
-        <TextView
-            android:id="@+id/host_address"
+        <android.support.v7.widget.CardView
+            xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:card_view="http://schemas.android.com/apk/res-auto"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/host_name"
-            android:layout_alignLeft="@+id/host_name"
-            android:layout_alignRight="@+id/host_name"
-            style="@style/TextAppearance.HostDetails"/>
+            android:layout_gravity="center"
+            android:layout_marginBottom="@dimen/default_card_elevation"
+            android:layout_marginLeft="@dimen/default_card_elevation"
+            android:layout_marginRight="@dimen/default_card_elevation"
+            android:layout_marginTop="@dimen/default_card_elevation"
+            card_view:cardUseCompatPadding="true"
+            card_view:cardElevation="@dimen/default_card_elevation"
+            card_view:cardBackgroundColor="?attr/appCardBackgroundColor">
 
-    </RelativeLayout>
-</android.support.v7.widget.CardView>
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="@dimen/default_padding">
+
+                <ImageView
+                    android:id="@+id/status_indicator"
+                    android:layout_width="@dimen/default_icon_size"
+                    android:layout_height="@dimen/default_icon_size"
+                    android:padding="@dimen/default_icon_padding"
+                    android:layout_alignParentStart="true"
+                    android:layout_alignParentLeft="true"
+                    android:src="?attr/iconHosts"/>
+
+                <ImageView
+                    android:id="@+id/list_context_menu"
+                    android:layout_width="@dimen/default_icon_size"
+                    android:layout_height="@dimen/default_icon_size"
+                    android:padding="@dimen/default_icon_padding"
+                    android:layout_alignTop="@id/status_indicator"
+                    android:layout_alignParentRight="true"
+                    style="@style/Widget.Button.Borderless"
+                    android:src="?attr/iconOverflow"
+                    android:contentDescription="@string/action_options"/>
+
+                <TextView
+                    android:id="@+id/host_name"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_toRightOf="@id/status_indicator"
+                    android:layout_toLeftOf="@id/list_context_menu"
+                    android:layout_alignTop="@id/status_indicator"
+                    android:layout_alignWithParentIfMissing="true"
+                    style="@style/TextAppearance.HostName"/>
+
+                <TextView
+                    android:id="@+id/host_address"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@+id/host_name"
+                    android:layout_alignLeft="@+id/host_name"
+                    android:layout_alignRight="@+id/host_name"
+                    style="@style/TextAppearance.HostDetails"/>
+
+            </RelativeLayout>
+        </android.support.v7.widget.CardView>
+    </FrameLayout>


### PR DESCRIPTION
When using an actual remote (non-touch), no highlight was drawn around the host cards

FYI, a distant project of mine would be to make Kore a thin Kodi client on AndroidTV which would use, e.g., an headless Kodi as server. 