### PR TITLE
Sync delay steps

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/GenericSelectDialog.java
+++ b/app/src/main/java/org/xbmc/kore/ui/GenericSelectDialog.java
@@ -143,6 +143,21 @@ public class GenericSelectDialog
                                 mListener.onDialogSelect(token, which);
                             dialog.dismiss();
                         }
+                    })
+                    .setPositiveButton("+0.5s >", new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            if (mListener != null)
+                                mListener.onDialogSelect(token, which);
+                        }
+                    })
+                    .setNegativeButton("< -0.5s", new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            if (mListener != null)
+                                mListener.onDialogSelect(token, which);
+                            dialog.cancel();
+                        }
                     });
         } else {
             final CharSequence[] items = args.getCharSequenceArray(ARRAY_ITEMS);
@@ -165,11 +180,23 @@ public class GenericSelectDialog
                         mListener.onDialogSelect(token, which);
                     dialog.dismiss();
                 }
-            });
+            })
+                    .setPositiveButton("+0.5s >", new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            if (mListener != null)
+                                mListener.onDialogSelect(token, which);
+                        }
+                    })
+                    .setNegativeButton("< -0.5s", new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            if (mListener != null)
+                                mListener.onDialogSelect(token, which);
+                        }
+                    });
 
         }
         return builder.create();
-
     }
-
 }

--- a/app/src/main/java/org/xbmc/kore/ui/GenericSelectDialog.java
+++ b/app/src/main/java/org/xbmc/kore/ui/GenericSelectDialog.java
@@ -43,7 +43,14 @@ public class GenericSelectDialog
             TITLE_KEY = "TITLE",
             ARRAY_ID_KEY = "ARRAY_ID_KEY",
             ARRAY_ITEMS = "ARRAY_ITEMS",
-            SELECTED_ITEM_KEY = "SELECTED_ITEM";
+            SELECTED_ITEM_KEY = "SELECTED_ITEM",
+            POSITIVE_BUTTON = "POSITIVE_BUTTON",
+            NEGATIVE_BUTTON = "NEGATIVE_BUTTON";
+
+    public static GenericSelectDialog newInstance(GenericSelectDialogListener listener,
+                                                  int token, String title, int arrayId, int selectedItem) {
+        return newInstance(listener, token, title, arrayId, selectedItem, null, null);
+    }
 
     /**
      * Create a new instance of the dialog, providing arguments.
@@ -52,9 +59,13 @@ public class GenericSelectDialog
      * @param title Title of the dialog
      * @param arrayId String array id of the options to show in the dialog
      * @param selectedItem Index of the selected item
+     * @param posText Text of the OK button
+     * @param negText Text of the cancel button
+     * @return New dialog
      */
     public static GenericSelectDialog newInstance(GenericSelectDialogListener listener,
-                                                  int token, String title, int arrayId, int selectedItem) {
+                                                  int token, String title, int arrayId, int selectedItem,
+                                                  String posText, String negText) {
         GenericSelectDialog dialog = new GenericSelectDialog();
         // TODO: This isn't going to survive destroys, but it's the easiast way to communicate
         dialog.mListener = listener;
@@ -64,9 +75,16 @@ public class GenericSelectDialog
         args.putString(TITLE_KEY, title);
         args.putInt(ARRAY_ID_KEY, arrayId);
         args.putInt(SELECTED_ITEM_KEY, selectedItem);
+        args.putString(POSITIVE_BUTTON, posText);
+        args.putString(NEGATIVE_BUTTON, negText);
         dialog.setArguments(args);
 
         return dialog;
+    }
+
+    public static GenericSelectDialog newInstance(GenericSelectDialogListener listener,
+                                                  int token, String title, CharSequence[] items, int selectedItem) {
+        return newInstance(listener, token, title, items, selectedItem, null, null);
     }
 
     /**
@@ -76,10 +94,13 @@ public class GenericSelectDialog
      * @param title Title of the dialog
      * @param items String array of the options to show in the dialog
      * @param selectedItem Index of the selected item
+     * @param posText Text of the OK button
+     * @param negText Text of the cancel button
      * @return New dialog
      */
     public static GenericSelectDialog newInstance(GenericSelectDialogListener listener,
-                                                  int token, String title, CharSequence[] items, int selectedItem) {
+                                                  int token, String title, CharSequence[] items, int selectedItem,
+                                                  String posText, String negText) {
         GenericSelectDialog dialog = new GenericSelectDialog();
         // TODO: This isn't going to survive destroys, but it's the easiast way to communicate
         dialog.mListener = listener;
@@ -89,6 +110,8 @@ public class GenericSelectDialog
         args.putString(TITLE_KEY, title);
         args.putCharSequenceArray(ARRAY_ITEMS, items);
         args.putInt(SELECTED_ITEM_KEY, selectedItem);
+        args.putString(POSITIVE_BUTTON, posText);
+        args.putString(NEGATIVE_BUTTON, negText);
         dialog.setArguments(args);
 
         return dialog;
@@ -131,6 +154,8 @@ public class GenericSelectDialog
         final String title = args.getString(TITLE_KEY);
         final int token = args.getInt(TOKEN_KEY);
         final int selectedItem = args.getInt(SELECTED_ITEM_KEY);
+        final String posText = args.getString(POSITIVE_BUTTON);
+        final String negText = args.getString(NEGATIVE_BUTTON);
 
         builder.setTitle(title);
         if (getArguments().containsKey(ARRAY_ID_KEY)) {
@@ -143,22 +168,25 @@ public class GenericSelectDialog
                                 mListener.onDialogSelect(token, which);
                             dialog.dismiss();
                         }
-                    })
-                    .setPositiveButton("+0.5s >", new DialogInterface.OnClickListener() {
-                        @Override
-                        public void onClick(DialogInterface dialog, int which) {
-                            if (mListener != null)
-                                mListener.onDialogSelect(token, which);
-                        }
-                    })
-                    .setNegativeButton("< -0.5s", new DialogInterface.OnClickListener() {
-                        @Override
-                        public void onClick(DialogInterface dialog, int which) {
-                            if (mListener != null)
-                                mListener.onDialogSelect(token, which);
-                            dialog.cancel();
-                        }
                     });
