### PR TITLE
Improved keeping user informed on sync progress

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/AbstractListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractListFragment.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2015 Martijn Brekhof. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.xbmc.kore.ui;
+
+import android.content.ServiceConnection;
+import android.database.Cursor;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.LoaderManager;
+import android.support.v4.content.CursorLoader;
+import android.support.v4.content.Loader;
+import android.support.v4.widget.SwipeRefreshLayout;
+import android.support.v7.widget.SearchView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.CursorAdapter;
+import android.widget.GridView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import org.xbmc.kore.R;
+import org.xbmc.kore.host.HostInfo;
+import org.xbmc.kore.host.HostManager;
+import org.xbmc.kore.jsonrpc.event.MediaSyncEvent;
+import org.xbmc.kore.service.SyncUtils;
+
+import butterknife.ButterKnife;
+import butterknife.InjectView;
+import de.greenrobot.event.EventBus;
+
+public abstract class AbstractListFragment extends Fragment
+		implements LoaderManager.LoaderCallbacks<Cursor>,
+		SyncUtils.OnServiceListener,
+		SearchView.OnQueryTextListener,
+		SwipeRefreshLayout.OnRefreshListener {
+
+	private ServiceConnection serviceConnection;
+	private CursorAdapter adapter;
+
+	private HostInfo hostInfo;
+	private EventBus bus;
+
+	// Loader IDs
+	private static final int LOADER = 0;
+
+	// The search filter to use in the loader
+	private String searchFilter = null;
+
+	private boolean isSyncing;
+
+	@InjectView(R.id.swipe_refresh_layout) SwipeRefreshLayout swipeRefreshLayout;
+	@InjectView(R.id.list) GridView gridView;
+	@InjectView(android.R.id.empty) TextView emptyView;
+
+	abstract protected AdapterView.OnItemClickListener createOnItemClickListener();
+	abstract protected CursorAdapter createAdapter();
+	abstract protected void onSwipeRefresh();
+	abstract protected CursorLoader createCursorLoader();
+
+	/**
+	 * Called each time a MediaSyncEvent is received.
+	 * @param event
+	 */
+	abstract protected void onSyncProcessEnded(MediaSyncEvent event);
+
+	@Nullable
+	@Override
+	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+		ViewGroup root = (ViewGroup) inflater.inflate(R.layout.fragment_generic_media_list, container, false);
+		ButterKnife.inject(this, root);
+
+		bus = EventBus.getDefault();
+		HostManager hostManager = HostManager.getInstance(getActivity());
+		hostInfo = hostManager.getHostInfo();
+
+		swipeRefreshLayout.setOnRefreshListener(this);
+
+		return root;
+	}
+
+	@Override
+	public void onActivityCreated (Bundle savedInstanceState) {
+		super.onActivityCreated(savedInstanceState);
+
+		gridView.setEmptyView(emptyView);
+		gridView.setOnItemClickListener(createOnItemClickListener());
+
+		// Configure the adapter and start the loader
+		adapter = createAdapter();
+		gridView.setAdapter(adapter);
+
+		getLoaderManager().initLoader(LOADER, null, this);
+
+		setHasOptionsMenu(true);
+	}
+
+	@Override
+	public void onStart() {
+		super.onStart();
+		serviceConnection = SyncUtils.connectToLibrarySyncService(getActivity(), this);
+	}
+
+	@Override
+	public void onResume() {
+		bus.register(this);
+		super.onResume();
+	}
+
+	@Override
+	public void onPause() {
+		bus.unregister(this);
+		super.onPause();
+	}
+
+	@Override
+	public void onStop() {
+		super.onStop();
+		SyncUtils.disconnectFromLibrarySyncService(getActivity(), serviceConnection);
+	}
+
+	/**
+	 * Swipe refresh layout callback
+	 */
+	/** {@inheritDoc} */
+	@Override
+	public void onRefresh() {
+		if (hostInfo != null) {
+			showRefreshAnimation();
+			onSwipeRefresh();
+		} else {
+			swipeRefreshLayout.setRefreshing(false);
+			Toast.makeText(getActivity(), R.string.no_xbmc_configured, Toast.LENGTH_SHORT)
+					.show();
+		}
+	}
+
+	/**
+	 * Event bus post. Called when the syncing process ended
+	 *
+	 * @param event Refreshes data
+	 */
+	public void onEventMainThread(MediaSyncEvent event) {
+		onSyncProcessEnded(event);
+	}
+
+	/**
+	 * Search view callbacks
+	 */
+	/** {@inheritDoc} */
+	@Override
+	public boolean onQueryTextChange(String newText) {
+		searchFilter = newText;
+		getLoaderManager().restartLoader(LOADER, null, this);
+		return true;
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public boolean onQueryTextSubmit(String newText) {
+		// All is handled in onQueryTextChange
+		return true;
+	}
+
+	/**
+	 * Loader callbacks
+	 */
+	/** {@inheritDoc} */
+	@Override
+	public Loader<Cursor> onCreateLoader(int i, Bundle bundle) {
+		return createCursorLoader();
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public void onLoadFinished(Loader<Cursor> cursorLoader, Cursor cursor) {
+		adapter.swapCursor(cursor);
+		// To prevent the empty text from appearing on the first load, set it now
+		emptyView.setText(getString(R.string.swipe_down_to_refresh));
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public void onLoaderReset(Loader<Cursor> cursorLoader) {
+		adapter.swapCursor(null);
+	}
+
+
+	/**
+	 * @return text entered in searchview
+	 */
+	public String getSearchFilter() {
+		return searchFilter;
+	}
+
+	/**
+	 * Use this to reload the items in the list
+	 */
+	public void refreshList() {
+		getLoaderManager().restartLoader(LOADER, null, this);
+	}
+
+	public void showRefreshAnimation() {
+		/**
+		 * Fixes issue with refresh animation not showing when using appcompat library (from version 20?)
+		 * See https://code.google.com/p/android/issues/detail?id=77712
+		 */
+		swipeRefreshLayout.post(new Runnable() {
+			@Override
+			public void run() {
+				swipeRefreshLayout.setRefreshing(true);
+			}
+		});
+	}
+}

--- a/app/src/main/java/org/xbmc/kore/ui/AbstractMusicListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractMusicListFragment.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 Martijn Brekhof. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.xbmc.kore.ui;
+
+import android.content.Intent;
+import android.widget.Toast;
+
+import org.xbmc.kore.R;
+import org.xbmc.kore.host.HostManager;
+import org.xbmc.kore.jsonrpc.ApiException;
+import org.xbmc.kore.jsonrpc.event.MediaSyncEvent;
+import org.xbmc.kore.service.LibrarySyncService;
+import org.xbmc.kore.service.SyncUtils;
+import org.xbmc.kore.utils.UIUtils;
+
+public abstract class AbstractMusicListFragment extends AbstractListFragment {
+	@Override
+	protected void onSwipeRefresh() {
+		// Start the syncing process
+		Intent syncIntent = new Intent(this.getActivity(), LibrarySyncService.class);
+		syncIntent.putExtra(LibrarySyncService.SYNC_ALL_MUSIC, true);
+		getActivity().startService(syncIntent);
+	}
+
+	@Override
+	protected void onSyncProcessEnded(MediaSyncEvent event) {
+		if (event.syncType.equals(LibrarySyncService.SYNC_ALL_MUSIC)) {
+			swipeRefreshLayout.setRefreshing(false);
+			if (event.status == MediaSyncEvent.STATUS_SUCCESS) {
+				refreshList();
+				Toast.makeText(getActivity(), R.string.sync_successful, Toast.LENGTH_SHORT)
+						.show();
+			} else {
+				String msg = (event.errorCode == ApiException.API_ERROR) ?
+						String.format(getString(R.string.error_while_syncing), event.errorMessage) :
+						getString(R.string.unable_to_connect_to_xbmc);
+				Toast.makeText(getActivity(), msg, Toast.LENGTH_SHORT).show();
+			}
+		}
+	}
+
+	@Override
+	public void onServiceConnected(LibrarySyncService librarySyncService) {
+		if(SyncUtils.isLibrarySyncing(librarySyncService, HostManager.getInstance(getActivity()).getHostInfo(),
+				LibrarySyncService.SYNC_ALL_MUSIC, LibrarySyncService.SYNC_ALL_MUSIC_VIDEOS)) {
+			showRefreshAnimation();
+		}
+	}
+}

--- a/app/src/main/java/org/xbmc/kore/ui/AlbumListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AlbumListFragment.java
@@ -62,39 +62,22 @@ import de.greenrobot.event.EventBus;
 /**
  * Fragment that presents the albums list
  */
-public class AlbumListFragment extends Fragment
-        implements LoaderManager.LoaderCallbacks<Cursor>,
-        SwipeRefreshLayout.OnRefreshListener,
-        SearchView.OnQueryTextListener {
+public class AlbumListFragment extends AbstractMusicListFragment {
     private static final String TAG = LogUtils.makeLogTag(AlbumListFragment.class);
 
     public interface OnAlbumSelectedListener {
         public void onAlbumSelected(int albumId, String albumTitle);
     }
 
-    // Loader IDs
-    private static final int LOADER_ALBUMS = 0;
-
     private static final String GENREID = "genreid",
             ARTISTID = "artistid";
 
-    // The search filter to use in the loader
-    private String searchFilter = null;
     private int genreId = -1;
     private int artistId = -1;
-
-    // Movies adapter
-    private CursorAdapter adapter;
 
     // Activity listener
     private OnAlbumSelectedListener listenerActivity;
 
-    private HostInfo hostInfo;
-    private EventBus bus;
-
-    @InjectView(R.id.list) GridView albumsGridView;
-    @InjectView(R.id.swipe_refresh_layout) SwipeRefreshLayout swipeRefreshLayout;
-    @InjectView(android.R.id.empty) TextView emptyView;
 
     /**
      * Create a new instance of this, initialized to show albums of genres
@@ -121,8 +104,47 @@ public class AlbumListFragment extends Fragment
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    protected AdapterView.OnItemClickListener createOnItemClickListener() {
+        return new AdapterView.OnItemClickListener() {
+            @Override
+            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                // Get the movie id from the tag
+                ViewHolder tag = (ViewHolder) view.getTag();
+                // Notify the activity
+                listenerActivity.onAlbumSelected(tag.albumId, tag.albumTitle);
+            }
+        };
+    }
+
+    @Override
+    protected CursorAdapter createAdapter() {
+        return new AlbumsAdapter(getActivity());
+    }
+
+    @Override
+    protected CursorLoader createCursorLoader() {
+        Uri uri;
+        HostInfo hostInfo = HostManager.getInstance(getActivity()).getHostInfo();
+        int hostId = hostInfo != null ? hostInfo.getId() : -1;
+
+        if (artistId != -1) {
+            uri = MediaContract.AlbumArtists.buildAlbumsForArtistListUri(hostId, artistId);
+        } else if (genreId != -1) {
+            uri = MediaContract.AlbumGenres.buildAlbumsForGenreListUri(hostId, genreId);
+        } else {
+            uri = MediaContract.Albums.buildAlbumsListUri(hostId);
+        }
+
+        String selection = null;
+        String selectionArgs[] = null;
+        String searchFilter = getSearchFilter();
+        if (!TextUtils.isEmpty(searchFilter)) {
+            selection = MediaContract.Albums.TITLE + " LIKE ?";
+            selectionArgs = new String[] {"%" + searchFilter + "%"};
+        }
+
+        return new CursorLoader(getActivity(), uri,
+                AlbumListQuery.PROJECTION, selection, selectionArgs, AlbumListQuery.SORT);
     }
 
     @Override
@@ -133,43 +155,7 @@ public class AlbumListFragment extends Fragment
             artistId = getArguments().getInt(ARTISTID, -1);
         }
 
-        ViewGroup root = (ViewGroup) inflater.inflate(R.layout.fragment_generic_media_list, container, false);
-        ButterKnife.inject(this, root);
-
-        bus = EventBus.getDefault();
-        hostInfo = HostManager.getInstance(getActivity()).getHostInfo();
-
-        swipeRefreshLayout.setOnRefreshListener(this);
-
-        // Pad main content view to overlap with bottom system bar
-//        UIUtils.setPaddingForSystemBars(getActivity(), albumsGridView, false, false, true);
-//        albumsGridView.setClipToPadding(false);
-
-        return root;
-    }
-
-
-    @Override
-    public void onActivityCreated (Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
-
-        albumsGridView.setEmptyView(emptyView);
-        albumsGridView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-            @Override
-            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                // Get the movie id from the tag
-                ViewHolder tag = (ViewHolder) view.getTag();
-                // Notify the activity
-                listenerActivity.onAlbumSelected(tag.albumId, tag.albumTitle);
-            }
-        });
-
-        // Configure the adapter and start the loader
-        adapter = new AlbumsAdapter(getActivity());
-        albumsGridView.setAdapter(adapter);
-        getLoaderManager().initLoader(LOADER_ALBUMS, null, this);
-
-        setHasOptionsMenu(true);
+        return super.onCreateView(inflater, container, savedInstanceState);
     }
 
     @Override
@@ -189,18 +175,6 @@ public class AlbumListFragment extends Fragment
     }
 
     @Override
-    public void onResume() {
-        bus.register(this);
-        super.onResume();
-    }
-
-    @Override
-    public void onPause() {
-        bus.unregister(this);
-        super.onPause();
-    }
-
-    @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         inflater.inflate(R.menu.media_search, menu);
         MenuItem searchItem = menu.findItem(R.id.action_search);
@@ -208,112 +182,6 @@ public class AlbumListFragment extends Fragment
         searchView.setOnQueryTextListener(this);
         searchView.setQueryHint(getString(R.string.action_search_albums));
         super.onCreateOptionsMenu(menu, inflater);
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        return super.onOptionsItemSelected(item);
-    }
-
-    /**
-     * Search view callbacks
-     */
-    /** {@inheritDoc} */
-    @Override
-    public boolean onQueryTextChange(String newText) {
-        searchFilter = newText;
-        getLoaderManager().restartLoader(LOADER_ALBUMS, null, this);
-        return true;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean onQueryTextSubmit(String newText) {
-        // All is handled in onQueryTextChange
-        return true;
-    }
-
-    /**
-     * Swipe refresh layout callback
-     */
-    /** {@inheritDoc} */
-    @Override
-    public void onRefresh () {
-        if (hostInfo != null) {
-            // Make sure we're showing the refresh
-            swipeRefreshLayout.setRefreshing(true);
-            // Start the syncing process
-            Intent syncIntent = new Intent(this.getActivity(), LibrarySyncService.class);
-            syncIntent.putExtra(LibrarySyncService.SYNC_ALL_MUSIC, true);
-            getActivity().startService(syncIntent);
-        } else {
-            swipeRefreshLayout.setRefreshing(false);
-            Toast.makeText(getActivity(), R.string.no_xbmc_configured, Toast.LENGTH_SHORT)
-                 .show();
-        }
-    }
-
-    /**
-     * Event bus post. Called when the syncing process ended
-     *
-     * @param event Refreshes data
-     */
-    public void onEventMainThread(MediaSyncEvent event) {
-        if (event.syncType.equals(LibrarySyncService.SYNC_ALL_MUSIC)) {
-            swipeRefreshLayout.setRefreshing(false);
-            if (event.status == MediaSyncEvent.STATUS_SUCCESS) {
-                getLoaderManager().restartLoader(LOADER_ALBUMS, null, this);
-                Toast.makeText(getActivity(), R.string.sync_successful, Toast.LENGTH_SHORT)
-                     .show();
-            } else {
-                String msg = (event.errorCode == ApiException.API_ERROR) ?
-                             String.format(getString(R.string.error_while_syncing), event.errorMessage) :
-                             getString(R.string.unable_to_connect_to_xbmc);
-                Toast.makeText(getActivity(), msg, Toast.LENGTH_SHORT).show();
-            }
-        }
-    }
-
-    /**
-     * Loader callbacks
-     */
-    /** {@inheritDoc} */
-    @Override
-    public Loader<Cursor> onCreateLoader(int i, Bundle bundle) {
-        Uri uri;
-        int hostId = hostInfo != null ? hostInfo.getId() : -1;
-
-        if (artistId != -1) {
-            uri = MediaContract.AlbumArtists.buildAlbumsForArtistListUri(hostId, artistId);
-        } else if (genreId != -1) {
-            uri = MediaContract.AlbumGenres.buildAlbumsForGenreListUri(hostId, genreId);
-        } else {
-            uri = MediaContract.Albums.buildAlbumsListUri(hostId);
-        }
-
-        String selection = null;
-        String selectionArgs[] = null;
-        if (!TextUtils.isEmpty(searchFilter)) {
-            selection = MediaContract.Albums.TITLE + " LIKE ?";
-            selectionArgs = new String[] {"%" + searchFilter + "%"};
-        }
-
-        return new CursorLoader(getActivity(), uri,
-                AlbumListQuery.PROJECTION, selection, selectionArgs, AlbumListQuery.SORT);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void onLoadFinished(Loader<Cursor> cursorLoader, Cursor cursor) {
-        adapter.swapCursor(cursor);
-        // To prevent the empty text from appearing on the first load, set it now
-        emptyView.setText(getString(R.string.no_albums_found_refresh));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void onLoaderReset(Loader<Cursor> cursorLoader) {
-        adapter.swapCursor(null);
     }
 
     /**

--- a/app/src/main/java/org/xbmc/kore/ui/ArtistListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/ArtistListFragment.java
@@ -17,18 +17,12 @@ package org.xbmc.kore.ui;
 
 import android.app.Activity;
 import android.content.Context;
-import android.content.Intent;
 import android.content.res.Resources;
 import android.database.Cursor;
 import android.net.Uri;
-import android.os.Bundle;
 import android.provider.BaseColumns;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.LoaderManager;
 import android.support.v4.content.CursorLoader;
-import android.support.v4.content.Loader;
 import android.support.v4.view.MenuItemCompat;
-import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.SearchView;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -39,104 +33,63 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.CursorAdapter;
-import android.widget.GridView;
 import android.widget.ImageView;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import org.xbmc.kore.R;
 import org.xbmc.kore.host.HostInfo;
 import org.xbmc.kore.host.HostManager;
-import org.xbmc.kore.jsonrpc.ApiException;
-import org.xbmc.kore.jsonrpc.event.MediaSyncEvent;
 import org.xbmc.kore.provider.MediaContract;
 import org.xbmc.kore.provider.MediaDatabase;
-import org.xbmc.kore.service.LibrarySyncService;
 import org.xbmc.kore.utils.LogUtils;
 import org.xbmc.kore.utils.UIUtils;
-
-import butterknife.ButterKnife;
-import butterknife.InjectView;
-import de.greenrobot.event.EventBus;
 
 /**
  * Fragment that presents the artists list
  */
-public class ArtistListFragment extends Fragment
-        implements LoaderManager.LoaderCallbacks<Cursor>,
-        SwipeRefreshLayout.OnRefreshListener,
-        SearchView.OnQueryTextListener {
+public class ArtistListFragment extends AbstractMusicListFragment {
     private static final String TAG = LogUtils.makeLogTag(ArtistListFragment.class);
 
     public interface OnArtistSelectedListener {
         public void onArtistSelected(int artistId, String artistName);
     }
 
-    // Loader IDs
-    private static final int LOADER_ARTISTS = 0;
-
-    // The search filter to use in the loader
-    private String searchFilter = null;
-
-    // Movies adapter
-    private CursorAdapter adapter;
-
     // Activity listener
     private OnArtistSelectedListener listenerActivity;
 
-    private HostManager hostManager;
-    private HostInfo hostInfo;
-    private EventBus bus;
-
-    @InjectView(R.id.list) GridView artistsGridView;
-    @InjectView(R.id.swipe_refresh_layout) SwipeRefreshLayout swipeRefreshLayout;
-    @InjectView(android.R.id.empty) TextView emptyView;
-
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-    }
-
-    @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        ViewGroup root = (ViewGroup) inflater.inflate(R.layout.fragment_generic_media_list, container, false);
-        ButterKnife.inject(this, root);
-
-        bus = EventBus.getDefault();
-        hostManager = HostManager.getInstance(getActivity());
-        hostInfo = hostManager.getHostInfo();
-
-        swipeRefreshLayout.setOnRefreshListener(this);
-        //UIUtils.setSwipeRefreshLayoutColorScheme(swipeRefreshLayout);
-
-        // Pad main content view to overlap with bottom system bar
-//        UIUtils.setPaddingForSystemBars(getActivity(), artistsGridView, false, false, true);
-//        artistsGridView.setClipToPadding(false);
-
-        return root;
-    }
-
-    @Override
-    public void onActivityCreated (Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
-
-        artistsGridView.setEmptyView(emptyView);
-        artistsGridView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+    protected AdapterView.OnItemClickListener createOnItemClickListener() {
+        return new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                // Get the movie id from the tag
+                // Get the artist id from the tag
                 ViewHolder tag = (ViewHolder) view.getTag();
                 // Notify the activity
                 listenerActivity.onArtistSelected(tag.artistId, tag.artistName);
             }
-        });
+        };
+    }
 
-        // Configure the adapter and start the loader
-        adapter = new ArtistsAdapter(getActivity());
-        artistsGridView.setAdapter(adapter);
-        getLoaderManager().initLoader(LOADER_ARTISTS, null, this);
+    @Override
+    protected CursorAdapter createAdapter() {
+        return new ArtistsAdapter(getActivity());
+    }
 
-        setHasOptionsMenu(true);
+    @Override
+    protected CursorLoader createCursorLoader() {
+        HostInfo hostInfo = HostManager.getInstance(getActivity()).getHostInfo();
+        Uri uri = MediaContract.Artists.buildArtistsListUri(hostInfo != null ? hostInfo.getId() : -1);
+
+        String selection = null;
+        String selectionArgs[] = null;
+        String searchFilter = getSearchFilter();
+        if (!TextUtils.isEmpty(searchFilter)) {
+            selection = MediaContract.ArtistsColumns.ARTIST + " LIKE ?";
+            selectionArgs = new String[] {"%" + searchFilter + "%"};
+        }
+
+        return new CursorLoader(getActivity(), uri,
+                ArtistListQuery.PROJECTION, selection, selectionArgs, ArtistListQuery.SORT);
     }
 
     @Override
@@ -156,18 +109,6 @@ public class ArtistListFragment extends Fragment
     }
 
     @Override
-    public void onResume() {
-        bus.register(this);
-        super.onResume();
-    }
-
-    @Override
-    public void onPause() {
-        bus.unregister(this);
-        super.onPause();
-    }
-
-    @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         inflater.inflate(R.menu.media_search, menu);
         MenuItem searchItem = menu.findItem(R.id.action_search);
@@ -175,113 +116,6 @@ public class ArtistListFragment extends Fragment
         searchView.setOnQueryTextListener(this);
         searchView.setQueryHint(getString(R.string.action_search_artists));
         super.onCreateOptionsMenu(menu, inflater);
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-//        switch (item.getItemId()) {
-//            default:
-//                break;
-//        }
-//
-        return super.onOptionsItemSelected(item);
-    }
-
-    /**
-     * Search view callbacks
-     */
-    /** {@inheritDoc} */
-    @Override
-    public boolean onQueryTextChange(String newText) {
-        searchFilter = newText;
-        getLoaderManager().restartLoader(LOADER_ARTISTS, null, this);
-        return true;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean onQueryTextSubmit(String newText) {
-        // All is handled in onQueryTextChange
-        return true;
-    }
-
-    /**
-     * Swipe refresh layout callback
-     */
-    /** {@inheritDoc} */
-    @Override
-    public void onRefresh() {
-        if (hostInfo != null) {
-            // Make sure we're showing the refresh
-            swipeRefreshLayout.setRefreshing(true);
-            // Start the syncing process
-            Intent syncIntent = new Intent(this.getActivity(), LibrarySyncService.class);
-            syncIntent.putExtra(LibrarySyncService.SYNC_ALL_MUSIC, true);
-            getActivity().startService(syncIntent);
-
-//            Toast.makeText(getActivity(),
-//                    String.format(getString(R.string.sync_movies_for_host), hostInfo.getName()),
-//                    Toast.LENGTH_SHORT)
-//                 .show();
-        } else {
-            swipeRefreshLayout.setRefreshing(false);
-            Toast.makeText(getActivity(), R.string.no_xbmc_configured, Toast.LENGTH_SHORT)
-                 .show();
-        }
-    }
-
-    /**
-     * Event bus post. Called when the syncing process ended
-     *
-     * @param event Refreshes data
-     */
-    public void onEventMainThread(MediaSyncEvent event) {
-        if (event.syncType.equals(LibrarySyncService.SYNC_ALL_MUSIC)) {
-            swipeRefreshLayout.setRefreshing(false);
-            if (event.status == MediaSyncEvent.STATUS_SUCCESS) {
-                getLoaderManager().restartLoader(LOADER_ARTISTS, null, this);
-                Toast.makeText(getActivity(), R.string.sync_successful, Toast.LENGTH_SHORT)
-                     .show();
-            } else {
-                String msg = (event.errorCode == ApiException.API_ERROR) ?
-                             String.format(getString(R.string.error_while_syncing), event.errorMessage) :
-                             getString(R.string.unable_to_connect_to_xbmc);
-                Toast.makeText(getActivity(), msg, Toast.LENGTH_SHORT).show();
-            }
-        }
-    }
-
-    /**
-     * Loader callbacks
-     */
-    /** {@inheritDoc} */
-    @Override
-    public Loader<Cursor> onCreateLoader(int i, Bundle bundle) {
-        Uri uri = MediaContract.Artists.buildArtistsListUri(hostInfo != null ? hostInfo.getId() : -1);
-
-        String selection = null;
-        String selectionArgs[] = null;
-        if (!TextUtils.isEmpty(searchFilter)) {
-            selection = MediaContract.ArtistsColumns.ARTIST + " LIKE ?";
-            selectionArgs = new String[] {"%" + searchFilter + "%"};
-        }
-
-        return new CursorLoader(getActivity(), uri,
-                ArtistListQuery.PROJECTION, selection, selectionArgs, ArtistListQuery.SORT);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void onLoadFinished(Loader<Cursor> cursorLoader, Cursor cursor) {
-        adapter.swapCursor(cursor);
-        // To prevent the empty text from appearing on the first load, set it now
-        emptyView.setText(getString(R.string.no_artists_found_refresh));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void onLoaderReset(Loader<Cursor> cursorLoader) {
-        adapter.swapCursor(null);
     }
 
     /**
@@ -317,16 +151,16 @@ public class ArtistListFragment extends Fragment
             // Get the art dimensions
             Resources resources = context.getResources();
             artWidth = (int)(resources.getDimension(R.dimen.artistlist_art_width) /
-                             UIUtils.IMAGE_RESIZE_FACTOR);
+                    UIUtils.IMAGE_RESIZE_FACTOR);
             artHeight = (int)(resources.getDimension(R.dimen.artistlist_art_heigth) /
-                              UIUtils.IMAGE_RESIZE_FACTOR);
+                    UIUtils.IMAGE_RESIZE_FACTOR);
         }
 
         /** {@inheritDoc} */
         @Override
         public View newView(Context context, final Cursor cursor, ViewGroup parent) {
             final View view = LayoutInflater.from(context)
-                                            .inflate(R.layout.grid_item_artist, parent, false);
+                    .inflate(R.layout.grid_item_artist, parent, false);
 
             // Setup View holder pattern
             ViewHolder viewHolder = new ViewHolder();

--- a/app/src/main/java/org/xbmc/kore/ui/AudioGenresListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AudioGenresListFragment.java
@@ -61,65 +61,19 @@ import de.greenrobot.event.EventBus;
 /**
  * Fragment that presents the album genres list
  */
-public class AudioGenresListFragment extends Fragment
-        implements LoaderManager.LoaderCallbacks<Cursor>,
-        SwipeRefreshLayout.OnRefreshListener,
-        SearchView.OnQueryTextListener {
+public class AudioGenresListFragment extends AbstractMusicListFragment {
     private static final String TAG = LogUtils.makeLogTag(AudioGenresListFragment.class);
 
     public interface OnAudioGenreSelectedListener {
         public void onAudioGenreSelected(int genreId, String genreTitle);
     }
 
-    // Loader IDs
-    private static final int LOADER_AUDIO_GENRES = 0;
-
-    // The search filter to use in the loader
-    private String searchFilter = null;
-
-    // Movies adapter
-    private CursorAdapter adapter;
-
     // Activity listener
     private OnAudioGenreSelectedListener listenerActivity;
 
-    private HostInfo hostInfo;
-    private EventBus bus;
-
-    @InjectView(R.id.list) GridView audioGenresGridView;
-    @InjectView(R.id.swipe_refresh_layout) SwipeRefreshLayout swipeRefreshLayout;
-    @InjectView(android.R.id.empty) TextView emptyView;
-
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-    }
-
-    @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        ViewGroup root = (ViewGroup) inflater.inflate(R.layout.fragment_generic_media_list, container, false);
-        ButterKnife.inject(this, root);
-
-        bus = EventBus.getDefault();
-        hostInfo = HostManager.getInstance(getActivity()).getHostInfo();
-
-        swipeRefreshLayout.setOnRefreshListener(this);
-        //UIUtils.setSwipeRefreshLayoutColorScheme(swipeRefreshLayout);
-
-        // Pad main content view to overlap with bottom system bar
-//        UIUtils.setPaddingForSystemBars(getActivity(), audioGenresGridView, false, false, true);
-//        audioGenresGridView.setClipToPadding(false);
-
-        return root;
-    }
-
-
-    @Override
-    public void onActivityCreated (Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
-
-        audioGenresGridView.setEmptyView(emptyView);
-        audioGenresGridView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+    protected AdapterView.OnItemClickListener createOnItemClickListener() {
+        return new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
                 // Get the movie id from the tag
@@ -127,14 +81,29 @@ public class AudioGenresListFragment extends Fragment
                 // Notify the activity
                 listenerActivity.onAudioGenreSelected(tag.genreId, tag.genreTitle);
             }
-        });
+        };
+    }
 
-        // Configure the adapter and start the loader
-        adapter = new AudioGenresAdapter(getActivity());
-        audioGenresGridView.setAdapter(adapter);
-        getLoaderManager().initLoader(LOADER_AUDIO_GENRES, null, this);
+    @Override
+    protected CursorAdapter createAdapter() {
+        return new AudioGenresAdapter(getActivity());
+    }
 
-        setHasOptionsMenu(true);
+    @Override
+    protected CursorLoader createCursorLoader() {
+        HostInfo hostInfo = HostManager.getInstance(getActivity()).getHostInfo();
+        Uri uri = MediaContract.AudioGenres.buildAudioGenresListUri(hostInfo != null ? hostInfo.getId() : -1);
+
+        String selection = null;
+        String selectionArgs[] = null;
+        String searchFilter = getSearchFilter();
+        if (!TextUtils.isEmpty(searchFilter)) {
+            selection = MediaContract.AudioGenres.TITLE + " LIKE ?";
+            selectionArgs = new String[] {"%" + searchFilter + "%"};
+        }
+
+        return new CursorLoader(getActivity(), uri,
+                AudioGenreListQuery.PROJECTION, selection, selectionArgs, AudioGenreListQuery.SORT);
     }
 
     @Override
@@ -154,18 +123,6 @@ public class AudioGenresListFragment extends Fragment
     }
 
     @Override
-    public void onResume() {
-        bus.register(this);
-        super.onResume();
-    }
-
-    @Override
-    public void onPause() {
-        bus.unregister(this);
-        super.onPause();
-    }
-
-    @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         inflater.inflate(R.menu.media_search, menu);
         MenuItem searchItem = menu.findItem(R.id.action_search);
@@ -175,102 +132,6 @@ public class AudioGenresListFragment extends Fragment
         super.onCreateOptionsMenu(menu, inflater);
     }
 
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        return super.onOptionsItemSelected(item);
-    }
-
-    /**
-     * Search view callbacks
-     */
-    /** {@inheritDoc} */
-    @Override
-    public boolean onQueryTextChange(String newText) {
-        searchFilter = newText;
-        getLoaderManager().restartLoader(LOADER_AUDIO_GENRES, null, this);
-        return true;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean onQueryTextSubmit(String newText) {
-        // All is handled in onQueryTextChange
-        return true;
-    }
-
-    /**
-     * Swipe refresh layout callback
-     */
-    /** {@inheritDoc} */
-    @Override
-    public void onRefresh() {
-        if (hostInfo != null) {
-            // Make sure we're showing the refresh
-            swipeRefreshLayout.setRefreshing(true);
-            // Start the syncing process
-            Intent syncIntent = new Intent(this.getActivity(), LibrarySyncService.class);
-            syncIntent.putExtra(LibrarySyncService.SYNC_ALL_MUSIC, true);
-            getActivity().startService(syncIntent);
-        } else {
-            swipeRefreshLayout.setRefreshing(false);
-            Toast.makeText(getActivity(), R.string.no_xbmc_configured, Toast.LENGTH_SHORT)
-                 .show();
-        }
-    }
-
-    /**
-     * Event bus post. Called when the syncing process ended
-     *
-     * @param event Refreshes data
-     */
-    public void onEventMainThread(MediaSyncEvent event) {
-        if (event.syncType.equals(LibrarySyncService.SYNC_ALL_MUSIC)) {
-            swipeRefreshLayout.setRefreshing(false);
-            if (event.status == MediaSyncEvent.STATUS_SUCCESS) {
-                getLoaderManager().restartLoader(LOADER_AUDIO_GENRES, null, this);
-                Toast.makeText(getActivity(), R.string.sync_successful, Toast.LENGTH_SHORT)
-                     .show();
-            } else {
-                String msg = (event.errorCode == ApiException.API_ERROR) ?
-                             String.format(getString(R.string.error_while_syncing), event.errorMessage) :
-                             getString(R.string.unable_to_connect_to_xbmc);
-                Toast.makeText(getActivity(), msg, Toast.LENGTH_SHORT).show();
-            }
-        }
-    }
-
-    /**
-     * Loader callbacks
-     */
-    /** {@inheritDoc} */
-    @Override
-    public Loader<Cursor> onCreateLoader(int i, Bundle bundle) {
-        Uri uri = MediaContract.AudioGenres.buildAudioGenresListUri(hostInfo != null ? hostInfo.getId() : -1);
-
-        String selection = null;
-        String selectionArgs[] = null;
-        if (!TextUtils.isEmpty(searchFilter)) {
-            selection = MediaContract.AudioGenres.TITLE + " LIKE ?";
-            selectionArgs = new String[] {"%" + searchFilter + "%"};
-        }
-
-        return new CursorLoader(getActivity(), uri,
-                AudioGenreListQuery.PROJECTION, selection, selectionArgs, AudioGenreListQuery.SORT);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void onLoadFinished(Loader<Cursor> cursorLoader, Cursor cursor) {
-        adapter.swapCursor(cursor);
-        // To prevent the empty text from appearing on the first load, set it now
-        emptyView.setText(getString(R.string.no_genres_found_refresh));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void onLoaderReset(Loader<Cursor> cursorLoader) {
-        adapter.swapCursor(null);
-    }
 
     /**
      * Audio genres list query parameters.

--- a/app/src/main/java/org/xbmc/kore/ui/MovieListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/MovieListFragment.java
@@ -22,15 +22,10 @@ import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.database.Cursor;
 import android.net.Uri;
-import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.provider.BaseColumns;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.LoaderManager;
 import android.support.v4.content.CursorLoader;
-import android.support.v4.content.Loader;
 import android.support.v4.view.MenuItemCompat;
-import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.SearchView;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -41,7 +36,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.CursorAdapter;
-import android.widget.GridView;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -55,77 +49,26 @@ import org.xbmc.kore.jsonrpc.event.MediaSyncEvent;
 import org.xbmc.kore.provider.MediaContract;
 import org.xbmc.kore.provider.MediaDatabase;
 import org.xbmc.kore.service.LibrarySyncService;
+import org.xbmc.kore.service.SyncUtils;
 import org.xbmc.kore.utils.LogUtils;
 import org.xbmc.kore.utils.UIUtils;
-
-import butterknife.ButterKnife;
-import butterknife.InjectView;
-import de.greenrobot.event.EventBus;
 
 /**
  * Fragment that presents the movie list
  */
-public class MovieListFragment extends Fragment
-        implements LoaderManager.LoaderCallbacks<Cursor>,
-        SwipeRefreshLayout.OnRefreshListener,
-        SearchView.OnQueryTextListener {
+public class MovieListFragment extends AbstractListFragment {
     private static final String TAG = LogUtils.makeLogTag(MovieListFragment.class);
 
     public interface OnMovieSelectedListener {
         public void onMovieSelected(int movieId, String movieTitle);
     }
 
-    // Loader IDs
-    private static final int LOADER_MOVIES = 0;
-
-    // The search filter to use in the loader
-    private String searchFilter = null;
-
-    // Movies adapter
-    private CursorAdapter adapter;
-
     // Activity listener
     private OnMovieSelectedListener listenerActivity;
 
-    private HostManager hostManager;
-    private HostInfo hostInfo;
-    private EventBus bus;
-
-    @InjectView(R.id.list) GridView moviesGridView;
-    @InjectView(R.id.swipe_refresh_layout) SwipeRefreshLayout swipeRefreshLayout;
-    @InjectView(android.R.id.empty) TextView emptyView;
-
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-    }
-
-    @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        ViewGroup root = (ViewGroup) inflater.inflate(R.layout.fragment_generic_media_list, container, false);
-        ButterKnife.inject(this, root);
-
-        bus = EventBus.getDefault();
-        hostManager = HostManager.getInstance(getActivity());
-        hostInfo = hostManager.getHostInfo();
-
-        swipeRefreshLayout.setOnRefreshListener(this);
-        //UIUtils.setSwipeRefreshLayoutColorScheme(swipeRefreshLayout);
-
-        // Pad main content view to overlap with bottom system bar
-//        UIUtils.setPaddingForSystemBars(getActivity(), moviesGridView, false, false, true);
-//        moviesGridView.setClipToPadding(false);
-
-        return root;
-    }
-
-
-    @Override
-    public void onActivityCreated (Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
-
-        moviesGridView.setEmptyView(emptyView);
-        moviesGridView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+    protected AdapterView.OnItemClickListener createOnItemClickListener() {
+        return new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
                 // Get the movie id from the tag
@@ -133,14 +76,90 @@ public class MovieListFragment extends Fragment
                 // Notify the activity
                 listenerActivity.onMovieSelected(tag.movieId, tag.movieTitle);
             }
-        });
+        };
+    }
 
