### PR TITLE
Added settings options for allowed network types

### DIFF
--- a/app/src/main/java/org/xbmc/kore/Settings.java
+++ b/app/src/main/java/org/xbmc/kore/Settings.java
@@ -15,12 +15,24 @@
  */
 package org.xbmc.kore;
 
+import android.app.DownloadManager;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.text.format.DateUtils;
+
+import org.xbmc.kore.utils.LogUtils;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Class that contains various constants and the keys for settings stored in shared preferences
  */
 public class Settings {
+    private static final String TAG = LogUtils.makeLogTag(Settings.class);
+
     /**
      * The update interval for the records in the DB. If the last update is older than this value
      * a refresh will be triggered. Applicable to TV Shows and Movies.
@@ -105,5 +117,32 @@ public class Settings {
     public static final String KEY_PREF_NAV_DRAWER_ITEMS = "pref_nav_drawer_items";
     public static String getNavDrawerItemsPrefKey(int hostId) {
         return Settings.KEY_PREF_NAV_DRAWER_ITEMS + hostId;
+    }
+
+    public static final String KEY_PREF_DOWNLOAD_TYPES = "pref_download_conn_types";
+
+    /**
+     * Determines the bit flags used by {@link DownloadManager.Request} to correspond to the enabled network connections
+     * from the settings screen.
+     * @return {@link DownloadManager.Request} network types bit flags that are enabled or 0 if none are enabled
+     */
+    public static int allowedDownloadNetworkTypes(Context context) {
+        SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(context);
+        Set<String> connPrefs = sharedPref.getStringSet(Settings.KEY_PREF_DOWNLOAD_TYPES,
+                                                        new HashSet<>(Arrays.asList(new String[]{"0"})));
+        int result = 0; // default none
+        for(String pref : connPrefs) {
+            switch( Integer.parseInt(pref) ) {
+                case 0:
+                    result |= DownloadManager.Request.NETWORK_WIFI;
+                    break;
+                case 1:
+                    result |= DownloadManager.Request.NETWORK_MOBILE;
+                    break;
+                case 2: // currently -1 means all network types in DownloadManager
+                    result |= ~0;
+            }
+        }
+        return result;
     }
 }

--- a/app/src/main/java/org/xbmc/kore/ui/AbstractDetailsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractDetailsFragment.java
@@ -31,6 +31,7 @@ import android.view.ViewGroup;
 import android.widget.Toast;
 
 import org.xbmc.kore.R;
+import org.xbmc.kore.Settings;
 import org.xbmc.kore.host.HostInfo;
 import org.xbmc.kore.host.HostManager;
 import org.xbmc.kore.jsonrpc.ApiException;
@@ -40,6 +41,8 @@ import org.xbmc.kore.service.SyncUtils;
 import org.xbmc.kore.utils.LogUtils;
 import org.xbmc.kore.utils.UIUtils;
 
+import butterknife.OnClick;
+import butterknife.Optional;
 import de.greenrobot.event.EventBus;
 
 abstract public class AbstractDetailsFragment extends Fragment
@@ -88,6 +91,12 @@ abstract public class AbstractDetailsFragment extends Fragment
      * @return
      */
     abstract protected SwipeRefreshLayout getSwipeRefreshLayout();
+
+    /**
+     * When the view created in {@link #createView(LayoutInflater, ViewGroup)} contains a button
+     * with resource identifier R.id.download this will be called to initiate the download
+     */
+    abstract protected void onDownload();
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -160,6 +169,16 @@ abstract public class AbstractDetailsFragment extends Fragment
                 onRefresh();
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    @Optional
+    @OnClick(R.id.download)
+    public void onDownloadClicked(View v) {
+        if (Settings.allowedDownloadNetworkTypes(getActivity()) != 0) {
+            onDownload();
+        } else {
+            Toast.makeText(getActivity(), R.string.no_connection_type_selected, Toast.LENGTH_SHORT).show();
+        }
     }
 
     protected void startSync(boolean silentRefresh) {

--- a/app/src/main/java/org/xbmc/kore/ui/MovieDetailsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/MovieDetailsFragment.java
@@ -271,11 +271,11 @@ public class MovieDetailsFragment extends AbstractDetailsFragment
             case LOADER_MOVIE:
                 uri = MediaContract.Movies.buildMovieUri(getHostInfo().getId(), movieId);
                 return new CursorLoader(getActivity(), uri,
-                        MovieDetailsQuery.PROJECTION, null, null, null);
+                                        MovieDetailsQuery.PROJECTION, null, null, null);
             case LOADER_CAST:
                 uri = MediaContract.MovieCast.buildMovieCastListUri(getHostInfo().getId(), movieId);
                 return new CursorLoader(getActivity(), uri,
-                        MovieCastListQuery.PROJECTION, null, null, MovieCastListQuery.SORT);
+                                        MovieCastListQuery.PROJECTION, null, null, MovieCastListQuery.SORT);
             default:
                 return null;
         }
