### PR TITLE
Implemented restoring search query

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/AlbumListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AlbumListFragment.java
@@ -24,16 +24,11 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.provider.BaseColumns;
 import android.support.v4.content.CursorLoader;
-import android.support.v4.view.MenuItemCompat;
-import android.support.v7.widget.SearchView;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
 import android.widget.CursorAdapter;
 import android.widget.ImageView;
 import android.widget.PopupMenu;
@@ -98,16 +93,11 @@ public class AlbumListFragment extends AbstractCursorListFragment {
     }
 
     @Override
-    protected AdapterView.OnItemClickListener createOnItemClickListener() {
-        return new AdapterView.OnItemClickListener() {
-            @Override
-            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                // Get the movie id from the tag
-                ViewHolder tag = (ViewHolder) view.getTag();
-                // Notify the activity
-                listenerActivity.onAlbumSelected(tag);
-            }
-        };
+    protected void onListItemClicked(View view) {
+        // Get the movie id from the tag
+        ViewHolder tag = (ViewHolder) view.getTag();
+        // Notify the activity
+        listenerActivity.onAlbumSelected(tag);
     }
 
     @Override
@@ -160,28 +150,14 @@ public class AlbumListFragment extends AbstractCursorListFragment {
         } catch (ClassCastException e) {
             throw new ClassCastException(activity.toString() + " must implement OnAlbumSelectedListener");
         }