-        // Configure the adapter and start the loader
-        adapter = new MoviesAdapter(getActivity());
-        moviesGridView.setAdapter(adapter);
-        getLoaderManager().initLoader(LOADER_MOVIES, null, this);
+    @Override
+    protected CursorAdapter createAdapter() {
+        return new MoviesAdapter(getActivity());
+    }
 
-        setHasOptionsMenu(true);
+    @Override
+    protected void onSwipeRefresh() {
+        Intent syncIntent = new Intent(this.getActivity(), LibrarySyncService.class);
+        syncIntent.putExtra(LibrarySyncService.SYNC_ALL_MOVIES, true);
+        getActivity().startService(syncIntent);
+    }
+
+    @Override
+    protected CursorLoader createCursorLoader() {
+        HostInfo hostInfo = HostManager.getInstance(getActivity()).getHostInfo();
+        Uri uri = MediaContract.Movies.buildMoviesListUri(hostInfo != null? hostInfo.getId() : -1);
+
+        StringBuilder selection = new StringBuilder();
+        String selectionArgs[] = null;
+        String searchFilter = getSearchFilter();
+        if (!TextUtils.isEmpty(searchFilter)) {
+            selection.append(MediaContract.MoviesColumns.TITLE + " LIKE ?");
+            selectionArgs = new String[] {"%" + searchFilter + "%"};
+        }
+
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
+        if (preferences.getBoolean(Settings.KEY_PREF_MOVIES_FILTER_HIDE_WATCHED, Settings.DEFAULT_PREF_MOVIES_FILTER_HIDE_WATCHED)) {
+            if (selection.length() != 0)
+                selection.append(" AND ");
+            selection.append(MediaContract.MoviesColumns.PLAYCOUNT)
+                    .append("=0");
+        }
+
+        String sortOrderStr;
+        int sortOrder = preferences.getInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.DEFAULT_PREF_MOVIES_SORT_ORDER);
+        if (sortOrder == Settings.SORT_BY_DATE_ADDED) {
+            sortOrderStr = MovieListQuery.SORT_BY_DATE_ADDED;
+        } else {
+            // Sort by name
+            if (preferences.getBoolean(Settings.KEY_PREF_MOVIES_IGNORE_PREFIXES, Settings.DEFAULT_PREF_MOVIES_IGNORE_PREFIXES)) {
+                sortOrderStr = MovieListQuery.SORT_BY_NAME_IGNORE_ARTICLES;
+            } else {
+                sortOrderStr = MovieListQuery.SORT_BY_NAME;
+            }
+        }
+
+        return new CursorLoader(getActivity(), uri,
+                MovieListQuery.PROJECTION, selection.toString(), selectionArgs, sortOrderStr);
+    }
+
+    @Override
+    protected void onSyncProcessEnded(MediaSyncEvent event) {
+        boolean silentSync = false;
+        if (event.syncExtras != null) {
+            silentSync = event.syncExtras.getBoolean(LibrarySyncService.SILENT_SYNC, false);
+        }
+
+        if (event.syncType.equals(LibrarySyncService.SYNC_SINGLE_MOVIE) ||
+                event.syncType.equals(LibrarySyncService.SYNC_ALL_MOVIES)) {
+            swipeRefreshLayout.setRefreshing(false);
+            if (event.status == MediaSyncEvent.STATUS_SUCCESS) {
+                refreshList();
+                if (!silentSync) {
+                    Toast.makeText(getActivity(), R.string.sync_successful, Toast.LENGTH_SHORT)
+                            .show();
+                }
+            } else if (!silentSync) {
+                String msg = (event.errorCode == ApiException.API_ERROR) ?
+                        String.format(getString(R.string.error_while_syncing), event.errorMessage) :
+                        getString(R.string.unable_to_connect_to_xbmc);
+                Toast.makeText(getActivity(), msg, Toast.LENGTH_SHORT).show();
+            }
+        }
+    }
+
+    @Override
+    public void onServiceConnected(LibrarySyncService librarySyncService) {
+        if(SyncUtils.isLibrarySyncing(librarySyncService, HostManager.getInstance(getActivity()).getHostInfo(),
+                LibrarySyncService.SYNC_ALL_MOVIES, LibrarySyncService.SYNC_SINGLE_MOVIE)) {
+            showRefreshAnimation();
+        }
     }
 
     @Override
