### PR TITLE
Fixed printing false message during gradle configuration phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ android:
 before_script:
 
 script: 
-  - ./gradlew assembleRelease
+  - ./gradlew assembleFullRelease

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -121,8 +121,10 @@ def adb = android.getAdbExe().toString()
 // Source: http://stackoverflow.com/q/29908110/112705
 afterEvaluate {
     task grantAnimationPermissionDev(type: Exec, dependsOn: 'installInstrumentationTestDebug') {
-        println("Executing: $adb shell pm grant $android.productFlavors.instrumentationTest.applicationId android.permission.SET_ANIMATION_SCALE")
-        commandLine "$adb shell pm grant $android.productFlavors.instrumentationTest.applicationId android.permission.SET_ANIMATION_SCALE".split(' ')
+        doFirst {
+            println("Executing: $adb shell pm grant $android.productFlavors.instrumentationTest.applicationId android.permission.SET_ANIMATION_SCALE")
+            commandLine "$adb shell pm grant $android.productFlavors.instrumentationTest.applicationId android.permission.SET_ANIMATION_SCALE".split(' ')
+        }
     }
 
     // When launching individual tests from Android Studio, it seems that only the assemble tasks


### PR DESCRIPTION
The println is invoked during gradle's configuration phase as well. During the configuration phase all projects are executed. This created some confusion, as it looked like the SET_ANIMATION_SCALE was granted for all flavors and not just the instrumentationTest flavor.

