### PR TITLE
Implemented shared element transitions for albums

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/AlbumDetailsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AlbumDetailsFragment.java
@@ -451,6 +451,9 @@ public class AlbumDetailsFragment extends Fragment
             UIUtils.loadImageIntoImageview(hostManager,
                     fanart,
                     mediaArt, artWidth, artHeight);
+        } else {
+            UIUtils.loadImageWithCharacterAvatar(getActivity(), hostManager,
+                    poster, albumTitle, mediaArt, artWidth, artHeight);
         }
     }
 

--- a/app/src/main/java/org/xbmc/kore/ui/AlbumDetailsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AlbumDetailsFragment.java
@@ -16,6 +16,7 @@
 
 package org.xbmc.kore.ui;
 
+import android.annotation.TargetApi;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.res.Resources;
@@ -134,6 +135,7 @@ public class AlbumDetailsFragment extends Fragment
     /**
      * Create a new instance of this, initialized to show the album albumId
      */
+    @TargetApi(21)
     public static AlbumDetailsFragment newInstance(AlbumListFragment.ViewHolder vh) {
         AlbumDetailsFragment fragment = new AlbumDetailsFragment();
 
@@ -158,6 +160,7 @@ public class AlbumDetailsFragment extends Fragment
     }
 
     @Override
+    @TargetApi(21)
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         albumId = getArguments().getInt(BUNDLE_KEY_ALBUMID, -1);
 

--- a/app/src/main/java/org/xbmc/kore/ui/AlbumDetailsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AlbumDetailsFragment.java
@@ -23,7 +23,8 @@ import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.database.Cursor;
 import android.net.Uri;
-import android.os.*;
+import android.os.Bundle;
+import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.provider.BaseColumns;
 import android.support.v4.app.Fragment;
@@ -47,6 +48,7 @@ import android.widget.Toast;
 
 import com.melnykov.fab.FloatingActionButton;
 import com.melnykov.fab.ObservableScrollView;
+
 import org.xbmc.kore.R;
 import org.xbmc.kore.Settings;
 import org.xbmc.kore.host.HostInfo;
@@ -69,7 +71,6 @@ import java.util.List;
 import butterknife.ButterKnife;
 import butterknife.InjectView;
 import butterknife.OnClick;
-import de.greenrobot.event.EventBus;
 
 /**
  * Presents movie details

--- a/app/src/main/res/layout/fragment_album_details.xml
+++ b/app/src/main/res/layout/fragment_album_details.xml
@@ -110,8 +110,7 @@
                     android:layout_height="match_parent"
                     style="@style/Widget.Button.Borderless"
                     android:src="?attr/iconDownload"
-                    android:contentDescription="@string/download"
-                    android:visibility="gone"/>
+                    android:contentDescription="@string/download"/>
             </LinearLayout>
 
             <RelativeLayout


### PR DESCRIPTION
I removed using the poster as fanart if no fanart is available.
The reason is that the shared element transition is not very smooth
when the aspect ratio of the two image states is not the same.
Going from AlbumListFragment to AlbumDetailsFragment the poster
is resized correctly to the fanart size. However, returning to the
AlbumListFragment from the AlbumDetailsFragment the poster is
abruptly resized to the square aspect ratio needed for the list
fragment.