@@ -157,18 +176,6 @@ public class MovieListFragment extends Fragment
     public void onDetach() {
         super.onDetach();
         listenerActivity = null;
-    }
-
-    @Override
-    public void onResume() {
-        bus.register(this);
-        super.onResume();
-    }
-
-    @Override
-    public void onPause() {
-        bus.unregister(this);
-        super.onPause();
     }
 
     @Override
@@ -213,160 +220,34 @@ public class MovieListFragment extends Fragment
                 preferences.edit()
                         .putBoolean(Settings.KEY_PREF_MOVIES_FILTER_HIDE_WATCHED, item.isChecked())
                         .apply();
-                getLoaderManager().restartLoader(LOADER_MOVIES, null, this);
+                refreshList();
                 break;
             case R.id.action_ignore_prefixes:
                 item.setChecked(!item.isChecked());
                 preferences.edit()
                         .putBoolean(Settings.KEY_PREF_MOVIES_IGNORE_PREFIXES, item.isChecked())
                         .apply();
-                getLoaderManager().restartLoader(LOADER_MOVIES, null, this);
+                refreshList();
                 break;
             case R.id.action_sort_by_name:
                 item.setChecked(true);
                 preferences.edit()
                         .putInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.SORT_BY_NAME)
                         .apply();
