### PR TITLE
Clear back stack when clicking FAB in movie/episode details

### DIFF
--- a/app/src/main/java/org/xbmc/kore/utils/UIUtils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/UIUtils.java
@@ -418,7 +418,8 @@ public class UIUtils {
     public static void switchToRemoteWithAnimation(final Context context,
                                                    int centerX, int centerY,
                                                    final View exitTransitionView) {
-        final Intent launchIntent = new Intent(context, RemoteActivity.class);
+        final Intent launchIntent = new Intent(context, RemoteActivity.class)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         if (Utils.isLollipopOrLater()) {
             // Show the animation
             int endRadius = Math.max(exitTransitionView.getHeight(), exitTransitionView.getWidth());

--- a/app/src/main/java/org/xbmc/kore/utils/UIUtils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/UIUtils.java
@@ -405,8 +405,8 @@ public class UIUtils {
     }
 
     /**
-     * Launches the remote activity, performing a circular reveal animation if
-     * Lollipop or later
+     * Launches {@link RemoteActivity}, performing a circular reveal animation if
+     * Lollipop or later. This method clears the back stack up to {@link RemoteActivity}
      *
      * @param context Context
      * @param centerX Center X of the animation


### PR DESCRIPTION
Earlier, clicking the FAB would start a new instance of RemoteActivity so the back stack would look like this:
RemoteActivity
MovieDetailsFragment
MoviesActivity
RemoteActivity
...

Clicking on the back button would return you to MovieDetailsFragment which is unintuitive.

Now, ckicking on the FAB will clear the back stack up to the last instance of RemoteActity, so clicking on the back button would either close the app or return you to the activity that started RemoteActivity.