@@ -319,7 +319,7 @@ public class MovieDetailsFragment extends AbstractDetailsFragment
                 boolean switchToRemote = PreferenceManager
                         .getDefaultSharedPreferences(getActivity())
                         .getBoolean(Settings.KEY_PREF_SWITCH_TO_REMOTE_AFTER_MEDIA_START,
-                                Settings.DEFAULT_PREF_SWITCH_TO_REMOTE_AFTER_MEDIA_START);
+                                    Settings.DEFAULT_PREF_SWITCH_TO_REMOTE_AFTER_MEDIA_START);
                 if (switchToRemote) {
                     int cx = (fabButton.getLeft() + fabButton.getRight()) / 2;
                     int cy = (fabButton.getTop() + fabButton.getBottom()) / 2;
@@ -332,7 +332,7 @@ public class MovieDetailsFragment extends AbstractDetailsFragment
                 if (!isAdded()) return;
                 // Got an error, show toast
                 Toast.makeText(getActivity(), R.string.unable_to_connect_to_xbmc, Toast.LENGTH_SHORT)
-                        .show();
+                     .show();
             }
         }, callbackHandler);
     }
@@ -364,7 +364,7 @@ public class MovieDetailsFragment extends AbstractDetailsFragment
                             if (!isAdded()) return;
                             // Got an error, show toast
                             Toast.makeText(getActivity(), R.string.item_added_to_playlist, Toast.LENGTH_SHORT)
-                                    .show();
+                                 .show();
                         }
 
                         @Override
@@ -372,12 +372,12 @@ public class MovieDetailsFragment extends AbstractDetailsFragment
                             if (!isAdded()) return;
                             // Got an error, show toast
                             Toast.makeText(getActivity(), R.string.unable_to_connect_to_xbmc, Toast.LENGTH_SHORT)
-                                    .show();
+                                 .show();
                         }
                     }, callbackHandler);
                 } else {
                     Toast.makeText(getActivity(), R.string.no_suitable_playlist, Toast.LENGTH_SHORT)
-                            .show();
+                         .show();
                 }
             }
 
@@ -386,7 +386,7 @@ public class MovieDetailsFragment extends AbstractDetailsFragment
                 if (!isAdded()) return;
                 // Got an error, show toast
                 Toast.makeText(getActivity(), R.string.unable_to_connect_to_xbmc, Toast.LENGTH_SHORT)
-                        .show();
+                     .show();
             }
         }, callbackHandler);
     }
@@ -425,8 +425,8 @@ public class MovieDetailsFragment extends AbstractDetailsFragment
         setupSeenButton(newPlaycount);
     }
 