-                getLoaderManager().restartLoader(LOADER_MOVIES, null, this);
+                refreshList();
                 break;
             case R.id.action_sort_by_date_added:
                 item.setChecked(true);
                 preferences.edit()
                         .putInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.SORT_BY_DATE_ADDED)
                         .apply();
-                getLoaderManager().restartLoader(LOADER_MOVIES, null, this);
+                refreshList();
                 break;
             default:
                 break;
         }
 
         return super.onOptionsItemSelected(item);
-    }
-
-    /**
-     * Search view callbacks
-     */
-    /** {@inheritDoc} */
-    @Override
-    public boolean onQueryTextChange(String newText) {
-        searchFilter = newText;
-        getLoaderManager().restartLoader(LOADER_MOVIES, null, this);
-        return true;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean onQueryTextSubmit(String newText) {
-        // All is handled in onQueryTextChange
-        return true;
-    }
-
-    /**
-     * Swipe refresh layout callback
-     */
-    /** {@inheritDoc} */
-    @Override
-    public void onRefresh () {
-        if (hostInfo != null) {
-            // Make sure we're showing the refresh
-            swipeRefreshLayout.setRefreshing(true);
-            // Start the syncing process
-            Intent syncIntent = new Intent(this.getActivity(), LibrarySyncService.class);
-            syncIntent.putExtra(LibrarySyncService.SYNC_ALL_MOVIES, true);
-            getActivity().startService(syncIntent);
-
-//            Toast.makeText(getActivity(),
-//                    String.format(getString(R.string.sync_movies_for_host), hostInfo.getName()),
-//                    Toast.LENGTH_SHORT)
-//                 .show();
-        } else {
-            swipeRefreshLayout.setRefreshing(false);
-            Toast.makeText(getActivity(), R.string.no_xbmc_configured, Toast.LENGTH_SHORT)
-                 .show();
-        }
-    }
-
-    /**
-     * Event bus post. Called when the syncing process ended
-     *
-     * @param event Refreshes data
-     */
-    public void onEventMainThread(MediaSyncEvent event) {
-        boolean silentSync = false;
-        if (event.syncExtras != null) {
-            silentSync = event.syncExtras.getBoolean(LibrarySyncService.SILENT_SYNC, false);
-        }
-
-        if (event.syncType.equals(LibrarySyncService.SYNC_SINGLE_MOVIE) ||
-            event.syncType.equals(LibrarySyncService.SYNC_ALL_MOVIES)) {
-            swipeRefreshLayout.setRefreshing(false);
-            if (event.status == MediaSyncEvent.STATUS_SUCCESS) {
-                getLoaderManager().restartLoader(LOADER_MOVIES, null, this);
-                if (!silentSync) {
-                    Toast.makeText(getActivity(), R.string.sync_successful, Toast.LENGTH_SHORT)
-                         .show();
-                }
-            } else if (!silentSync) {
-                String msg = (event.errorCode == ApiException.API_ERROR) ?
-                             String.format(getString(R.string.error_while_syncing), event.errorMessage) :
-                             getString(R.string.unable_to_connect_to_xbmc);
-                Toast.makeText(getActivity(), msg, Toast.LENGTH_SHORT).show();
-            }
-        }
-    }
-
-    /**
-     * Loader callbacks
-     */
-    /** {@inheritDoc} */
-    @Override
-    public Loader<Cursor> onCreateLoader(int i, Bundle bundle) {
-        Uri uri = MediaContract.Movies.buildMoviesListUri(hostInfo != null? hostInfo.getId() : -1);
-
-        StringBuilder selection = new StringBuilder();
-        String selectionArgs[] = null;
-        if (!TextUtils.isEmpty(searchFilter)) {
-            selection.append(MediaContract.MoviesColumns.TITLE + " LIKE ?");
-            selectionArgs = new String[] {"%" + searchFilter + "%"};
-        }
-
-        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
-        if (preferences.getBoolean(Settings.KEY_PREF_MOVIES_FILTER_HIDE_WATCHED, Settings.DEFAULT_PREF_MOVIES_FILTER_HIDE_WATCHED)) {
-            if (selection.length() != 0)
-                selection.append(" AND ");
-            selection.append(MediaContract.MoviesColumns.PLAYCOUNT)
-                     .append("=0");
-        }
-
-        String sortOrderStr;
-        int sortOrder = preferences.getInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.DEFAULT_PREF_MOVIES_SORT_ORDER);
-        if (sortOrder == Settings.SORT_BY_DATE_ADDED) {
-            sortOrderStr = MovieListQuery.SORT_BY_DATE_ADDED;
-        } else {
-            // Sort by name
-            if (preferences.getBoolean(Settings.KEY_PREF_MOVIES_IGNORE_PREFIXES, Settings.DEFAULT_PREF_MOVIES_IGNORE_PREFIXES)) {
-                sortOrderStr = MovieListQuery.SORT_BY_NAME_IGNORE_ARTICLES;
-            } else {
-                sortOrderStr = MovieListQuery.SORT_BY_NAME;
-            }
-        }
-
-        return new CursorLoader(getActivity(), uri,
-                MovieListQuery.PROJECTION, selection.toString(), selectionArgs, sortOrderStr);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void onLoadFinished(Loader<Cursor> cursorLoader, Cursor cursor) {
-        adapter.swapCursor(cursor);
-        // To prevent the empty text from appearing on the first load, set it now
-        emptyView.setText(getString(R.string.no_movies_found_refresh));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void onLoaderReset(Loader<Cursor> cursorLoader) {
-        adapter.swapCursor(null);
     }
 
     /**

--- a/app/src/main/java/org/xbmc/kore/ui/MusicListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/MusicListFragment.java
@@ -15,20 +15,44 @@
  */
 package org.xbmc.kore.ui;
 
+import android.animation.ObjectAnimator;
+import android.animation.ValueAnimator;
+import android.app.Activity;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
 import android.os.Bundle;
+import android.os.IBinder;
 import android.support.v4.app.Fragment;
 import android.support.v4.view.ViewPager;
+import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.Toast;
 
 import com.astuetz.PagerSlidingTabStrip;
+
 import org.xbmc.kore.R;
+import org.xbmc.kore.host.HostInfo;
+import org.xbmc.kore.host.HostManager;
+import org.xbmc.kore.jsonrpc.ApiException;
+import org.xbmc.kore.jsonrpc.event.MediaSyncEvent;
+import org.xbmc.kore.service.LibrarySyncService;
+import org.xbmc.kore.service.SyncUtils;
 import org.xbmc.kore.utils.LogUtils;
 import org.xbmc.kore.utils.TabsAdapter;
 
+import java.util.ArrayList;
+
 import butterknife.ButterKnife;
 import butterknife.InjectView;
+import de.greenrobot.event.EventBus;
 
 /**
  * Container for the various music lists
@@ -36,20 +60,17 @@ import butterknife.InjectView;
 public class MusicListFragment extends Fragment {
     private static final String TAG = LogUtils.makeLogTag(MusicListFragment.class);
 
+    private TabsAdapter tabsAdapter;
+
     @InjectView(R.id.pager_tab_strip) PagerSlidingTabStrip pagerTabStrip;
     @InjectView(R.id.pager) ViewPager viewPager;
-
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         ViewGroup root = (ViewGroup) inflater.inflate(R.layout.fragment_music_list, container, false);
         ButterKnife.inject(this, root);
 
-        TabsAdapter tabsAdapter = new TabsAdapter(getActivity(), getChildFragmentManager())
+        tabsAdapter = new TabsAdapter(getActivity(), getChildFragmentManager())
                 .addTab(ArtistListFragment.class, getArguments(), R.string.artists, 1)
                 .addTab(AlbumListFragment.class, getArguments(), R.string.albums, 2)
                 .addTab(AudioGenresListFragment.class, getArguments(), R.string.genres, 3)
@@ -65,21 +86,5 @@ public class MusicListFragment extends Fragment {
     public void onActivityCreated (Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         setHasOptionsMenu(false);
-    }
-
-    @Override
-    public void onResume() {
-        super.onResume();
-    }
-
-    @Override
-    public void onPause() {
-        super.onPause();
-    }
-
-    @Override
-    public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
-//        outState.putInt(TVSHOWID, tvshowId);
     }
 }

--- a/app/src/main/java/org/xbmc/kore/ui/MusicVideoListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/MusicVideoListFragment.java
@@ -21,12 +21,9 @@ import android.content.Intent;
 import android.content.res.Resources;
 import android.database.Cursor;
 import android.net.Uri;
-import android.os.Bundle;
 import android.provider.BaseColumns;
-import android.support.v4.app.Fragment;
 import android.support.v4.app.LoaderManager;
 import android.support.v4.content.CursorLoader;
-import android.support.v4.content.Loader;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.SearchView;
@@ -39,7 +36,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.CursorAdapter;
-import android.widget.GridView;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -52,74 +48,26 @@ import org.xbmc.kore.jsonrpc.event.MediaSyncEvent;
 import org.xbmc.kore.provider.MediaContract;
 import org.xbmc.kore.provider.MediaDatabase;
 import org.xbmc.kore.service.LibrarySyncService;
+import org.xbmc.kore.service.SyncUtils;
 import org.xbmc.kore.utils.LogUtils;
 import org.xbmc.kore.utils.UIUtils;
-
-import butterknife.ButterKnife;
-import butterknife.InjectView;
-import de.greenrobot.event.EventBus;
 
 /**
  * Fragment that presents the artists list
  */
-public class MusicVideoListFragment extends Fragment
-        implements LoaderManager.LoaderCallbacks<Cursor>,
-        SwipeRefreshLayout.OnRefreshListener,
-        SearchView.OnQueryTextListener {
+public class MusicVideoListFragment extends AbstractListFragment {
     private static final String TAG = LogUtils.makeLogTag(MusicVideoListFragment.class);
 
     public interface OnMusicVideoSelectedListener {
         public void onMusicVideoSelected(int musicVideoId, String musicVideoTitle);
     }
 
-    // Loader IDs
-    private static final int LOADER_MUSIC_VIDEOS = 0;
-
-    // The search filter to use in the loader
-    private String searchFilter = null;
-
-    // Movies adapter
-    private CursorAdapter adapter;
-
     // Activity listener
     private OnMusicVideoSelectedListener listenerActivity;
 
-    private HostInfo hostInfo;
-    private EventBus bus;
-
-    @InjectView(R.id.list) GridView musicVideosGridView;
-    @InjectView(R.id.swipe_refresh_layout) SwipeRefreshLayout swipeRefreshLayout;
-    @InjectView(android.R.id.empty) TextView emptyView;
-
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-    }
-
-    @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        ViewGroup root = (ViewGroup) inflater.inflate(R.layout.fragment_generic_media_list, container, false);
-        ButterKnife.inject(this, root);
-
-        bus = EventBus.getDefault();
-        hostInfo = HostManager.getInstance(getActivity()).getHostInfo();
-
-        swipeRefreshLayout.setOnRefreshListener(this);
-//        UIUtils.setSwipeRefreshLayoutColorScheme(swipeRefreshLayout);
-
-        // Pad main content view to overlap with bottom system bar
-//        UIUtils.setPaddingForSystemBars(getActivity(), musicVideosGridView, false, false, true);
-//        musicVideosGridView.setClipToPadding(false);
-
-        return root;
-    }
-
-    @Override
-    public void onActivityCreated (Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
-
-        musicVideosGridView.setEmptyView(emptyView);
-        musicVideosGridView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+    protected AdapterView.OnItemClickListener createOnItemClickListener() {
+        return new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
                 // Get the movie id from the tag
@@ -127,14 +75,61 @@ public class MusicVideoListFragment extends Fragment
                 // Notify the activity
                 listenerActivity.onMusicVideoSelected(tag.musicVideoId, tag.musicVideoTitle);
             }
-        });
+        };
+    }
 
