### PR TITLE
Plugin/addon content browser

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/AddonDetailsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AddonDetailsFragment.java
@@ -58,7 +58,7 @@ import butterknife.OnClick;
 /**
  * Presents addon details
  */
-public class AddonDetailsFragment extends Fragment {
+public class AddonDetailsFragment extends SharedElementFragment {
     private static final String TAG = LogUtils.makeLogTag(AddonDetailsFragment.class);
 
     public static final String BUNDLE_KEY_ADDONID = "addon_id";
@@ -71,6 +71,7 @@ public class AddonDetailsFragment extends Fragment {
     public static final String BUNDLE_KEY_FANART = "fanart";
     public static final String BUNDLE_KEY_POSTER = "poster";
     public static final String BUNDLE_KEY_ENABLED = "enabled";
+    public static final String BUNDLE_KEY_BROWSABLE = "browsable";
 
     private HostManager hostManager;
     private HostInfo hostInfo;
@@ -119,6 +120,7 @@ public class AddonDetailsFragment extends Fragment {
         args.putString(BUNDLE_KEY_FANART, vh.fanart);
         args.putString(BUNDLE_KEY_POSTER, vh.poster);
         args.putBoolean(BUNDLE_KEY_ENABLED, vh.enabled);
+        args.putBoolean(BUNDLE_KEY_BROWSABLE, vh.browsable);
 
         if( Utils.isLollipopOrLater()) {
             args.putString(POSTER_TRANS_NAME, vh.artView.getTransitionName());
@@ -177,7 +179,8 @@ public class AddonDetailsFragment extends Fragment {
         setImages(bundle.getString(BUNDLE_KEY_POSTER), bundle.getString(BUNDLE_KEY_FANART));
 
         setupEnableButton(bundle.getBoolean(BUNDLE_KEY_ENABLED, false));
-        updatePinButton();
+        if (bundle.getBoolean(BUNDLE_KEY_BROWSABLE, true))
+            updatePinButton();
 
         // Pad main content view to overlap with bottom system bar
 //        UIUtils.setPaddingForSystemBars(getActivity(), mediaPanel, false, false, true);
@@ -296,6 +299,7 @@ public class AddonDetailsFragment extends Fragment {
      * Returns the shared element if visible
      * @return View if visible, null otherwise
      */
+    @Override
     public View getSharedElement() {
         if (UIUtils.isViewInBounds(mediaPanel, mediaPoster)) {
             return mediaPoster;
@@ -362,6 +366,7 @@ public class AddonDetailsFragment extends Fragment {
             pinButton.clearColorFilter();
         }
         pinButton.setTag(enabled);
+        pinButton.setVisibility(View.VISIBLE);
     }
 
     private void updatePinButton() {

--- a/app/src/main/java/org/xbmc/kore/ui/AddonListContainerFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AddonListContainerFragment.java
@@ -67,14 +67,14 @@ public class AddonListContainerFragment extends Fragment {
         SharedPreferences prefs = getActivity().getSharedPreferences("addons", Context.MODE_PRIVATE);
         Set<String> bookmarked = prefs.getStringSet("bookmarked", Collections.<String>emptySet());
         long baseFragmentId = 70 + bookmarked.size() * 100;
+        tabsAdapter.addTab(AddonListFragment.class, new Bundle(), R.string.addons, baseFragmentId);
         for (String path: bookmarked) {
             String name = prefs.getString("name_" + path, "Content");
             Bundle addon = new Bundle();
             addon.putString(AddonDetailsFragment.BUNDLE_KEY_NAME, name);
             addon.putParcelable(MediaFileListFragment.ROOT_PATH, new MediaFileListFragment.FileLocation(name, "plugin://" + path, true));
-            tabsAdapter.addTab(MediaFileListFragment.class, addon, name, baseFragmentId++);
+            tabsAdapter.addTab(MediaFileListFragment.class, addon, name, ++baseFragmentId);
         }
-        tabsAdapter.addTab(AddonListFragment.class, new Bundle(), R.string.addons, baseFragmentId);
         viewPager.setAdapter(tabsAdapter);
         pagerTabStrip.setViewPager(viewPager);
 

--- a/app/src/main/java/org/xbmc/kore/ui/AddonListContainerFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AddonListContainerFragment.java
@@ -40,8 +40,8 @@ import butterknife.InjectView;
 /**
  * Container for the TV Show overview and Episodes list
  */
-public class AddonsOverviewFragment extends Fragment {
-    private static final String TAG = LogUtils.makeLogTag(AddonsOverviewFragment.class);
+public class AddonListContainerFragment extends Fragment {
+    private static final String TAG = LogUtils.makeLogTag(AddonListContainerFragment.class);
 
     private TabsAdapter tabsAdapter;
 

--- a/app/src/main/java/org/xbmc/kore/ui/AddonListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AddonListFragment.java
@@ -265,6 +265,7 @@ public class AddonListFragment extends Fragment
             viewHolder.fanart = addonDetails.fanart;
             viewHolder.poster = addonDetails.thumbnail;
             viewHolder.enabled = addonDetails.enabled;
+            viewHolder.browsable = AddonType.Types.XBMC_PYTHON_PLUGINSOURCE.equals(addonDetails.type);
 
             viewHolder.titleView.setText(viewHolder.addonName);
             viewHolder.detailsView.setText(addonDetails.summary);
@@ -297,5 +298,6 @@ public class AddonListFragment extends Fragment
         String fanart;
         String poster;
         Boolean enabled;
+        Boolean browsable;
     }
 }

--- a/app/src/main/java/org/xbmc/kore/ui/AddonOverviewFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AddonOverviewFragment.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2016 Synced Synapse. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.xbmc.kore.ui;
+
+import android.annotation.TargetApi;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.view.ViewPager;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.astuetz.PagerSlidingTabStrip;
+
+import org.xbmc.kore.R;
+import org.xbmc.kore.utils.LogUtils;
+import org.xbmc.kore.utils.TabsAdapter;
+import org.xbmc.kore.utils.UIUtils;
+import org.xbmc.kore.utils.Utils;
+
+import butterknife.ButterKnife;
+import butterknife.InjectView;
+
+/**
+ * Container for the TV Show overview and Episodes list
+ */
+public class AddonOverviewFragment extends Fragment {
+    private static final String TAG = LogUtils.makeLogTag(AddonOverviewFragment.class);
+
+    private TabsAdapter tabsAdapter;
+
+    @InjectView(R.id.pager_tab_strip) PagerSlidingTabStrip pagerTabStrip;
+    @InjectView(R.id.pager) ViewPager viewPager;
+
+    /**
+     * Create a new instance of this, initialized to show the addon addonId
+     */
+    @TargetApi(21)
+    public static AddonOverviewFragment newInstance(AddonListFragment.ViewHolder vh) {
+        AddonOverviewFragment fragment = new AddonOverviewFragment();
+
+        Bundle args = new Bundle();
+        args.putString(AddonDetailsFragment.BUNDLE_KEY_ADDONID, vh.addonId);
+        args.putString(AddonDetailsFragment.BUNDLE_KEY_NAME, vh.addonName);
+        args.putString(AddonDetailsFragment.BUNDLE_KEY_AUTHOR, vh.author);
+        args.putString(AddonDetailsFragment.BUNDLE_KEY_VERSION, vh.version);
+        args.putString(AddonDetailsFragment.BUNDLE_KEY_SUMMARY, vh.summary);
+        args.putString(AddonDetailsFragment.BUNDLE_KEY_DESCRIPTION, vh.description);
+        args.putString(AddonDetailsFragment.BUNDLE_KEY_FANART, vh.fanart);
+        args.putString(AddonDetailsFragment.BUNDLE_KEY_POSTER, vh.poster);
+        args.putBoolean(AddonDetailsFragment.BUNDLE_KEY_ENABLED, vh.enabled);
+
+        if( Utils.isLollipopOrLater()) {
+            args.putString(AddonDetailsFragment.POSTER_TRANS_NAME, vh.artView.getTransitionName());
+        }
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        Bundle args = getArguments();
+
+        if ((container == null) || (args == null)) {
+            // We're not being shown or there's nothing to show
+            return null;
+        }
+
+        ViewGroup root = (ViewGroup) inflater.inflate(R.layout.fragment_default_view_pager, container, false);
+        ButterKnife.inject(this, root);
+
+        Bundle plugin = new Bundle();
+        MediaFileListFragment.FileLocation rootPath = new MediaFileListFragment.FileLocation(
+                args.getString(AddonDetailsFragment.BUNDLE_KEY_NAME, "Content"),
+                "plugin://" + args.getString(AddonDetailsFragment.BUNDLE_KEY_ADDONID, ""),
+                true);
+        rootPath.setRootDir(true);
+        plugin.putParcelable(MediaFileListFragment.ROOT_PATH, rootPath);
+
+        long baseFragmentId = 1000;
+        tabsAdapter = new TabsAdapter(getActivity(), getChildFragmentManager())
+                .addTab(AddonDetailsFragment.class, args, R.string.addon_overview, baseFragmentId++)
+                .addTab(MediaFileListFragment.class, plugin, R.string.addon_content, baseFragmentId++)
+                ;
+        viewPager.setAdapter(tabsAdapter);
+        pagerTabStrip.setViewPager(viewPager);
+
+        return root;
+    }
+
+    @Override
+    public void onActivityCreated (Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        setHasOptionsMenu(false);
+    }
+
+    public Fragment getCurrentTabFragment() {
+        return tabsAdapter.getItem(viewPager.getCurrentItem());
+    }
+
+    public View getSharedElement() {
+        View view = getView();
+        if (view == null)
+            return null;
+
+        //Note: this works as R.id.poster is only used in TVShowOverviewFragment.
+        //If the same id is used in other fragments in the TabsAdapter we
+        //need to check which fragment is currently displayed
+        View artView = view.findViewById(R.id.poster);
+        View scrollView = view.findViewById(R.id.media_panel);
+        if (( artView != null ) &&
+                ( scrollView != null ) &&
+                UIUtils.isViewInBounds(scrollView, artView)) {
+            return artView;
+        }
+
+        return null;
+    }
+}

--- a/app/src/main/java/org/xbmc/kore/ui/AddonOverviewFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AddonOverviewFragment.java
@@ -85,6 +85,7 @@ public class AddonOverviewFragment extends Fragment {
         MediaFileListFragment.FileLocation rootPath = new MediaFileListFragment.FileLocation(name, "plugin://" + path, true);
         rootPath.setRootDir(true);
         content.putParcelable(MediaFileListFragment.ROOT_PATH, rootPath);
+        content.putBoolean(MediaFileListFragment.DELAY_LOAD, true);
         return content;
     }
 

--- a/app/src/main/java/org/xbmc/kore/ui/AddonOverviewFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AddonOverviewFragment.java
@@ -43,7 +43,7 @@ import butterknife.InjectView;
 /**
  * Container for the TV Show overview and Episodes list
  */
-public class AddonOverviewFragment extends Fragment {
+public class AddonOverviewFragment extends SharedElementFragment {
     private static final String TAG = LogUtils.makeLogTag(AddonOverviewFragment.class);
 
     private TabsAdapter tabsAdapter;
@@ -68,6 +68,7 @@ public class AddonOverviewFragment extends Fragment {
         args.putString(AddonDetailsFragment.BUNDLE_KEY_FANART, vh.fanart);
         args.putString(AddonDetailsFragment.BUNDLE_KEY_POSTER, vh.poster);
         args.putBoolean(AddonDetailsFragment.BUNDLE_KEY_ENABLED, vh.enabled);
+        args.putBoolean(AddonDetailsFragment.BUNDLE_KEY_BROWSABLE, vh.browsable);
 
         if( Utils.isLollipopOrLater()) {
             args.putString(AddonDetailsFragment.POSTER_TRANS_NAME, vh.artView.getTransitionName());
@@ -127,6 +128,7 @@ public class AddonOverviewFragment extends Fragment {
         return tabsAdapter.getItem(viewPager.getCurrentItem());
     }
 
+    @Override
     public View getSharedElement() {
         View view = getView();
         if (view == null)

--- a/app/src/main/java/org/xbmc/kore/ui/AddonsActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AddonsActivity.java
@@ -206,7 +206,7 @@ public class AddonsActivity extends BaseActivity
         selectedAddonTitle = vh.addonName;
 
         // Replace list fragment
-        final AddonDetailsFragment addonDetailsFragment = AddonDetailsFragment.newInstance(vh);
+        final AddonOverviewFragment addonDetailsFragment = AddonOverviewFragment.newInstance(vh);
         FragmentTransaction fragTrans = getSupportFragmentManager().beginTransaction();
 
         // Set up transitions

--- a/app/src/main/java/org/xbmc/kore/ui/AddonsActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AddonsActivity.java
@@ -206,7 +206,11 @@ public class AddonsActivity extends BaseActivity
         selectedAddonTitle = vh.addonName;
 
         // Replace list fragment
-        final AddonOverviewFragment addonDetailsFragment = AddonOverviewFragment.newInstance(vh);
+        final SharedElementFragment addonDetailsFragment =
+            vh.browsable
+            ? AddonOverviewFragment.newInstance(vh)
+            : AddonDetailsFragment.newInstance(vh)
+            ;
         FragmentTransaction fragTrans = getSupportFragmentManager().beginTransaction();
 
         // Set up transitions

--- a/app/src/main/java/org/xbmc/kore/ui/AddonsActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AddonsActivity.java
@@ -70,7 +70,7 @@ public class AddonsActivity extends BaseActivity
         navigationDrawerFragment.setUp(R.id.navigation_drawer, (DrawerLayout) findViewById(R.id.drawer_layout));
 
         if (savedInstanceState == null) {
-            AddonsOverviewFragment addonListFragment = new AddonsOverviewFragment();
+            AddonListContainerFragment addonListFragment = new AddonListContainerFragment();
 
             // Setup animations
             if (Utils.isLollipopOrLater()) {

--- a/app/src/main/java/org/xbmc/kore/ui/AddonsActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AddonsActivity.java
@@ -70,7 +70,7 @@ public class AddonsActivity extends BaseActivity
         navigationDrawerFragment.setUp(R.id.navigation_drawer, (DrawerLayout) findViewById(R.id.drawer_layout));
 
         if (savedInstanceState == null) {
-            AddonListFragment addonListFragment = new AddonListFragment();
+            AddonsOverviewFragment addonListFragment = new AddonsOverviewFragment();
 
             // Setup animations
             if (Utils.isLollipopOrLater()) {

--- a/app/src/main/java/org/xbmc/kore/ui/MediaFileListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/MediaFileListFragment.java
@@ -143,7 +143,8 @@ public class MediaFileListFragment extends AbstractListFragment {
         emptyView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                browseSources();
+                if (!atRootDirectory())
+                    browseSources();
             }
         });
 

--- a/app/src/main/java/org/xbmc/kore/ui/MediaFileListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/MediaFileListFragment.java
@@ -78,6 +78,7 @@ public class MediaFileListFragment extends AbstractListFragment {
     int playlistId = PlaylistType.MUSIC_PLAYLISTID;             // this is the ID of the music player
 //    private MediaFileListAdapter adapter = null;
     boolean browseRootAlready = false;
+    FileLocation loadOnVisible = null;
 
     ArrayList<FileLocation> rootFileLocation = new ArrayList<FileLocation>();
     Queue<FileLocation> mediaQueueFileLocation = new LinkedList<>();
@@ -162,13 +163,25 @@ public class MediaFileListFragment extends AbstractListFragment {
             ((MediaFileListAdapter) getAdapter()).setFilelistItems(list);
         }
         else if (rootPath != null) {
-            browseRootAlready = true;
-            browseDirectory(rootPath);
+            loadOnVisible = rootPath;
+            // setUserVisibleHint may have already fired
+            setUserVisibleHint(getUserVisibleHint());
         }
         else {
             browseSources();
         }
         return root;
+    }
+
+    @Override
+    public void setUserVisibleHint (boolean isVisibleToUser) {
+        super.setUserVisibleHint(isVisibleToUser);
+        if (isVisibleToUser && loadOnVisible != null) {
+            FileLocation rootPath = loadOnVisible;
+            loadOnVisible = null;
+            browseRootAlready = true;
+            browseDirectory(rootPath);
+        }
     }
 
     void handleFileSelect(FileLocation f) {

--- a/app/src/main/java/org/xbmc/kore/ui/MediaFileListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/MediaFileListFragment.java
@@ -65,6 +65,7 @@ public class MediaFileListFragment extends AbstractListFragment {
     public static final String ROOT_PATH_CONTENTS = "rootPathContents";
     public static final String ROOT_VISITED = "rootVisited";
     public static final String ROOT_PATH = "rootPath";
+    public static final String DELAY_LOAD = "delayLoad";
     private static final String ADDON_SOURCE = "addons:";
 
     private HostManager hostManager;
@@ -165,7 +166,7 @@ public class MediaFileListFragment extends AbstractListFragment {
         else if (rootPath != null) {
             loadOnVisible = rootPath;
             // setUserVisibleHint may have already fired
-            setUserVisibleHint(getUserVisibleHint());
+            setUserVisibleHint(getUserVisibleHint() || !args.getBoolean(DELAY_LOAD, false));
         }
         else {
             browseSources();

--- a/app/src/main/java/org/xbmc/kore/ui/SharedElementFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/SharedElementFragment.java
@@ -1,0 +1,8 @@
+package org.xbmc.kore.ui;
+
+import android.support.v4.app.Fragment;
+import android.view.View;
+
+public abstract class SharedElementFragment extends Fragment {
+    public abstract View getSharedElement();
+}

--- a/app/src/main/java/org/xbmc/kore/utils/TabsAdapter.java
+++ b/app/src/main/java/org/xbmc/kore/utils/TabsAdapter.java
@@ -38,12 +38,21 @@ public class TabsAdapter extends FragmentPagerAdapter {
         private final Bundle args;
         private final int titleRes;
         private final long fragmentId;
+        private final String titleString;
 
         TabInfo(Class<?> fragmentClass, Bundle args, int titleRes, long fragmentId) {
             this.fragmentClass = fragmentClass;
             this.args = args;
             this.titleRes = titleRes;
             this.fragmentId = fragmentId;
+            this.titleString = null;
+        }
+        TabInfo(Class<?> fragmentClass, Bundle args, String titleString, long fragmentId) {
+            this.fragmentClass = fragmentClass;
+            this.args = args;
+            this.titleRes = 0;
+            this.fragmentId = fragmentId;
+            this.titleString = titleString;
         }
     }
 
@@ -55,6 +64,12 @@ public class TabsAdapter extends FragmentPagerAdapter {
 
     public TabsAdapter addTab(Class<?> fragmentClass, Bundle args, int titleRes, long fragmentId) {
         TabInfo info = new TabInfo(fragmentClass, args, titleRes, fragmentId);
+        tabInfos.add(info);
+        return this;
+    }
+
+    public TabsAdapter addTab(Class<?> fragmentClass, Bundle args, String titleString, long fragmentId) {
+        TabInfo info = new TabInfo(fragmentClass, args, titleString, fragmentId);
         tabInfos.add(info);
         return this;
     }
@@ -101,7 +116,7 @@ public class TabsAdapter extends FragmentPagerAdapter {
         TabInfo tabInfo = tabInfos.get(position);
         if (tabInfo != null) {
 //            return context.getString(tabInfo.titleRes).toUpperCase(Locale.getDefault());
-            return context.getString(tabInfo.titleRes);
+            return tabInfo.titleString == null? context.getString(tabInfo.titleRes) : tabInfo.titleString;
         }
         return null;
     }

--- a/app/src/main/res/layout/fragment_addon_details.xml
+++ b/app/src/main/res/layout/fragment_addon_details.xml
@@ -98,6 +98,13 @@
                     android:layout_weight="1"
                     android:layout_height="match_parent"/>
                 <ImageButton
+                    android:id="@+id/pin_unpin"
+                    android:layout_width="@dimen/buttonbar_button_width"
+                    android:layout_height="match_parent"
+                    style="@style/Widget.Button.Borderless"
+                    android:src="?attr/iconNew"
+                    android:contentDescription="@string/enable_disable"/>
+                <ImageButton
                     android:id="@+id/enable_disable"
                     android:layout_width="@dimen/buttonbar_button_width"
                     android:layout_height="match_parent"

--- a/app/src/main/res/layout/fragment_addon_details.xml
+++ b/app/src/main/res/layout/fragment_addon_details.xml
@@ -99,6 +99,7 @@
                     android:layout_height="match_parent"/>
                 <ImageButton
                     android:id="@+id/pin_unpin"
+                    android:visibility="gone"
                     android:layout_width="@dimen/buttonbar_button_width"
                     android:layout_height="match_parent"
                     style="@style/Widget.Button.Borderless"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -286,6 +286,9 @@
     <string name="tvshow_overview">Overview</string>
     <string name="tvshow_episodes">Episodes</string>
 
+    <string name="addon_overview">Overview</string>
+    <string name="addon_content">Content</string>
+
     <string name="artists">Artists</string>
     <string name="albums">Albums</string>
     <string name="genres">Genres</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -302,6 +302,9 @@
     <string name="enable_disable">Enable/Disable Addon</string>
     <string name="addon_enabled">Addon enabled</string>
     <string name="addon_disabled">Addon disabled</string>
+    <string name="pin_unpin">Pin/Unpin Addon</string>
+    <string name="addon_pinned">Addon pinned</string>
+    <string name="addon_unpinned">Addon unpinned</string>
 
     <!-- Filters on list menus -->
     <string name="hide_watched">Hide watched</string>


### PR DESCRIPTION
See #72.

This adds a tab beside the addon details view for browsing the content that's presented by the addon through its virtual file tree.

This also adds a "Pin/Unpin" button to the addon details view which allows the content tab for a particular addon to be pinned as a tab in the addons activity for quick access. This gives addons that present a good content tree ease of use comparable to the Files browser, once you've picked them out.