-    @OnClick(R.id.download)
-    public void onDownloadClicked(View v) {
+    @Override
+    protected void onDownload() {
         if (movieDownloadInfo == null) {
             // Nothing to download
             Toast.makeText(getActivity(), R.string.no_files_to_download, Toast.LENGTH_SHORT).show();
@@ -444,43 +444,43 @@ public class MovieDetailsFragment extends AbstractDetailsFragment
         if (file.exists()) {
             AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
             builder.setTitle(R.string.download)
-                    .setMessage(R.string.download_file_exists)
-                    .setPositiveButton(R.string.overwrite,
-                            new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface dialog, int which) {
-                                    FileDownloadHelper.downloadFiles(getActivity(), getHostInfo(),
-                                            movieDownloadInfo, FileDownloadHelper.OVERWRITE_FILES,
-                                            callbackHandler);
-                                }
-                            })
-                    .setNeutralButton(R.string.download_with_new_name,
-                            new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface dialog, int which) {
-                                    FileDownloadHelper.downloadFiles(getActivity(), getHostInfo(),
-                                            movieDownloadInfo, FileDownloadHelper.DOWNLOAD_WITH_NEW_NAME,
-                                            callbackHandler);
-                                }
-                            })
-                    .setNegativeButton(android.R.string.cancel, noopClickListener)
-                    .show();
+                   .setMessage(R.string.download_file_exists)
+                   .setPositiveButton(R.string.overwrite,
+                                      new DialogInterface.OnClickListener() {
+                                          @Override
+                                          public void onClick(DialogInterface dialog, int which) {
+                                              FileDownloadHelper.downloadFiles(getActivity(), getHostInfo(),
+                                                                               movieDownloadInfo, FileDownloadHelper.OVERWRITE_FILES,
+                                                                               callbackHandler);
+                                          }
+                                      })
+                   .setNeutralButton(R.string.download_with_new_name,
+                                     new DialogInterface.OnClickListener() {
+                                         @Override
+                                         public void onClick(DialogInterface dialog, int which) {
+                                             FileDownloadHelper.downloadFiles(getActivity(), getHostInfo(),
+                                                                              movieDownloadInfo, FileDownloadHelper.DOWNLOAD_WITH_NEW_NAME,
+                                                                              callbackHandler);
+                                         }
+                                     })
+                   .setNegativeButton(android.R.string.cancel, noopClickListener)
+                   .show();
         } else {
             // Confirm that the user really wants to download the file
             AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
             builder.setTitle(R.string.download)
-                    .setMessage(R.string.confirm_movie_download)
-                    .setPositiveButton(android.R.string.ok,
-                            new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface dialog, int which) {
-                                    FileDownloadHelper.downloadFiles(getActivity(), getHostInfo(),
-                                            movieDownloadInfo, FileDownloadHelper.OVERWRITE_FILES,
-                                            callbackHandler);
-                                }
-                            })
-                    .setNegativeButton(android.R.string.cancel, noopClickListener)
-                    .show();
+                   .setMessage(R.string.confirm_movie_download)
+                   .setPositiveButton(android.R.string.ok,
+                                      new DialogInterface.OnClickListener() {
+                                          @Override
+                                          public void onClick(DialogInterface dialog, int which) {
+                                              FileDownloadHelper.downloadFiles(getActivity(), getHostInfo(),
+                                                                               movieDownloadInfo, FileDownloadHelper.OVERWRITE_FILES,
+                                                                               callbackHandler);
+                                          }
+                                      })
+                   .setNegativeButton(android.R.string.cancel, noopClickListener)
+                   .show();
         }
     }
 
@@ -508,7 +508,7 @@ public class MovieDetailsFragment extends AbstractDetailsFragment
             setMediaRating(rating);
             String votes = cursor.getString(MovieDetailsQuery.VOTES);
             mediaRatingVotes.setText((TextUtils.isEmpty(votes)) ?
-                    "" : String.format(getString(R.string.votes), votes));
+                                     "" : String.format(getString(R.string.votes), votes));
         } else {
             mediaRating.setVisibility(View.INVISIBLE);
             mediaMaxRating.setVisibility(View.INVISIBLE);
@@ -531,12 +531,12 @@ public class MovieDetailsFragment extends AbstractDetailsFragment
         int posterWidth = resources.getDimensionPixelOffset(R.dimen.now_playing_poster_width);
         int posterHeight = resources.getDimensionPixelOffset(R.dimen.now_playing_poster_height);
         UIUtils.loadImageWithCharacterAvatar(getActivity(), getHostManager(),
-                cursor.getString(MovieDetailsQuery.THUMBNAIL), movieTitle,
-                mediaPoster, posterWidth, posterHeight);
+                                             cursor.getString(MovieDetailsQuery.THUMBNAIL), movieTitle,
+                                             mediaPoster, posterWidth, posterHeight);
         int artHeight = resources.getDimensionPixelOffset(R.dimen.now_playing_art_height);
         UIUtils.loadImageIntoImageview(getHostManager(),
-                cursor.getString(MovieDetailsQuery.FANART),
-                mediaArt, displayMetrics.widthPixels, artHeight);
+                                       cursor.getString(MovieDetailsQuery.FANART),
+                                       mediaArt, displayMetrics.widthPixels, artHeight);
 
         // Setup movie download info
         movieDownloadInfo = new FileDownloadHelper.MovieInfo(
@@ -549,7 +549,7 @@ public class MovieDetailsFragment extends AbstractDetailsFragment
                     R.attr.colorAccent});
             downloadButton.setColorFilter(
                     styledAttributes.getColor(0,
-                            getActivity().getResources().getColor(R.color.accent_default)));
+                                              getActivity().getResources().getColor(R.color.accent_default)));
             styledAttributes.recycle();
         } else {
             downloadButton.clearColorFilter();
@@ -563,9 +563,9 @@ public class MovieDetailsFragment extends AbstractDetailsFragment
 
     private void setMediaYear(int runtime, int year) {
         String durationYear =  runtime > 0 ?
-                String.format(getString(R.string.minutes_abbrev), String.valueOf(runtime)) +
-                        "  |  " + year :
-                String.valueOf(year);
+                               String.format(getString(R.string.minutes_abbrev), String.valueOf(runtime)) +
+                               "  |  " + year :
+                               String.valueOf(year);
         mediaYear.setText(durationYear);
     }
 
@@ -576,7 +576,7 @@ public class MovieDetailsFragment extends AbstractDetailsFragment
             TypedArray styledAttributes = theme.obtainStyledAttributes(new int[] {
                     R.attr.colorAccent});
             seenButton.setColorFilter(styledAttributes.getColor(0,
-                    getActivity().getResources().getColor(R.color.accent_default)));
+                                                                getActivity().getResources().getColor(R.color.accent_default)));
             styledAttributes.recycle();
         } else {
             seenButton.clearColorFilter();
@@ -597,13 +597,13 @@ public class MovieDetailsFragment extends AbstractDetailsFragment
             castArrayList = new ArrayList<VideoType.Cast>(cursor.getCount());
             do {
                 castArrayList.add(new VideoType.Cast(cursor.getString(MovieCastListQuery.NAME),
-                        cursor.getInt(MovieCastListQuery.ORDER),
-                        cursor.getString(MovieCastListQuery.ROLE),
-                        cursor.getString(MovieCastListQuery.THUMBNAIL)));
+                                                     cursor.getInt(MovieCastListQuery.ORDER),
+                                                     cursor.getString(MovieCastListQuery.ROLE),
+                                                     cursor.getString(MovieCastListQuery.THUMBNAIL)));
             } while (cursor.moveToNext());
 
             UIUtils.setupCastInfo(getActivity(), castArrayList, videoCastList,
-                    AllCastActivity.buildLaunchIntent(getActivity(), movieTitle, castArrayList));
+                                  AllCastActivity.buildLaunchIntent(getActivity(), movieTitle, castArrayList));
         }
     }
 