-        // Configure the adapter and start the loader
-        adapter = new MusicVideosAdapter(getActivity());
-        musicVideosGridView.setAdapter(adapter);
-        getLoaderManager().initLoader(LOADER_MUSIC_VIDEOS, null, this);
+    @Override
+    protected CursorAdapter createAdapter() {
+        return new MusicVideosAdapter(getActivity());
+    }
 
-        setHasOptionsMenu(true);
+    @Override
+    protected void onSwipeRefresh() {
+        Intent syncIntent = new Intent(this.getActivity(), LibrarySyncService.class);
+        syncIntent.putExtra(LibrarySyncService.SYNC_ALL_MUSIC_VIDEOS, true);
+        getActivity().startService(syncIntent);
+    }
+
+    @Override
+    protected CursorLoader createCursorLoader() {
+        HostInfo hostInfo = HostManager.getInstance(getActivity()).getHostInfo();
+        Uri uri = MediaContract.MusicVideos.buildMusicVideosListUri(hostInfo != null ? hostInfo.getId() : -1);
+
+        String selection = null;
+        String selectionArgs[] = null;
+        String searchFilter = getSearchFilter();
+        if (!TextUtils.isEmpty(searchFilter)) {
+            selection = MediaContract.MusicVideosColumns.TITLE + " LIKE ?";
+            selectionArgs = new String[] {"%" + searchFilter + "%"};
+        }
+
+        return new CursorLoader(getActivity(), uri,
+                MusicVideosListQuery.PROJECTION, selection, selectionArgs, MusicVideosListQuery.SORT);
+    }
+
+    @Override
+    protected void onSyncProcessEnded(MediaSyncEvent event) {
+        if (event.syncType.equals(LibrarySyncService.SYNC_ALL_MUSIC_VIDEOS)) {
+            swipeRefreshLayout.setRefreshing(false);
+            if (event.status == MediaSyncEvent.STATUS_SUCCESS) {
+                refreshList();
+                Toast.makeText(getActivity(), R.string.sync_successful, Toast.LENGTH_SHORT)
+                        .show();
+            } else {
+                String msg = (event.errorCode == ApiException.API_ERROR) ?
+                        String.format(getString(R.string.error_while_syncing), event.errorMessage) :
+                        getString(R.string.unable_to_connect_to_xbmc);
+                Toast.makeText(getActivity(), msg, Toast.LENGTH_SHORT).show();
+            }
+        }
+    }
+
+    @Override
+    public void onServiceConnected(LibrarySyncService librarySyncService) {
+        if(SyncUtils.isLibrarySyncing(librarySyncService, HostManager.getInstance(getActivity()).getHostInfo(),
+                LibrarySyncService.SYNC_ALL_MUSIC_VIDEOS)) {
+            showRefreshAnimation();
+        }
     }
 
     @Override