+            if (posText != null) {
+                builder.setPositiveButton(posText, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        if (mListener != null)
+                            mListener.onDialogSelect(token, which);
+                    }
+                });
+            }
+            if (negText != null) {
+                builder.setNegativeButton(negText, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        if (mListener != null)
+                            mListener.onDialogSelect(token, which);
+                    }
+                });
+            }
         } else {
             final CharSequence[] items = args.getCharSequenceArray(ARRAY_ITEMS);
 
@@ -180,22 +208,25 @@ public class GenericSelectDialog
                         mListener.onDialogSelect(token, which);
                     dialog.dismiss();
                 }
-            })
-                    .setPositiveButton("+0.5s >", new DialogInterface.OnClickListener() {
-                        @Override
-                        public void onClick(DialogInterface dialog, int which) {
-                            if (mListener != null)
-                                mListener.onDialogSelect(token, which);
-                        }
-                    })
-                    .setNegativeButton("< -0.5s", new DialogInterface.OnClickListener() {
-                        @Override
-                        public void onClick(DialogInterface dialog, int which) {
-                            if (mListener != null)
-                                mListener.onDialogSelect(token, which);
-                        }
-                    });
-
+            });
+            if (posText != null) {
+                builder.setPositiveButton(posText, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        if (mListener != null)
+                            mListener.onDialogSelect(token, which);
+                    }
+                });
+            }
+            if (negText != null) {
+                builder.setNegativeButton(negText, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        if (mListener != null)
+                            mListener.onDialogSelect(token, which);
+                    }
+                });
+            }
         }
         return builder.create();
     }

--- a/app/src/main/java/org/xbmc/kore/ui/NowPlayingFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/NowPlayingFragment.java
@@ -445,6 +445,18 @@ public class NowPlayingFragment extends Fragment
             case SELECT_AUDIOSTREAM:
                 // 0 is to sync audio, other is for a specific audiostream
                 switch (which) {
+                    case -2:
+                        for(int i = 0; i < 5; i++) {
+                            Input.ExecuteAction syncAudioDelayAction = new Input.ExecuteAction(Input.ExecuteAction.AUDIODELAYMINUS);
+                            syncAudioDelayAction.execute(hostManager.getConnection(), defaultStringActionCallback, callbackHandler);
+                        }
+                        break;
+                    case -1:
+                        for(int i = 0; i < 5; i++) {
+                            Input.ExecuteAction syncAudioAheadAction = new Input.ExecuteAction(Input.ExecuteAction.AUDIODELAYPLUS);
+                            syncAudioAheadAction.execute(hostManager.getConnection(), defaultStringActionCallback, callbackHandler);
+                        }
+                        break;
                     case 0:
                         Input.ExecuteAction syncAudioAction = new Input.ExecuteAction(Input.ExecuteAction.AUDIODELAY);
                         syncAudioAction.execute(hostManager.getConnection(), new ApiCallback<String>() {
@@ -469,6 +481,18 @@ public class NowPlayingFragment extends Fragment
                 Player.SetSubtitle setSubtitle;
                 // 0 is to download subtitles, 1 is for sync, 2 is for none, other is for a specific subtitle index
                 switch (which) {
+                    case -2:
+                        for(int i = 0; i < 5; i++) {
+                            Input.ExecuteAction syncSubtitleDelayAction = new Input.ExecuteAction(Input.ExecuteAction.SUBTITLEDELAYMINUS);
+                            syncSubtitleDelayAction.execute(hostManager.getConnection(), defaultStringActionCallback, callbackHandler);
+                        }
+                        break;
+                    case -1:
+                        for(int i = 0; i < 5; i++) {
+                            Input.ExecuteAction syncSubtitleAheadAction = new Input.ExecuteAction(Input.ExecuteAction.SUBTITLEDELAYPLUS);
+                            syncSubtitleAheadAction.execute(hostManager.getConnection(), defaultStringActionCallback, callbackHandler);
+                        }
+                        break;
                     case 0:
                         // Download subtitles. First check host version to see which method to call
                         Application.GetProperties getProperties = new Application.GetProperties(Application.GetProperties.VERSION);

--- a/app/src/main/java/org/xbmc/kore/ui/NowPlayingFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/NowPlayingFragment.java
@@ -402,7 +402,7 @@ public class NowPlayingFragment extends Fragment
                         }
 
                         GenericSelectDialog dialog = GenericSelectDialog.newInstance(NowPlayingFragment.this,
-                                SELECT_AUDIOSTREAM, getString(R.string.audiostreams), audiostreams, selectedItem);
+                                SELECT_AUDIOSTREAM, getString(R.string.audiostreams), audiostreams, selectedItem, "+0.125s >", "< -0.125s");
                         dialog.show(NowPlayingFragment.this.getFragmentManager(), null);
                     }
                     return true;
@@ -427,7 +427,7 @@ public class NowPlayingFragment extends Fragment
                     }
 
                     GenericSelectDialog dialog = GenericSelectDialog.newInstance(NowPlayingFragment.this,
-                            SELECT_SUBTITLES, getString(R.string.subtitles), subtitles, selectedItem);
+                            SELECT_SUBTITLES, getString(R.string.subtitles), subtitles, selectedItem, "+0.5s >", "< -0.5s");
                     dialog.show(NowPlayingFragment.this.getFragmentManager(), null);
                     return true;
             }