--- a/app/src/main/java/org/xbmc/kore/ui/MusicVideoDetailsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/MusicVideoDetailsFragment.java
@@ -44,6 +44,7 @@ import android.widget.Toast;
 
 import com.melnykov.fab.FloatingActionButton;
 import com.melnykov.fab.ObservableScrollView;
+
 import org.xbmc.kore.R;
 import org.xbmc.kore.Settings;
 import org.xbmc.kore.jsonrpc.ApiCallback;
@@ -246,7 +247,7 @@ public class MusicVideoDetailsFragment extends AbstractDetailsFragment
             case LOADER_MUSIC_VIDEO:
                 uri = MediaContract.MusicVideos.buildMusicVideoUri(getHostInfo().getId(), musicVideoId);
                 return new CursorLoader(getActivity(), uri,
-                        MusicVideoDetailsQuery.PROJECTION, null, null, null);
+                                        MusicVideoDetailsQuery.PROJECTION, null, null, null);
             default:
                 return null;
         }
@@ -286,7 +287,7 @@ public class MusicVideoDetailsFragment extends AbstractDetailsFragment
                 boolean switchToRemote = PreferenceManager
                         .getDefaultSharedPreferences(getActivity())
                         .getBoolean(Settings.KEY_PREF_SWITCH_TO_REMOTE_AFTER_MEDIA_START,
-                                Settings.DEFAULT_PREF_SWITCH_TO_REMOTE_AFTER_MEDIA_START);
+                                    Settings.DEFAULT_PREF_SWITCH_TO_REMOTE_AFTER_MEDIA_START);
                 if (switchToRemote) {
                     int cx = (fabButton.getLeft() + fabButton.getRight()) / 2;
                     int cy = (fabButton.getTop() + fabButton.getBottom()) / 2;
@@ -299,7 +300,7 @@ public class MusicVideoDetailsFragment extends AbstractDetailsFragment
                 if (!isAdded()) return;
                 // Got an error, show toast
                 Toast.makeText(getActivity(), R.string.unable_to_connect_to_xbmc, Toast.LENGTH_SHORT)
-                        .show();
+                     .show();
             }
         }, callbackHandler);
     }
@@ -331,7 +332,7 @@ public class MusicVideoDetailsFragment extends AbstractDetailsFragment
                             if (!isAdded()) return;
                             // Got an error, show toast
                             Toast.makeText(getActivity(), R.string.item_added_to_playlist, Toast.LENGTH_SHORT)
-                                    .show();
+                                 .show();
                         }
 
                         @Override
@@ -339,12 +340,12 @@ public class MusicVideoDetailsFragment extends AbstractDetailsFragment
                             if (!isAdded()) return;
                             // Got an error, show toast
                             Toast.makeText(getActivity(), R.string.unable_to_connect_to_xbmc, Toast.LENGTH_SHORT)
-                                    .show();
+                                 .show();
                         }
                     }, callbackHandler);
                 } else {
                     Toast.makeText(getActivity(), R.string.no_suitable_playlist, Toast.LENGTH_SHORT)
-                            .show();
+                         .show();
                 }
             }
 