@@ -154,18 +149,6 @@ public class MusicVideoListFragment extends Fragment
     }
 
     @Override
-    public void onResume() {
-        bus.register(this);
-        super.onResume();
-    }
-
-    @Override
-    public void onPause() {
-        bus.unregister(this);
-        super.onPause();
-    }
-
-    @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         inflater.inflate(R.menu.media_search, menu);
         MenuItem searchItem = menu.findItem(R.id.action_search);
@@ -173,103 +156,6 @@ public class MusicVideoListFragment extends Fragment
         searchView.setOnQueryTextListener(this);
         searchView.setQueryHint(getString(R.string.action_search_music_videos));
         super.onCreateOptionsMenu(menu, inflater);
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        return super.onOptionsItemSelected(item);
-    }
-
-    /**
-     * Search view callbacks
-     */
-    /** {@inheritDoc} */
-    @Override
-    public boolean onQueryTextChange(String newText) {
-        searchFilter = newText;
-        getLoaderManager().restartLoader(LOADER_MUSIC_VIDEOS, null, this);
-        return true;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean onQueryTextSubmit(String newText) {
-        // All is handled in onQueryTextChange
-        return true;
-    }
-
-    /**
-     * Swipe refresh layout callback
-     */
-    /** {@inheritDoc} */
-    @Override
-    public void onRefresh() {
-        if (hostInfo != null) {
-            // Make sure we're showing the refresh
-            swipeRefreshLayout.setRefreshing(true);
-            // Start the syncing process
-            Intent syncIntent = new Intent(this.getActivity(), LibrarySyncService.class);
-            syncIntent.putExtra(LibrarySyncService.SYNC_ALL_MUSIC_VIDEOS, true);
-            getActivity().startService(syncIntent);
-        } else {
-            swipeRefreshLayout.setRefreshing(false);
-            Toast.makeText(getActivity(), R.string.no_xbmc_configured, Toast.LENGTH_SHORT)
-                 .show();
-        }
-    }
-
-    /**
-     * Event bus post. Called when the syncing process ended
-     *
-     * @param event Refreshes data
-     */
-    public void onEventMainThread(MediaSyncEvent event) {
-        if (event.syncType.equals(LibrarySyncService.SYNC_ALL_MUSIC_VIDEOS)) {
-            swipeRefreshLayout.setRefreshing(false);
-            if (event.status == MediaSyncEvent.STATUS_SUCCESS) {
-                getLoaderManager().restartLoader(LOADER_MUSIC_VIDEOS, null, this);
-                Toast.makeText(getActivity(), R.string.sync_successful, Toast.LENGTH_SHORT)
-                     .show();
-            } else {
-                String msg = (event.errorCode == ApiException.API_ERROR) ?
-                             String.format(getString(R.string.error_while_syncing), event.errorMessage) :
-                             getString(R.string.unable_to_connect_to_xbmc);
-                Toast.makeText(getActivity(), msg, Toast.LENGTH_SHORT).show();
-            }
-        }
-    }
-
-    /**
-     * Loader callbacks
-     */
-    /** {@inheritDoc} */
-    @Override
-    public Loader<Cursor> onCreateLoader(int i, Bundle bundle) {
-        Uri uri = MediaContract.MusicVideos.buildMusicVideosListUri(hostInfo != null ? hostInfo.getId() : -1);
-
-        String selection = null;
-        String selectionArgs[] = null;
-        if (!TextUtils.isEmpty(searchFilter)) {
-            selection = MediaContract.MusicVideosColumns.TITLE + " LIKE ?";
-            selectionArgs = new String[] {"%" + searchFilter + "%"};
-        }
-
-        return new CursorLoader(getActivity(), uri,
-                MusicVideosListQuery.PROJECTION, selection, selectionArgs, MusicVideosListQuery.SORT);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void onLoadFinished(Loader<Cursor> cursorLoader, Cursor cursor) {
-        adapter.swapCursor(cursor);
-        // To prevent the empty text from appearing on the first load, set it now
-        emptyView.setText(getString(R.string.no_music_videos_found_refresh));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void onLoaderReset(Loader<Cursor> cursorLoader) {
-        adapter.swapCursor(null);
     }
 
     /**

--- a/app/src/main/java/org/xbmc/kore/ui/TVShowListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/TVShowListFragment.java
@@ -55,6 +55,7 @@ import org.xbmc.kore.jsonrpc.event.MediaSyncEvent;
 import org.xbmc.kore.provider.MediaContract;
 import org.xbmc.kore.provider.MediaDatabase;
 import org.xbmc.kore.service.LibrarySyncService;
+import org.xbmc.kore.service.SyncUtils;
 import org.xbmc.kore.utils.LogUtils;
 import org.xbmc.kore.utils.UIUtils;
 
@@ -65,66 +66,19 @@ import de.greenrobot.event.EventBus;
 /**
  * Fragment that presents the tv show list
  */
-public class TVShowListFragment extends Fragment
-        implements LoaderManager.LoaderCallbacks<Cursor>,
-        SwipeRefreshLayout.OnRefreshListener,
-        SearchView.OnQueryTextListener {
+public class TVShowListFragment extends AbstractListFragment {
     private static final String TAG = LogUtils.makeLogTag(TVShowListFragment.class);
 
     public interface OnTVShowSelectedListener {
         public void onTVShowSelected(int tvshowId, String tvshowTitle);
     }
 
-    // Loader IDs
-    private static final int LOADER_TVSHOWS = 0;
-
-    // The search filter to use in the loader
-    private String searchFilter = null;
-
-    // Movies adapter
-    private CursorAdapter adapter;
-
     // Activity listener
     private OnTVShowSelectedListener listenerActivity;
 
-    private HostManager hostManager;
-    private HostInfo hostInfo;
-    private EventBus bus;
-
-    @InjectView(R.id.list) GridView tvshowsGridView;
-    @InjectView(R.id.swipe_refresh_layout) SwipeRefreshLayout swipeRefreshLayout;
-    @InjectView(android.R.id.empty) TextView emptyView;
-
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-    }
-
-    @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        ViewGroup root = (ViewGroup) inflater.inflate(R.layout.fragment_generic_media_list, container, false);
-        ButterKnife.inject(this, root);
-
-        bus = EventBus.getDefault();
-        hostManager = HostManager.getInstance(getActivity());
-        hostInfo = hostManager.getHostInfo();
-
-        swipeRefreshLayout.setOnRefreshListener(this);
-        //UIUtils.setSwipeRefreshLayoutColorScheme(swipeRefreshLayout);
-
-        // Pad main content view to overlap with bottom system bar
-//        UIUtils.setPaddingForSystemBars(getActivity(), moviesGridView, false, false, true);
-//        moviesGridView.setClipToPadding(false);
-
-        return root;
-    }
-
-    @Override
-    public void onActivityCreated(Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
-
-        tvshowsGridView.setEmptyView(emptyView);
-        tvshowsGridView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+    protected AdapterView.OnItemClickListener createOnItemClickListener() {
+        return new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
                 // Get the movie id from the tag
@@ -132,14 +86,94 @@ public class TVShowListFragment extends Fragment
                 // Notify the activity
                 listenerActivity.onTVShowSelected(tag.tvshowId, tag.tvshowTitle);
             }
-        });
+        };
+    }
 