+
+        setSupportsSearch(true);
     }
 
     @Override
     public void onDetach() {
         super.onDetach();
         listenerActivity = null;
-    }
-
-    @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
-        if (!isAdded()) {
-            // HACK: Fix crash reported on Play Store. Why does this is necessary is beyond me
-            super.onCreateOptionsMenu(menu, inflater);
-            return;
-        }
-
-        inflater.inflate(R.menu.media_search, menu);
-        MenuItem searchItem = menu.findItem(R.id.action_search);
-        SearchView searchView = (SearchView) MenuItemCompat.getActionView(searchItem);
-        searchView.setOnQueryTextListener(this);
-        searchView.setQueryHint(getString(R.string.action_search_albums));
-        super.onCreateOptionsMenu(menu, inflater);
     }
 
     /**

--- a/app/src/main/java/org/xbmc/kore/ui/ArtistListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/ArtistListFragment.java
@@ -23,16 +23,11 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.provider.BaseColumns;
 import android.support.v4.content.CursorLoader;
-import android.support.v4.view.MenuItemCompat;
-import android.support.v7.widget.SearchView;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
 import android.widget.CursorAdapter;
 import android.widget.ImageView;
 import android.widget.PopupMenu;
@@ -67,16 +62,11 @@ public class ArtistListFragment extends AbstractCursorListFragment {
     protected String getListSyncType() { return LibrarySyncService.SYNC_ALL_MUSIC; }
 
     @Override
-    protected AdapterView.OnItemClickListener createOnItemClickListener() {
-        return new AdapterView.OnItemClickListener() {
-            @Override
-            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                // Get the artist id from the tag
-                ViewHolder tag = (ViewHolder) view.getTag();
-                // Notify the activity
-                listenerActivity.onArtistSelected(tag);
-            }
-        };
+    protected void onListItemClicked(View view) {
+        // Get the artist id from the tag
+        ViewHolder tag = (ViewHolder) view.getTag();
+        // Notify the activity
+        listenerActivity.onArtistSelected(tag);
     }
 
     @Override
@@ -109,27 +99,13 @@ public class ArtistListFragment extends AbstractCursorListFragment {
         } catch (ClassCastException e) {
             throw new ClassCastException(activity.toString() + " must implement OnArtistSelectedListener");
         }
+        setSupportsSearch(true);
     }
 
     @Override
     public void onDetach() {
         super.onDetach();
         listenerActivity = null;
-    }
-
-    @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
-        if (!isAdded()) {
-            // HACK: Fix crash reported on Play Store. Why does this is necessary is beyond me
-            super.onCreateOptionsMenu(menu, inflater);
-            return;
-        }
-        inflater.inflate(R.menu.media_search, menu);
-        MenuItem searchItem = menu.findItem(R.id.action_search);
-        SearchView searchView = (SearchView) MenuItemCompat.getActionView(searchItem);
-        searchView.setOnQueryTextListener(this);
-        searchView.setQueryHint(getString(R.string.action_search_artists));
-        super.onCreateOptionsMenu(menu, inflater);
     }
 
     /**

--- a/app/src/main/java/org/xbmc/kore/ui/AudioGenresListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AudioGenresListFragment.java
@@ -22,16 +22,11 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.provider.BaseColumns;
 import android.support.v4.content.CursorLoader;
-import android.support.v4.view.MenuItemCompat;
-import android.support.v7.widget.SearchView;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
 import android.widget.CursorAdapter;
 import android.widget.ImageView;
 import android.widget.PopupMenu;
@@ -64,16 +59,11 @@ public class AudioGenresListFragment extends AbstractCursorListFragment {
     protected String getListSyncType() { return LibrarySyncService.SYNC_ALL_MUSIC; }
 
     @Override
-    protected AdapterView.OnItemClickListener createOnItemClickListener() {
-        return new AdapterView.OnItemClickListener() {
-            @Override
-            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                // Get the movie id from the tag
-                ViewHolder tag = (ViewHolder) view.getTag();
-                // Notify the activity
-                listenerActivity.onAudioGenreSelected(tag.genreId, tag.genreTitle);
-            }
-        };
+    protected void onListItemClicked(View view) {
+        // Get the movie id from the tag
+        ViewHolder tag = (ViewHolder) view.getTag();
+        // Notify the activity
+        listenerActivity.onAudioGenreSelected(tag.genreId, tag.genreTitle);
     }
 
     @Override
@@ -106,6 +96,7 @@ public class AudioGenresListFragment extends AbstractCursorListFragment {
         } catch (ClassCastException e) {
             throw new ClassCastException(activity.toString() + " must implement OnAudioGenreSelectedListener");
         }
+        setSupportsSearch(true);
     }
 
     @Override
@@ -113,23 +104,6 @@ public class AudioGenresListFragment extends AbstractCursorListFragment {
         super.onDetach();
         listenerActivity = null;
     }
-
-    @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
-        if (!isAdded()) {
-            // HACK: Fix crash reported on Play Store. Why does this is necessary is beyond me
-            super.onCreateOptionsMenu(menu, inflater);
-            return;
-        }
-
-        inflater.inflate(R.menu.media_search, menu);
-        MenuItem searchItem = menu.findItem(R.id.action_search);
-        SearchView searchView = (SearchView) MenuItemCompat.getActionView(searchItem);
-        searchView.setOnQueryTextListener(this);
-        searchView.setQueryHint(getString(R.string.action_search_genres));
-        super.onCreateOptionsMenu(menu, inflater);
-    }
-
 
     /**
      * Audio genres list query parameters.

--- a/app/src/main/java/org/xbmc/kore/ui/MovieListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/MovieListFragment.java
@@ -25,8 +25,6 @@ import android.net.Uri;
 import android.preference.PreferenceManager;
 import android.provider.BaseColumns;
 import android.support.v4.content.CursorLoader;
-import android.support.v4.view.MenuItemCompat;
-import android.support.v7.widget.SearchView;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -34,7 +32,6 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
 import android.widget.CursorAdapter;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -67,16 +64,11 @@ public class MovieListFragment extends AbstractCursorListFragment {
     protected String getListSyncType() { return LibrarySyncService.SYNC_ALL_MOVIES; }
 
     @Override
-    protected AdapterView.OnItemClickListener createOnItemClickListener() {
-        return new AdapterView.OnItemClickListener() {
-            @Override
-            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                // Get the movie id from the tag
-                ViewHolder tag = (ViewHolder) view.getTag();
-                // Notify the activity
-                listenerActivity.onMovieSelected(tag);
-            }
-        };
+    protected void onListItemClicked(View view) {
+        // Get the movie id from the tag
+        ViewHolder tag = (ViewHolder) view.getTag();
+        // Notify the activity
+        listenerActivity.onMovieSelected(tag);
     }
 
     @Override
@@ -136,6 +128,7 @@ public class MovieListFragment extends AbstractCursorListFragment {
         } catch (ClassCastException e) {
             throw new ClassCastException(activity.toString() + " must implement OnMovieSelectedListener");
         }
+        setSupportsSearch(true);
     }
 
     @Override
@@ -153,12 +146,6 @@ public class MovieListFragment extends AbstractCursorListFragment {
         }
 
         inflater.inflate(R.menu.movie_list, menu);
-
-        // Setup search view
-        MenuItem searchItem = menu.findItem(R.id.action_search);
-        SearchView searchView = (SearchView) MenuItemCompat.getActionView(searchItem);
-        searchView.setOnQueryTextListener(this);
-        searchView.setQueryHint(getString(R.string.action_search_movies));
 
         // Setup filters
         MenuItem hideWatched = menu.findItem(R.id.action_hide_watched),

--- a/app/src/main/java/org/xbmc/kore/ui/MoviesActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/MoviesActivity.java
@@ -54,6 +54,8 @@ public class MoviesActivity extends BaseActivity
 
     private boolean clearSharedElements;
 
+    private MovieListFragment movieListFragment;
+
     @TargetApi(21)
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -70,7 +72,7 @@ public class MoviesActivity extends BaseActivity
         navigationDrawerFragment.setUp(R.id.navigation_drawer, (DrawerLayout) findViewById(R.id.drawer_layout));
 
         if (savedInstanceState == null) {
-            MovieListFragment movieListFragment = new MovieListFragment();
+            movieListFragment = new MovieListFragment();
 
             // Setup animations
             if (Utils.isLollipopOrLater()) {
@@ -169,6 +171,7 @@ public class MoviesActivity extends BaseActivity
             selectedMovieTitle = null;
             setupActionBar(null);
         }
+
         super.onBackPressed();
     }
 

--- a/app/src/main/java/org/xbmc/kore/ui/MusicListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/MusicListFragment.java
@@ -39,6 +39,8 @@ public class MusicListFragment extends Fragment {
 
     private TabsAdapter tabsAdapter;
 
+    private int currentItem;
+
     @InjectView(R.id.pager_tab_strip) PagerSlidingTabStrip pagerTabStrip;
     @InjectView(R.id.pager) ViewPager viewPager;
 
@@ -56,6 +58,28 @@ public class MusicListFragment extends Fragment {
         viewPager.setAdapter(tabsAdapter);
         pagerTabStrip.setViewPager(viewPager);
 
+        currentItem = viewPager.getCurrentItem();
+
+        viewPager.addOnPageChangeListener(new ViewPager.OnPageChangeListener() {
+            @Override
+            public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
+
+            }
+
+            @Override
+            public void onPageSelected(int position) {
+                AbstractCursorListFragment f =
+                        ((AbstractCursorListFragment) tabsAdapter.getStoredFragment(currentItem));
+                if (f != null) {
+                    f.saveSearchState();
+                }
+                currentItem = viewPager.getCurrentItem();
+            }
+
+            @Override
+            public void onPageScrollStateChanged(int state) {
+            }
+        });
         return root;
     }
 

--- a/app/src/main/java/org/xbmc/kore/ui/MusicVideoListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/MusicVideoListFragment.java
@@ -23,16 +23,10 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.provider.BaseColumns;
 import android.support.v4.content.CursorLoader;
-import android.support.v4.view.MenuItemCompat;
-import android.support.v7.widget.SearchView;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
 import android.widget.CursorAdapter;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -64,16 +58,11 @@ public class MusicVideoListFragment extends AbstractCursorListFragment {
     protected String getListSyncType() { return LibrarySyncService.SYNC_ALL_MUSIC_VIDEOS; }
 
     @Override
-    protected AdapterView.OnItemClickListener createOnItemClickListener() {
-        return new AdapterView.OnItemClickListener() {
-            @Override
-            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                // Get the movie id from the tag
-                ViewHolder tag = (ViewHolder)view.getTag();
-                // Notify the activity
-                listenerActivity.onMusicVideoSelected(tag);
-            }
-        };
+    protected void onListItemClicked(View view) {
+        // Get the movie id from the tag
+        ViewHolder tag = (ViewHolder)view.getTag();
+        // Notify the activity
+        listenerActivity.onMusicVideoSelected(tag);
     }
 
     @Override
@@ -106,28 +95,13 @@ public class MusicVideoListFragment extends AbstractCursorListFragment {
         } catch (ClassCastException e) {
             throw new ClassCastException(activity.toString() + " must implement OnMusicVideoSelectedListener");
         }
+        setSupportsSearch(true);
     }
 
     @Override
     public void onDetach() {
         super.onDetach();
         listenerActivity = null;
-    }
-
-    @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
-        if (!isAdded()) {
-            // HACK: Fix crash reported on Play Store. Why does this is necessary is beyond me
-            super.onCreateOptionsMenu(menu, inflater);
-            return;
-        }
-
-        inflater.inflate(R.menu.media_search, menu);
-        MenuItem searchItem = menu.findItem(R.id.action_search);
-        SearchView searchView = (SearchView) MenuItemCompat.getActionView(searchItem);
-        searchView.setOnQueryTextListener(this);
-        searchView.setQueryHint(getString(R.string.action_search_music_videos));
-        super.onCreateOptionsMenu(menu, inflater);
     }
 
     /**

--- a/app/src/main/java/org/xbmc/kore/ui/TVShowListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/TVShowListFragment.java
@@ -25,8 +25,6 @@ import android.net.Uri;
 import android.preference.PreferenceManager;
 import android.provider.BaseColumns;
 import android.support.v4.content.CursorLoader;
-import android.support.v4.view.MenuItemCompat;
-import android.support.v7.widget.SearchView;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -34,7 +32,6 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
 import android.widget.CursorAdapter;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -67,16 +64,11 @@ public class TVShowListFragment extends AbstractCursorListFragment {
     protected String getListSyncType() { return LibrarySyncService.SYNC_ALL_TVSHOWS; }
 
     @Override
-    protected AdapterView.OnItemClickListener createOnItemClickListener() {
-        return new AdapterView.OnItemClickListener() {
-            @Override
-            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                // Get the movie id from the tag
-                ViewHolder tag = (ViewHolder) view.getTag();
-                // Notify the activity
-                listenerActivity.onTVShowSelected(tag);
-            }
-        };
+    protected void onListItemClicked(View view) {
+        // Get the movie id from the tag
+        ViewHolder tag = (ViewHolder) view.getTag();
+        // Notify the activity
+        listenerActivity.onTVShowSelected(tag);
     }
 
     @Override
@@ -138,6 +130,7 @@ public class TVShowListFragment extends AbstractCursorListFragment {
         } catch (ClassCastException e) {
             throw new ClassCastException(activity.toString() + " must implement OnTVShowSelectedListener");
         }
+        setSupportsSearch(true);
     }
 
     @Override
@@ -155,10 +148,6 @@ public class TVShowListFragment extends AbstractCursorListFragment {
         }
 
         inflater.inflate(R.menu.tvshow_list, menu);
-        MenuItem searchItem = menu.findItem(R.id.action_search);
-        SearchView searchView = (SearchView) MenuItemCompat.getActionView(searchItem);
-        searchView.setOnQueryTextListener(this);
-        searchView.setQueryHint(getString(R.string.action_search_tvshows));
 
         // Setup filters
         MenuItem hideWatched = menu.findItem(R.id.action_hide_watched),

--- a/app/src/main/res/menu/movie_list.xml
+++ b/app/src/main/res/menu/movie_list.xml
@@ -18,13 +18,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
-        android:id="@+id/action_search"
-        android:title="@string/action_search"
-        android:icon="?attr/iconSearchToolbar"
-        android:queryHint="@string/action_search"
-        app:showAsAction="ifRoom|collapseActionView"
-        app:actionViewClass="android.support.v7.widget.SearchView"/>
-    <item
         android:title="@string/sort_order"
         app:showAsAction="never">
         <menu>

--- a/app/src/main/res/menu/tvshow_list.xml
+++ b/app/src/main/res/menu/tvshow_list.xml
@@ -16,12 +16,6 @@
 -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:app="http://schemas.android.com/apk/res-auto">
-    <item android:id="@+id/action_search"
-          android:title="@string/action_search"
-          android:icon="?attr/iconSearchToolbar"
-          android:queryHint="@string/action_search"
-          app:showAsAction="ifRoom|collapseActionView"
-          app:actionViewClass="android.support.v7.widget.SearchView"/>
     <item
         android:title="@string/sort_order"
         app:showAsAction="never">


### PR DESCRIPTION
When user enters a search query for a ListFragment the query will
now be restored on device configuration changes and when
ListFragment is restored from the backstack.

I hit the limit of manually testing this and implemented unit tests to automate all cases I could think of. See #223 for the the PR implementing unit tests.

I created tests for two different list fragment setups. One using a view pager and one that does not.
See 
https://github.com/poisdeux/Kore/blob/unittest/restoresearchquery/app/src/androidTest/java/org/xbmc/kore/RestoreSearchQueryViewPagerTest.java
for the view pager tests.

See https://github.com/poisdeux/Kore/blob/unittest/restoresearchquery/app/src/androidTest/java/org/xbmc/kore/RestoreSearchQueryListFragmentTest.java
for the single list fragment tests

Btw this fixes #161