### PR TITLE
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/TVShowEpisodeListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/TVShowEpisodeListFragment.java
@@ -482,9 +482,7 @@ public class TVShowEpisodeListFragment extends AbstractDetailsFragment
 
         @Override
         public View newGroupView(Context context, Cursor cursor, boolean isExpanded, ViewGroup parent) {
-            final View view = LayoutInflater.from(context)
-                                            .inflate(R.layout.list_item_season, parent, false);
-            return view;
+            return LayoutInflater.from(context).inflate(R.layout.list_item_season, parent, false);
         }
 
         @Override

--- a/app/src/main/java/org/xbmc/kore/ui/hosts/AddHostFragmentZeroconf.java
+++ b/app/src/main/java/org/xbmc/kore/ui/hosts/AddHostFragmentZeroconf.java
@@ -316,10 +316,7 @@ public class AddHostFragmentZeroconf extends Fragment {
                 (ConnectivityManager) getActivity().getSystemService(Context.CONNECTIVITY_SERVICE);
 
         NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
-        boolean isConnected = activeNetwork != null &&
-                activeNetwork.isConnectedOrConnecting();
-
-        return isConnected;
+        return activeNetwork != null && activeNetwork.isConnectedOrConnecting();
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1488
Please let me know if you have any questions.
George Kankava