-        // Configure the adapter and start the loader
-        adapter = new TVShowsAdapter(getActivity());
-        tvshowsGridView.setAdapter(adapter);
-        getLoaderManager().initLoader(LOADER_TVSHOWS, null, this);
+    @Override
+    protected CursorAdapter createAdapter() {
+        return new TVShowsAdapter(getActivity());
+    }
 
-        setHasOptionsMenu(true);
+    @Override
+    protected void onSwipeRefresh() {
+        Intent syncIntent = new Intent(this.getActivity(), LibrarySyncService.class);
+        syncIntent.putExtra(LibrarySyncService.SYNC_ALL_TVSHOWS, true);
+        getActivity().startService(syncIntent);
+    }
+
+    @Override
+    protected CursorLoader createCursorLoader() {
+        HostInfo hostInfo = HostManager.getInstance(getActivity()).getHostInfo();
+        Uri uri = MediaContract.TVShows.buildTVShowsListUri(hostInfo != null ? hostInfo.getId() : -1);
+
+        StringBuilder selection = new StringBuilder();
+        String selectionArgs[] = null;
+        String searchFilter = getSearchFilter();
+        if (!TextUtils.isEmpty(searchFilter)) {
+            selection.append(MediaContract.TVShowsColumns.TITLE + " LIKE ?");
+            selectionArgs = new String[] {"%" + searchFilter + "%"};
+        }
+
+        // Filters
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
+        if (preferences.getBoolean(Settings.KEY_PREF_TVSHOWS_FILTER_HIDE_WATCHED, Settings.DEFAULT_PREF_TVSHOWS_FILTER_HIDE_WATCHED)) {
+            if (selection.length() != 0)
+                selection.append(" AND ");
+            selection.append(MediaContract.TVShowsColumns.WATCHEDEPISODES)
+                    .append("!=")
+                    .append(MediaContract.TVShowsColumns.EPISODE);
+        }
+
+        String sortOrderStr;
+        int sortOrder = preferences.getInt(Settings.KEY_PREF_TVSHOWS_SORT_ORDER, Settings.DEFAULT_PREF_TVSHOWS_SORT_ORDER);
+        if (sortOrder == Settings.SORT_BY_DATE_ADDED) {
+            sortOrderStr = TVShowListQuery.SORT_BY_DATE_ADDED;
+        } else {
+            // Sort by name
+            if (preferences.getBoolean(Settings.KEY_PREF_TVSHOWS_IGNORE_PREFIXES, Settings.DEFAULT_PREF_TVSHOWS_IGNORE_PREFIXES)) {
+                sortOrderStr = TVShowListQuery.SORT_BY_NAME_IGNORE_ARTICLES;
+            } else {
+                sortOrderStr = TVShowListQuery.SORT_BY_NAME;
+            }
+        }
+
+
+        return new CursorLoader(getActivity(), uri,
+                TVShowListQuery.PROJECTION, selection.toString(),
+                selectionArgs, sortOrderStr);
+    }
+
+    @Override
+    protected void onSyncProcessEnded(MediaSyncEvent event) {
+        boolean silentSync = false;
+        if (event.syncExtras != null) {
+            silentSync = event.syncExtras.getBoolean(LibrarySyncService.SILENT_SYNC, false);
+        }
+
+        if (event.syncType.equals(LibrarySyncService.SYNC_SINGLE_TVSHOW) ||
+                event.syncType.equals(LibrarySyncService.SYNC_ALL_TVSHOWS)) {
+            swipeRefreshLayout.setRefreshing(false);
+            if (event.status == MediaSyncEvent.STATUS_SUCCESS) {
+                refreshList();
+                if (!silentSync) {
+                    Toast.makeText(getActivity(), R.string.sync_successful, Toast.LENGTH_SHORT)
+                            .show();
+                }
+            } else if (!silentSync) {
+                String msg = (event.errorCode == ApiException.API_ERROR) ?
+                        String.format(getString(R.string.error_while_syncing), event.errorMessage) :
+                        getString(R.string.unable_to_connect_to_xbmc);
+                Toast.makeText(getActivity(), msg, Toast.LENGTH_SHORT).show();
+            }
+        }
+    }
+
+    @Override
+    public void onServiceConnected(LibrarySyncService librarySyncService) {
+        if(SyncUtils.isLibrarySyncing(librarySyncService, HostManager.getInstance(getActivity()).getHostInfo(),
+                LibrarySyncService.SYNC_ALL_TVSHOWS, LibrarySyncService.SYNC_SINGLE_TVSHOW)) {
+            showRefreshAnimation();
+        }
     }
 
     @Override