@@ -446,14 +446,10 @@ public class NowPlayingFragment extends Fragment
                 // 0 is to sync audio, other is for a specific audiostream
                 switch (which) {
                     case -2:
-                        for(int i = 0; i < 5; i++) {
-                            Input.ExecuteAction syncAudioDelayAction = new Input.ExecuteAction(Input.ExecuteAction.AUDIODELAYMINUS);
-                            syncAudioDelayAction.execute(hostManager.getConnection(), defaultStringActionCallback, callbackHandler);
-                        }
-                        break;
                     case -1:
+                        String action = (which == -2) ? Input.ExecuteAction.AUDIODELAYMINUS : Input.ExecuteAction.AUDIODELAYPLUS;
                         for(int i = 0; i < 5; i++) {
-                            Input.ExecuteAction syncAudioAheadAction = new Input.ExecuteAction(Input.ExecuteAction.AUDIODELAYPLUS);
+                            Input.ExecuteAction syncAudioAheadAction = new Input.ExecuteAction(action);
                             syncAudioAheadAction.execute(hostManager.getConnection(), defaultStringActionCallback, callbackHandler);
                         }
                         break;
@@ -482,14 +478,10 @@ public class NowPlayingFragment extends Fragment
                 // 0 is to download subtitles, 1 is for sync, 2 is for none, other is for a specific subtitle index
                 switch (which) {
                     case -2:
-                        for(int i = 0; i < 5; i++) {
-                            Input.ExecuteAction syncSubtitleDelayAction = new Input.ExecuteAction(Input.ExecuteAction.SUBTITLEDELAYMINUS);
-                            syncSubtitleDelayAction.execute(hostManager.getConnection(), defaultStringActionCallback, callbackHandler);
-                        }
-                        break;
                     case -1:
+                        String action = (which == -2) ? Input.ExecuteAction.SUBTITLEDELAYMINUS : Input.ExecuteAction.SUBTITLEDELAYPLUS;
                         for(int i = 0; i < 5; i++) {
-                            Input.ExecuteAction syncSubtitleAheadAction = new Input.ExecuteAction(Input.ExecuteAction.SUBTITLEDELAYPLUS);
+                            Input.ExecuteAction syncSubtitleAheadAction = new Input.ExecuteAction(action);
                             syncSubtitleAheadAction.execute(hostManager.getConnection(), defaultStringActionCallback, callbackHandler);
                         }
                         break;


### PR DESCRIPTION
Sometime when I have a wrong version of subtitles it often gets out of sync and there's no easy way to adjust it. Since I don't know how much to delay I have to do several trial and error sessions and each one takes clicking through a long series of menus.

I'm not sure what's the best solution here, so I'll describe what I did/want.

The current implementation opens the Kodi slider where you can offset by a small step (0.1s) and only see the results once you click ok.
My idea to fix it is to add 2 buttons (+/- delay) on the Kore's subtitles submenu that will allow to quickly adjust the subtitles by a more significant step and have immediate feedback (the finer control is still available).
I added +0.5s and -0.5s buttons using the dialog's ok/cancel buttons.
I still want to keep the dialog visible for further adjustments after clicking, but even without calling dismiss() explicitly it still disappear (why?).
