### PR TITLE
#99, fixed external keyboard return key to send text instead of just …

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/SendTextDialogFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/SendTextDialogFragment.java
@@ -137,13 +137,21 @@ public class SendTextDialogFragment extends DialogFragment {
         textToSend.setOnEditorActionListener(new TextView.OnEditorActionListener() {
             @Override
             public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
-                if (actionId == EditorInfo.IME_ACTION_SEND) {
-                    mListener.onSendTextFinished(
-                            textToSend.getText().toString(),
-                            finishAfterSend.isChecked());
+                if (actionId == EditorInfo.IME_ACTION_SEND ) {
+                    onSendTextFinished();
+                }  // handles enter key on external keyboard, issue #99
+                else if (actionId == EditorInfo.IME_ACTION_UNSPECIFIED &&
+                        (event != null && event.getAction() == KeyEvent.ACTION_DOWN && event.getKeyCode() == KeyEvent.KEYCODE_ENTER)) {
+                    onSendTextFinished();
                 }
                 dialog.dismiss();
                 return false;
+            }
+
+            private void onSendTextFinished() {
+                mListener.onSendTextFinished(
+                        textToSend.getText().toString(),
+                        finishAfterSend.isChecked());
             }
         });
         return dialog;


### PR DESCRIPTION
…dismiss dialog

There was no handler for external keyboard enter key. I just added handler (if statement) for that case. When user is pressing enter key there is actionId 0 (unspecified) and event  keycode ENTER_KEY.