@@ -353,13 +354,13 @@ public class MusicVideoDetailsFragment extends AbstractDetailsFragment
                 if (!isAdded()) return;
                 // Got an error, show toast
                 Toast.makeText(getActivity(), R.string.unable_to_connect_to_xbmc, Toast.LENGTH_SHORT)
-                        .show();
+                     .show();
             }
         }, callbackHandler);
     }
 
-    @OnClick(R.id.download)
-    public void onDownloadClicked(View v) {
+    @Override
+    protected void onDownload() {
         if (musicVideoDownloadInfo == null) {
             // Nothing to download
             Toast.makeText(getActivity(), R.string.no_files_to_download, Toast.LENGTH_SHORT).show();
@@ -371,37 +372,37 @@ public class MusicVideoDetailsFragment extends AbstractDetailsFragment
         if (file.exists()) {
             AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
             builder.setTitle(R.string.download)
-                    .setMessage(R.string.download_file_exists)
-                    .setPositiveButton(R.string.overwrite,
-                            new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface dialog, int which) {
-                                    FileDownloadHelper.downloadFiles(getActivity(), getHostInfo(),
-                                            musicVideoDownloadInfo, FileDownloadHelper.OVERWRITE_FILES,
-                                            callbackHandler);
-                                }
-                            })
-                    .setNeutralButton(R.string.download_with_new_name,
-                            new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface dialog, int which) {
-                                    FileDownloadHelper.downloadFiles(getActivity(), getHostInfo(),
-                                            musicVideoDownloadInfo, FileDownloadHelper.DOWNLOAD_WITH_NEW_NAME,
-                                            callbackHandler);
-                                }
-                            })
-                    .setNegativeButton(android.R.string.cancel,
-                            new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface dialog, int which) {
-                                    // Nothing to do
-                                }
-                            })
-                    .show();
+                   .setMessage(R.string.download_file_exists)
+                   .setPositiveButton(R.string.overwrite,
+                                      new DialogInterface.OnClickListener() {
+                                          @Override
+                                          public void onClick(DialogInterface dialog, int which) {
+                                              FileDownloadHelper.downloadFiles(getActivity(), getHostInfo(),
+                                                                               musicVideoDownloadInfo, FileDownloadHelper.OVERWRITE_FILES,
+                                                                               callbackHandler);
+                                          }
+                                      })
+                   .setNeutralButton(R.string.download_with_new_name,
+                                     new DialogInterface.OnClickListener() {
+                                         @Override
+                                         public void onClick(DialogInterface dialog, int which) {
+                                             FileDownloadHelper.downloadFiles(getActivity(), getHostInfo(),
+                                                                              musicVideoDownloadInfo, FileDownloadHelper.DOWNLOAD_WITH_NEW_NAME,
+                                                                              callbackHandler);
+                                         }
+                                     })
+                   .setNegativeButton(android.R.string.cancel,
+                                      new DialogInterface.OnClickListener() {
+                                          @Override
+                                          public void onClick(DialogInterface dialog, int which) {
+                                              // Nothing to do
+                                          }
+                                      })
+                   .show();
         } else {
             FileDownloadHelper.downloadFiles(getActivity(), getHostInfo(),
-                    musicVideoDownloadInfo, FileDownloadHelper.DOWNLOAD_WITH_NEW_NAME,
-                    callbackHandler);
+                                             musicVideoDownloadInfo, FileDownloadHelper.DOWNLOAD_WITH_NEW_NAME,
+                                             callbackHandler);
         }
     }
 
