### PR TITLE
Implemented shared element transition for TV shows

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/TVShowDetailsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/TVShowDetailsFragment.java
@@ -15,6 +15,7 @@
  */
 package org.xbmc.kore.ui;
 
+import android.annotation.TargetApi;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.view.ViewPager;
@@ -23,9 +24,12 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.astuetz.PagerSlidingTabStrip;
+
 import org.xbmc.kore.R;
 import org.xbmc.kore.utils.LogUtils;
 import org.xbmc.kore.utils.TabsAdapter;
+import org.xbmc.kore.utils.UIUtils;
+import org.xbmc.kore.utils.Utils;
 
 import butterknife.ButterKnife;
 import butterknife.InjectView;
@@ -36,10 +40,21 @@ import butterknife.InjectView;
 public class TVShowDetailsFragment extends Fragment {
     private static final String TAG = LogUtils.makeLogTag(TVShowDetailsFragment.class);
 
-    public static final String TVSHOWID = "tvshow_id";
+    public static final String POSTER_TRANS_NAME = "POSTER_TRANS_NAME";
+    public static final String BUNDLE_KEY_TVSHOWID = "tvshow_id";
+    public static final String BUNDLE_KEY_TITLE = "title";
+    public static final String BUNDLE_KEY_PREMIERED = "premiered";
+    public static final String BUNDLE_KEY_STUDIO = "studio";
+    public static final String BUNDLE_KEY_EPISODE = "episode";
+    public static final String BUNDLE_KEY_WATCHEDEPISODES = "watchedepisodes";
+    public static final String BUNDLE_KEY_RATING = "rating";
+    public static final String BUNDLE_KEY_PLOT = "plot";
+    public static final String BUNDLE_KEY_GENRES = "genres";
 
     // Displayed movie id
     private int tvshowId = -1;
+
+    private TabsAdapter tabsAdapter;
 
     @InjectView(R.id.pager_tab_strip) PagerSlidingTabStrip pagerTabStrip;
     @InjectView(R.id.pager) ViewPager viewPager;
@@ -47,11 +62,23 @@ public class TVShowDetailsFragment extends Fragment {
     /**
      * Create a new instance of this, initialized to show tvshowId
      */
-    public static TVShowDetailsFragment newInstance(int tvshowId) {
+    @TargetApi(21)
+    public static TVShowDetailsFragment newInstance(TVShowListFragment.ViewHolder vh) {
         TVShowDetailsFragment fragment = new TVShowDetailsFragment();
 
         Bundle args = new Bundle();
-        args.putInt(TVSHOWID, tvshowId);
+        args.putInt(BUNDLE_KEY_TVSHOWID, vh.tvshowId);
+        args.putInt(BUNDLE_KEY_EPISODE, vh.episode);
+        args.putString(BUNDLE_KEY_GENRES, vh.genres);
+        args.putString(BUNDLE_KEY_PLOT, vh.plot);
+        args.putString(BUNDLE_KEY_PREMIERED, vh.premiered);
+        args.putDouble(BUNDLE_KEY_RATING, vh.rating);
+        args.putString(BUNDLE_KEY_STUDIO, vh.studio);
+        args.putString(BUNDLE_KEY_TITLE, vh.tvshowTitle);
+        args.putInt(BUNDLE_KEY_WATCHEDEPISODES, vh.watchedEpisodes);
+        if( Utils.isLollipopOrLater()) {
+            args.putString(POSTER_TRANS_NAME, vh.artView.getTransitionName());
+        }
         fragment.setArguments(args);
         return fragment;
     }
@@ -63,7 +90,7 @@ public class TVShowDetailsFragment extends Fragment {
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        tvshowId = getArguments().getInt(TVSHOWID, -1);
+        tvshowId = getArguments().getInt(BUNDLE_KEY_TVSHOWID, -1);
 
         if ((container == null) || (tvshowId == -1)) {
             // We're not being shown or there's nothing to show
@@ -74,7 +101,7 @@ public class TVShowDetailsFragment extends Fragment {
         ButterKnife.inject(this, root);
 
         long baseFragmentId = tvshowId * 10;
-        TabsAdapter tabsAdapter = new TabsAdapter(getActivity(), getChildFragmentManager())
+        tabsAdapter = new TabsAdapter(getActivity(), getChildFragmentManager())
                 .addTab(TVShowOverviewFragment.class, getArguments(), R.string.tvshow_overview,
                         baseFragmentId)
                 .addTab(TVShowEpisodeListFragment.class, getArguments(),
@@ -92,19 +119,26 @@ public class TVShowDetailsFragment extends Fragment {
         setHasOptionsMenu(false);
     }
 
-    @Override
-    public void onResume() {
-        super.onResume();
+    public Fragment getCurrentTabFragment() {
+        return tabsAdapter.getItem(viewPager.getCurrentItem());
     }
 
-    @Override
-    public void onPause() {
-        super.onPause();
-    }
+    public View getSharedElement() {
+        View view = getView();
+        if (view == null)
+            return null;
 
-    @Override
-    public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
-//        outState.putInt(TVSHOWID, tvshowId);
+        //Note: this works as R.id.poster is only used in TVShowOverviewFragment.
+        //If the same id is used in other fragments in the TabsAdapter we
+        //need to check which fragment is currently displayed
+        View artView = view.findViewById(R.id.poster);
+        View scrollView = view.findViewById(R.id.media_panel);
+        if (( artView != null ) &&
+                ( scrollView != null ) &&
+                UIUtils.isViewInBounds(scrollView, artView)) {
+            return artView;
+        }
+
+        return null;
     }
 }

--- a/app/src/main/java/org/xbmc/kore/utils/UIUtils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/UIUtils.java
@@ -22,6 +22,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
+import android.graphics.Rect;
 import android.os.Vibrator;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
@@ -461,5 +462,14 @@ public class UIUtils {
                 layout.setRefreshing(true);
             }
         });
+    }
+
+    /**
+     * Returns true if {@param view} is contained within {@param container}'s bounds.
+     */
+    public static boolean isViewInBounds(@NonNull View container, @NonNull View view) {
+        Rect containerBounds = new Rect();
+        container.getHitRect(containerBounds);
+        return view.getLocalVisibleRect(containerBounds);
     }
 }

--- a/app/src/main/res/transition-v21/media_details.xml
+++ b/app/src/main/res/transition-v21/media_details.xml
@@ -18,6 +18,7 @@
     <fade>
         <targets>
             <target android:targetId="@id/art"/>
+            <target android:targetId="@id/pager_tab_strip"/>
         </targets>
     </fade>
 


### PR DESCRIPTION
Added SharedElementCallback to be able to detect if shared element
is still visible. If not, the shared element transition should not
be performed when returning to the previous fragment.
Added the pager tab strip to the fade animation to keep shared element
transition smooth when poster is partly below the toolbar.