### PR TITLE
Define the versionName shown in settings from git

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,15 @@
 apply plugin: 'com.android.application'
 
+def getVersionName = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'describe', '--tags'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}
+
+
 android {
     compileSdkVersion 22
     buildToolsVersion "22.0.1"
@@ -9,7 +19,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 22
         versionCode 12
-        versionName "1.5.0"
+        versionName = getVersionName()
     }
 
     File keystoreFile = file('keystore.properties')

--- a/app/src/main/java/org/xbmc/kore/ui/AboutDialogFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AboutDialogFragment.java
@@ -40,7 +40,7 @@ public class AboutDialogFragment
             versionName = null;
         }
         TextView version = (TextView) mainView.findViewById(R.id.app_version);
-        version.setText("v" + versionName);
+        version.setText(versionName);
 
         TextView about = (TextView)mainView.findViewById(R.id.about_desc);
         about.setText(Html.fromHtml(getString(R.string.about_desc)));

--- a/app/src/main/java/org/xbmc/kore/ui/SettingsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/SettingsFragment.java
@@ -118,7 +118,7 @@ public class SettingsFragment extends PreferenceFragment
         // About preference
         String nameAndVersion = getActivity().getString(R.string.app_name);
         try {
-            nameAndVersion += " v" +
+            nameAndVersion += " " +
                     getActivity().getPackageManager().getPackageInfo(getActivity().getPackageName(), 0).versionName;
         } catch (PackageManager.NameNotFoundException exc) {
         }


### PR DESCRIPTION
The version string displayed in the app should ideally be derived from the git tag (git describe --tag), and not defined in duplicate in the gradle config as a string.

Developers will further benefit from seeing a dynamically generated version that reflects the git commit id from which the build originates.

Note: When the app is built from sources that have a git tag consistent with other release tags (i.e. "v1.5.0") the value of versionName will evaluate to the string representation of the tag -- preserving the current behavior.