@@ -436,11 +437,11 @@ public class MusicVideoDetailsFragment extends AbstractDetailsFragment
         int posterWidth = resources.getDimensionPixelOffset(R.dimen.musicvideodetail_poster_width);
         int posterHeight = resources.getDimensionPixelOffset(R.dimen.musicvideodetail_poster_width);
         UIUtils.loadImageWithCharacterAvatar(getActivity(), getHostManager(),
-                poster, musicVideoTitle,
-                mediaPoster, posterWidth, posterHeight);
+                                             poster, musicVideoTitle,
+                                             mediaPoster, posterWidth, posterHeight);
         UIUtils.loadImageIntoImageview(getHostManager(),
-                TextUtils.isEmpty(fanart)? poster : fanart,
-                mediaArt, artWidth, artHeight);
+                                       TextUtils.isEmpty(fanart)? poster : fanart,
+                                       mediaArt, artWidth, artHeight);
 
         // Setup download info
         musicVideoDownloadInfo = new FileDownloadHelper.MusicVideoInfo(
@@ -453,7 +454,7 @@ public class MusicVideoDetailsFragment extends AbstractDetailsFragment
                     R.attr.colorAccent});
             downloadButton.setColorFilter(
                     styledAttributes.getColor(0,
-                            getActivity().getResources().getColor(R.color.accent_default)));
+                                              getActivity().getResources().getColor(R.color.accent_default)));
             styledAttributes.recycle();
         } else {
             downloadButton.clearColorFilter();
@@ -466,9 +467,9 @@ public class MusicVideoDetailsFragment extends AbstractDetailsFragment
 
     private void setMediaYear(int runtime, int year) {
         String durationYear =  runtime > 0 ?
-                UIUtils.formatTime(runtime) + "  |  " +
-                        String.valueOf(year) :
-                String.valueOf(year);
+                               UIUtils.formatTime(runtime) + "  |  " +
+                               String.valueOf(year) :
+                               String.valueOf(year);
         mediaYear.setText(durationYear);
     }
 

--- a/app/src/main/java/org/xbmc/kore/ui/TVShowEpisodeDetailsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/TVShowEpisodeDetailsFragment.java
@@ -42,6 +42,7 @@ import android.widget.Toast;
 
 import com.melnykov.fab.FloatingActionButton;
 import com.melnykov.fab.ObservableScrollView;
+
 import org.xbmc.kore.R;
 import org.xbmc.kore.Settings;
 import org.xbmc.kore.jsonrpc.ApiCallback;
@@ -222,7 +223,7 @@ public class TVShowEpisodeDetailsFragment extends AbstractDetailsFragment
             case LOADER_EPISODE:
                 uri = MediaContract.Episodes.buildTVShowEpisodeUri(getHostInfo().getId(), tvshowId, episodeId);
                 return new CursorLoader(getActivity(), uri,
-                        EpisodeDetailsQuery.PROJECTION, null, null, null);
+                                        EpisodeDetailsQuery.PROJECTION, null, null, null);
 //            case LOADER_CAST:
 //                uri = MediaContract.MovieCast.buildMovieCastListUri(hostInfo.getId(), episodeId);
 //                return new CursorLoader(getActivity(), uri,
@@ -269,7 +270,7 @@ public class TVShowEpisodeDetailsFragment extends AbstractDetailsFragment
                 boolean switchToRemote = PreferenceManager
                         .getDefaultSharedPreferences(getActivity())
                         .getBoolean(Settings.KEY_PREF_SWITCH_TO_REMOTE_AFTER_MEDIA_START,
-                                Settings.DEFAULT_PREF_SWITCH_TO_REMOTE_AFTER_MEDIA_START);
+                                    Settings.DEFAULT_PREF_SWITCH_TO_REMOTE_AFTER_MEDIA_START);
                 if (switchToRemote) {
                     int cx = (fabButton.getLeft() + fabButton.getRight()) / 2;
                     int cy = (fabButton.getTop() + fabButton.getBottom()) / 2;
@@ -282,7 +283,7 @@ public class TVShowEpisodeDetailsFragment extends AbstractDetailsFragment
                 if (!isAdded()) return;
                 // Got an error, show toast
                 Toast.makeText(getActivity(), R.string.unable_to_connect_to_xbmc, Toast.LENGTH_SHORT)
-                        .show();
+                     .show();
             }
         }, callbackHandler);
     }
@@ -314,7 +315,7 @@ public class TVShowEpisodeDetailsFragment extends AbstractDetailsFragment
                             if (!isAdded()) return;
                             // Got an error, show toast
                             Toast.makeText(getActivity(), R.string.item_added_to_playlist, Toast.LENGTH_SHORT)
-                                    .show();
+                                 .show();
                         }
 
                         @Override
@@ -322,12 +323,12 @@ public class TVShowEpisodeDetailsFragment extends AbstractDetailsFragment
                             if (!isAdded()) return;
                             // Got an error, show toast
                             Toast.makeText(getActivity(), R.string.unable_to_connect_to_xbmc, Toast.LENGTH_SHORT)
-                                    .show();
+                                 .show();
                         }
                     }, callbackHandler);
                 } else {
                     Toast.makeText(getActivity(), R.string.no_suitable_playlist, Toast.LENGTH_SHORT)
-                            .show();
+                         .show();
                 }
             }
 
@@ -336,7 +337,7 @@ public class TVShowEpisodeDetailsFragment extends AbstractDetailsFragment
                 if (!isAdded()) return;
                 // Got an error, show toast
                 Toast.makeText(getActivity(), R.string.unable_to_connect_to_xbmc, Toast.LENGTH_SHORT)
-                        .show();
+                     .show();
             }
         }, callbackHandler);
     }
@@ -366,8 +367,8 @@ public class TVShowEpisodeDetailsFragment extends AbstractDetailsFragment
         setupSeenButton(newPlaycount);
     }
 