@@ -156,18 +190,6 @@ public class TVShowListFragment extends Fragment
     public void onDetach() {
         super.onDetach();
         listenerActivity = null;
-    }
-
-    @Override
-    public void onResume() {
-        bus.register(this);
-        super.onResume();
-    }
-
-    @Override
-    public void onPause() {
-        bus.unregister(this);
-        super.onPause();
     }
 
     @Override
@@ -210,160 +232,34 @@ public class TVShowListFragment extends Fragment
                 preferences.edit()
                         .putBoolean(Settings.KEY_PREF_TVSHOWS_FILTER_HIDE_WATCHED, item.isChecked())
                         .apply();
-                getLoaderManager().restartLoader(LOADER_TVSHOWS, null, this);
+                refreshList();
                 break;
             case R.id.action_ignore_prefixes:
                 item.setChecked(!item.isChecked());
                 preferences.edit()
                         .putBoolean(Settings.KEY_PREF_TVSHOWS_IGNORE_PREFIXES, item.isChecked())
                         .apply();
-                getLoaderManager().restartLoader(LOADER_TVSHOWS, null, this);
+                refreshList();
                 break;
             case R.id.action_sort_by_name:
                 item.setChecked(true);
                 preferences.edit()
                         .putInt(Settings.KEY_PREF_TVSHOWS_SORT_ORDER, Settings.SORT_BY_NAME)
                         .apply();
-                getLoaderManager().restartLoader(LOADER_TVSHOWS, null, this);
+                refreshList();
                 break;
             case R.id.action_sort_by_date_added:
                 item.setChecked(true);
                 preferences.edit()
                         .putInt(Settings.KEY_PREF_TVSHOWS_SORT_ORDER, Settings.SORT_BY_DATE_ADDED)
                         .apply();
-                getLoaderManager().restartLoader(LOADER_TVSHOWS, null, this);
+                refreshList();
                 break;
             default:
                 break;
         }
 
         return super.onOptionsItemSelected(item);
-    }
-
-    /**
-     * Search view callbacks
-     */
-    /** {@inheritDoc} */
-    @Override
-    public boolean onQueryTextChange(String newText) {
-        searchFilter = newText;
-        getLoaderManager().restartLoader(LOADER_TVSHOWS, null, this);
-        return true;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean onQueryTextSubmit(String newText) {
-        // All is handled in onQueryTextChange
-        return true;
-    }
-
-    /**
-     * Swipe refresh layout callback
-     */
-    /** {@inheritDoc} */
-    @Override
-    public void onRefresh() {
-        if (hostInfo != null) {
-            LogUtils.LOGD(TAG, "Starting onRefresh");
-            // Make sure we're showing the refresh
-            swipeRefreshLayout.setRefreshing(true);
-            // Start the syncing process
-            Intent syncIntent = new Intent(this.getActivity(), LibrarySyncService.class);
-            syncIntent.putExtra(LibrarySyncService.SYNC_ALL_TVSHOWS, true);
-            getActivity().startService(syncIntent);
-        } else {
-            swipeRefreshLayout.setRefreshing(false);
-            Toast.makeText(getActivity(), R.string.no_xbmc_configured, Toast.LENGTH_SHORT)
-                 .show();
-        }
-    }
-
-    /**
-     * Event bus post. Called when the syncing process ended
-     *
-     * @param event Refreshes data
-     */
-    public void onEventMainThread(MediaSyncEvent event) {
-        boolean silentSync = false;
-        if (event.syncExtras != null) {
-            silentSync = event.syncExtras.getBoolean(LibrarySyncService.SILENT_SYNC, false);
-        }
-
-        if (event.syncType.equals(LibrarySyncService.SYNC_SINGLE_TVSHOW) ||
-            event.syncType.equals(LibrarySyncService.SYNC_ALL_TVSHOWS)) {
-            swipeRefreshLayout.setRefreshing(false);
-            if (event.status == MediaSyncEvent.STATUS_SUCCESS) {
-                getLoaderManager().restartLoader(LOADER_TVSHOWS, null, this);
-                if (!silentSync) {
-                    Toast.makeText(getActivity(), R.string.sync_successful, Toast.LENGTH_SHORT)
-                         .show();
-                }
-            } else if (!silentSync) {
-                String msg = (event.errorCode == ApiException.API_ERROR) ?
-                             String.format(getString(R.string.error_while_syncing), event.errorMessage) :
-                             getString(R.string.unable_to_connect_to_xbmc);
-                Toast.makeText(getActivity(), msg, Toast.LENGTH_SHORT).show();
-            }
-        }
-    }
-
-    /**
-     * Loader callbacks
-     */
-    /** {@inheritDoc} */
-    @Override
-    public Loader<Cursor> onCreateLoader(int i, Bundle bundle) {
-        Uri uri = MediaContract.TVShows.buildTVShowsListUri(hostInfo != null ? hostInfo.getId() : -1);
-
-        StringBuilder selection = new StringBuilder();
-        String selectionArgs[] = null;
-        if (!TextUtils.isEmpty(searchFilter)) {
-            selection.append(MediaContract.TVShowsColumns.TITLE + " LIKE ?");
-            selectionArgs = new String[] {"%" + searchFilter + "%"};
-        }
-
-        // Filters
-        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
-        if (preferences.getBoolean(Settings.KEY_PREF_TVSHOWS_FILTER_HIDE_WATCHED, Settings.DEFAULT_PREF_TVSHOWS_FILTER_HIDE_WATCHED)) {
-            if (selection.length() != 0)
-                selection.append(" AND ");
-            selection.append(MediaContract.TVShowsColumns.WATCHEDEPISODES)
-                     .append("!=")
-                     .append(MediaContract.TVShowsColumns.EPISODE);
-        }
-
-        String sortOrderStr;
-        int sortOrder = preferences.getInt(Settings.KEY_PREF_TVSHOWS_SORT_ORDER, Settings.DEFAULT_PREF_TVSHOWS_SORT_ORDER);
-        if (sortOrder == Settings.SORT_BY_DATE_ADDED) {
-            sortOrderStr = TVShowListQuery.SORT_BY_DATE_ADDED;
-        } else {
-            // Sort by name
-            if (preferences.getBoolean(Settings.KEY_PREF_TVSHOWS_IGNORE_PREFIXES, Settings.DEFAULT_PREF_TVSHOWS_IGNORE_PREFIXES)) {
-                sortOrderStr = TVShowListQuery.SORT_BY_NAME_IGNORE_ARTICLES;
-            } else {
-                sortOrderStr = TVShowListQuery.SORT_BY_NAME;
-            }
-        }
-
-
-        return new CursorLoader(getActivity(), uri,
-                TVShowListQuery.PROJECTION, selection.toString(),
-                selectionArgs, sortOrderStr);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void onLoadFinished(Loader<Cursor> cursorLoader, Cursor cursor) {
-        adapter.swapCursor(cursor);
-        // To prevent the empty text from appearing on the first load, set it now
-        emptyView.setText(getString(R.string.no_tvshows_found_refresh));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void onLoaderReset(Loader<Cursor> cursorLoader) {
-        adapter.swapCursor(null);
     }
 
     /**

--- a/app/src/main/java/org/xbmc/kore/utils/UIUtils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/UIUtils.java
@@ -24,6 +24,7 @@ import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.os.Vibrator;
 import android.preference.PreferenceManager;
+import android.support.v4.widget.SwipeRefreshLayout;
 import android.text.TextUtils;
 import android.util.DisplayMetrics;
 import android.view.LayoutInflater;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -229,6 +229,7 @@
     <string name="no_movies_found_refresh">No movies found\n\nSwipe down to refresh</string>
     <string name="no_tvshows_found_refresh">No TV Shows found\n\nSwipe down to refresh</string>
     <string name="no_episodes_found">No episodes found</string>
+    <string name="swipe_down_to_refresh">Swipe down to refresh</string>
     <string name="no_artists_found_refresh">No artists found\n\nSwipe down to refresh</string>
     <string name="no_albums_found_refresh">No albums found\n\nSwipe down to refresh</string>
     <string name="no_genres_found_refresh">No genres found\n\nSwipe down to refresh</string>


### PR DESCRIPTION
Implemented binding to LibrarySyncService to check if there are items currently
syncing or queued to sync. This makes it possible to inform user of background
sync processes. 
Especially with slow devices running Kodi and/or large libraries, syncing takes a long time. When switching between different screens the refresh animation would not show. By checking if a sync process for the currently displayed items is still in progress we now manually start the refresh animation or not.

Redesigned the code quite a bit to prevent me from having to copy/paste duplicate code into every list fragment that should notify user of a running sync process. For this I created two abstract classes.
Hope you don't object :).

This pull request also fixes an issue with SwipeRefreshLayout from appcompat library. It does not
always show the refresh animation when refresh is set to true. See https://code.google.com/p/android/issues/detail?id=77712 for details