-    @OnClick(R.id.download)
-    public void onDownloadClicked(View v) {
+    @Override
+    protected void onDownload() {
         if (tvshowDownloadInfo == null) {
             // Nothing to download
             Toast.makeText(getActivity(), R.string.no_files_to_download, Toast.LENGTH_SHORT).show();
@@ -385,43 +386,43 @@ public class TVShowEpisodeDetailsFragment extends AbstractDetailsFragment
         if (file.exists()) {
             AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
             builder.setTitle(R.string.download)
-                    .setMessage(R.string.download_file_exists)
-                    .setPositiveButton(R.string.overwrite,
-                            new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface dialog, int which) {
-                                    FileDownloadHelper.downloadFiles(getActivity(), getHostInfo(),
-                                            tvshowDownloadInfo, FileDownloadHelper.OVERWRITE_FILES,
-                                            callbackHandler);
-                                }
-                            })
-                    .setNeutralButton(R.string.download_with_new_name,
-                            new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface dialog, int which) {
-                                    FileDownloadHelper.downloadFiles(getActivity(), getHostInfo(),
-                                            tvshowDownloadInfo, FileDownloadHelper.DOWNLOAD_WITH_NEW_NAME,
-                                            callbackHandler);
-                                }
-                            })
-                    .setNegativeButton(android.R.string.cancel, noopClickListener)
-                    .show();
+                   .setMessage(R.string.download_file_exists)
+                   .setPositiveButton(R.string.overwrite,
+                                      new DialogInterface.OnClickListener() {
+                                          @Override
+                                          public void onClick(DialogInterface dialog, int which) {
+                                              FileDownloadHelper.downloadFiles(getActivity(), getHostInfo(),
+                                                                               tvshowDownloadInfo, FileDownloadHelper.OVERWRITE_FILES,
+                                                                               callbackHandler);
+                                          }
+                                      })
+                   .setNeutralButton(R.string.download_with_new_name,
+                                     new DialogInterface.OnClickListener() {
+                                         @Override
+                                         public void onClick(DialogInterface dialog, int which) {
+                                             FileDownloadHelper.downloadFiles(getActivity(), getHostInfo(),
+                                                                              tvshowDownloadInfo, FileDownloadHelper.DOWNLOAD_WITH_NEW_NAME,
+                                                                              callbackHandler);
+                                         }
+                                     })
+                   .setNegativeButton(android.R.string.cancel, noopClickListener)
+                   .show();
         } else {
             // Confirm that the user really wants to download the file
             AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
             builder.setTitle(R.string.download)
-                    .setMessage(R.string.confirm_episode_download)
-                    .setPositiveButton(android.R.string.ok,
-                            new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface dialog, int which) {
-                                    FileDownloadHelper.downloadFiles(getActivity(), getHostInfo(),
-                                            tvshowDownloadInfo, FileDownloadHelper.OVERWRITE_FILES,
-                                            callbackHandler);
-                                }
-                            })
-                    .setNegativeButton(android.R.string.cancel, noopClickListener)
-                    .show();
+                   .setMessage(R.string.confirm_episode_download)
+                   .setPositiveButton(android.R.string.ok,
+                                      new DialogInterface.OnClickListener() {
+                                          @Override
+                                          public void onClick(DialogInterface dialog, int which) {
+                                              FileDownloadHelper.downloadFiles(getActivity(), getHostInfo(),
+                                                                               tvshowDownloadInfo, FileDownloadHelper.OVERWRITE_FILES,
+                                                                               callbackHandler);
+                                          }
+                                      })
+                   .setNegativeButton(android.R.string.cancel, noopClickListener)
+                   .show();
         }
     }
 
@@ -437,13 +438,13 @@ public class TVShowEpisodeDetailsFragment extends AbstractDetailsFragment
 
         int runtime = cursor.getInt(EpisodeDetailsQuery.RUNTIME) / 60;
         String durationPremiered =  runtime > 0 ?
-                String.format(getString(R.string.minutes_abbrev), String.valueOf(runtime)) +
-                        "  |  " + cursor.getString(EpisodeDetailsQuery.FIRSTAIRED) :
-                cursor.getString(EpisodeDetailsQuery.FIRSTAIRED);
+                                    String.format(getString(R.string.minutes_abbrev), String.valueOf(runtime)) +
+                                    "  |  " + cursor.getString(EpisodeDetailsQuery.FIRSTAIRED) :
+                                    cursor.getString(EpisodeDetailsQuery.FIRSTAIRED);
         mediaPremiered.setText(durationPremiered);
         String season = String.format(getString(R.string.season_episode),
-                cursor.getInt(EpisodeDetailsQuery.SEASON),
-                cursor.getInt(EpisodeDetailsQuery.EPISODE));
+                                      cursor.getInt(EpisodeDetailsQuery.SEASON),
+                                      cursor.getInt(EpisodeDetailsQuery.EPISODE));
         mediaSeason.setText(season);
 
         double rating = cursor.getDouble(EpisodeDetailsQuery.RATING);
@@ -474,8 +475,8 @@ public class TVShowEpisodeDetailsFragment extends AbstractDetailsFragment
 //                mediaPoster, posterWidth, posterHeight);
         int artHeight = resources.getDimensionPixelOffset(R.dimen.now_playing_art_height);
         UIUtils.loadImageIntoImageview(getHostManager(),
-                cursor.getString(EpisodeDetailsQuery.THUMBNAIL),
-                mediaArt, displayMetrics.widthPixels, artHeight);
+                                       cursor.getString(EpisodeDetailsQuery.THUMBNAIL),
+                                       mediaArt, displayMetrics.widthPixels, artHeight);
 
         // Setup movie download info
         tvshowDownloadInfo = new FileDownloadHelper.TVShowInfo(

--- a/app/src/main/java/org/xbmc/kore/ui/TVShowEpisodeListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/TVShowEpisodeListFragment.java
@@ -134,6 +134,11 @@ public class TVShowEpisodeListFragment extends AbstractDetailsFragment
     }
 
     @Override
+    protected void onDownload() {
+
+    }
+
+    @Override
     public void onActivityCreated (Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 

--- a/app/src/main/java/org/xbmc/kore/ui/TVShowOverviewFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/TVShowOverviewFragment.java
@@ -174,6 +174,11 @@ public class TVShowOverviewFragment extends AbstractDetailsFragment
     }
 
     @Override
+    protected void onDownload() {
+
+    }
+
+    @Override
     public void onActivityCreated (Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 

--- a/app/src/main/java/org/xbmc/kore/utils/FileDownloadHelper.java
+++ b/app/src/main/java/org/xbmc/kore/utils/FileDownloadHelper.java
@@ -25,6 +25,7 @@ import android.util.Base64;
 import android.widget.Toast;
 
 import org.xbmc.kore.R;
+import org.xbmc.kore.Settings;
 import org.xbmc.kore.host.HostInfo;
 import org.xbmc.kore.jsonrpc.ApiCallback;
 import org.xbmc.kore.jsonrpc.HostConnection;
@@ -375,7 +376,7 @@ public class FileDownloadHelper {
                     request.addRequestHeader("Authorization", "Basic " + token);
                 }
                 request.allowScanningByMediaScanner();
-                request.setAllowedNetworkTypes(DownloadManager.Request.NETWORK_WIFI);
+                request.setAllowedNetworkTypes(Settings.allowedDownloadNetworkTypes(context));
                 request.setTitle(mediaInfo.getDownloadTitle(context));
                 request.setDescription(mediaInfo.getDownloadDescrition(context));
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -51,6 +51,23 @@
         <item>@string/addons</item>
     </string-array>
 
+    <!-- Download connection types -->
+    <string-array name="entries_download_media_items">
+        <item>WiFi</item>
+        <item>Mobile</item>
+        <item>Any</item>
+    </string-array>
+
+    <string-array name="entry_values_download_media_items">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+
+    <string-array name="default_values_download_media_items">
+        <item>0</item>
+    </string-array>
+
     <!-- CAUTION: Keep this synced with the entries ids in NavigationDrawerFragment.java -->
     <string-array translatable="false" name="entry_values_nav_drawer_items">
         <item>2</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -364,5 +364,6 @@
     <string name="pvr_epg">Guide</string>
     <string name="unable_to_move_item">Unable to move item</string>
     <string name="cannot_move_playing_item">Cannot move currently playing/paused item</string>
+    <string name="no_connection_type_selected">No connection type selected in settings</string>
 
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -51,6 +51,14 @@
         android:entryValues="@array/entry_values_nav_drawer_items"
         android:defaultValue="@array/entry_values_nav_drawer_items"/>
 
+    <MultiSelectListPreference
+        android:key="pref_download_conn_types"
+        android:title="Download network types"
+        android:summary="Allowed network types for media downloads"
+        android:entries="@array/entries_download_media_items"
+        android:entryValues="@array/entry_values_download_media_items"
+        android:defaultValue="@array/default_values_download_media_items"/>
+
     <Preference
         android:key="pref_about"
         android:title="@string/about"/>


### PR DESCRIPTION
This allows the user to select other network connection types,
besides WiFi, for downloading media files.

The "Any" network type is added to allow downloading over USB network connections and probably bluetooth as well (didn't test that, as I do not have bluetooth on a device running Kodi).