### PR TITLE
squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/app/src/main/java/org/xbmc/kore/host/HostConnectionObserver.java
+++ b/app/src/main/java/org/xbmc/kore/host/HostConnectionObserver.java
@@ -135,7 +135,7 @@ public class HostConnectionObserver
         public void run() {
             final int HTTP_NOTIFICATION_CHECK_INTERVAL = 3000;
             // If no one is listening to this, just exit
-            if (playerEventsObservers.size() == 0) return;
+            if (playerEventsObservers.isEmpty()) return;
 
             // Check whats playing
             checkWhatsPlaying();
@@ -151,7 +151,7 @@ public class HostConnectionObserver
             final int PING_AFTER_ERROR_CHECK_INTERVAL = 2000,
                     PING_AFTER_SUCCESS_CHECK_INTERVAL = 10000;
             // If no one is listening to this, just exit
-            if (playerEventsObservers.size() == 0) return;
+            if (playerEventsObservers.isEmpty()) return;
 
             JSONRPC.Ping ping = new JSONRPC.Ping();
             ping.execute(connection, new ApiCallback<String>() {
@@ -232,7 +232,7 @@ public class HostConnectionObserver
         LogUtils.LOGD(TAG, "Unregistering observer. Still got " + playerEventsObservers.size() +
                            " observers.");
 
-        if (playerEventsObservers.size() == 0) {
+        if (playerEventsObservers.isEmpty()) {
             // No more observers, so unregister us from the host connection, or stop
             // the http checker thread
             if (connection.getProtocol() == HostConnection.PROTOCOL_TCP) {

--- a/app/src/main/java/org/xbmc/kore/host/HostManager.java
+++ b/app/src/main/java/org/xbmc/kore/host/HostManager.java
@@ -119,7 +119,7 @@ public class HostManager {
      * @return Host list
      */
 	public ArrayList<HostInfo> getHosts(boolean forcedReload) {
-        if (forcedReload || (hosts.size() == 0)) {
+        if (forcedReload || (hosts.isEmpty())) {
             hosts.clear();
 
             Cursor cursor = context.getContentResolver()
@@ -167,7 +167,7 @@ public class HostManager {
 
             // No host selected. Check if there are hosts configured and default to the first one
             if (currentHostId == -1) {
-                if (hosts.size() > 0) {
+                if (!hosts.isEmpty()) {
                     currentHostInfo = hosts.get(0);
                     currentHostId = currentHostInfo.getId();
                     prefs.edit()
@@ -424,7 +424,7 @@ public class HostManager {
         // If we just deleted the current connection, switch to another
         if ((currentHostInfo != null) && (currentHostInfo.getId() == hostId)) {
             releaseCurrentHost();
-            if (hosts.size() > 0)
+            if (!hosts.isEmpty())
                 switchHost(hosts.get(0));
         }
 	}

--- a/app/src/main/java/org/xbmc/kore/service/ConnectionObserversManagerService.java
+++ b/app/src/main/java/org/xbmc/kore/service/ConnectionObserversManagerService.java
@@ -65,7 +65,7 @@ public class ConnectionObserversManagerService extends Service
         createObservers();
 
         // If no observers created, stop immediately
-        if (mConnectionObservers.size() == 0) {
+        if (mConnectionObservers.isEmpty()) {
             LogUtils.LOGD(TAG, "No observers, stopping observer service.");
             stopSelf();
         }

--- a/app/src/main/java/org/xbmc/kore/service/library/SyncMovies.java
+++ b/app/src/main/java/org/xbmc/kore/service/library/SyncMovies.java
@@ -153,7 +153,7 @@ public class SyncMovies extends SyncItem {
                     // First call, delete movies from DB
                     deleteMovies(contentResolver, hostId, -1);
                 }
-                if (result.size() > 0) {
+                if (!result.isEmpty()) {
                     insertMovies(orchestrator, contentResolver, result);
                 }
 

--- a/app/src/main/java/org/xbmc/kore/ui/AlbumDetailsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AlbumDetailsFragment.java
@@ -339,7 +339,7 @@ public class AlbumDetailsFragment extends AbstractDetailsFragment
     @Override
     protected void onDownload() {
         if ((albumTitle == null) || (albumDisplayArtist == null) ||
-            (songInfoList == null) || (songInfoList.size() == 0)) {
+            (songInfoList == null) || (songInfoList.isEmpty())) {
             // Nothing to download
             Toast.makeText(getActivity(), R.string.no_files_to_download, Toast.LENGTH_SHORT).show();
             return;
@@ -676,7 +676,7 @@ public class AlbumDetailsFragment extends AbstractDetailsFragment
                 songListView.addView(songView);
             } while (cursor.moveToNext());
 
-            if (songInfoList.size() > 0) {
+            if (!songInfoList.isEmpty()) {
                 // Check if download dir exists
                 FileDownloadHelper.SongInfo songInfo = new FileDownloadHelper.SongInfo
                         (albumDisplayArtist, albumTitle, 0, 0, null, null);

--- a/app/src/main/java/org/xbmc/kore/ui/MediaFileListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/MediaFileListFragment.java
@@ -367,7 +367,7 @@ public class MediaFileListFragment extends AbstractListFragment {
         action.execute(hostManager.getConnection(), new ApiCallback<String>() {
             @Override
             public void onSuccess(String result) {
-                while (mediaQueueFileLocation.size() > 0) {
+                while (!mediaQueueFileLocation.isEmpty()) {
                     queueMediaFile(mediaQueueFileLocation.poll().file);
                 }
             }

--- a/app/src/main/java/org/xbmc/kore/ui/PlaylistFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/PlaylistFragment.java
@@ -340,7 +340,7 @@ public class PlaylistFragment extends Fragment
 
     private void displayPlaylist(final ListType.ItemsAll getItemResult,
                                  final List<ListType.ItemsAll> playlistItems) {
-        if (playlistItems.size() == 0) {
+        if (playlistItems.isEmpty()) {
             displayEmptyPlaylistMessage();
             return;
         }

--- a/app/src/main/java/org/xbmc/kore/utils/FileDownloadHelper.java
+++ b/app/src/main/java/org/xbmc/kore/utils/FileDownloadHelper.java
@@ -295,7 +295,7 @@ public class FileDownloadHelper {
                                     final List<? extends MediaInfo> mediaInfoList,
                                     final int fileHandlingMode,
                                     final Handler callbackHandler) {
-        if ((mediaInfoList == null) || (mediaInfoList.size() == 0))
+        if ((mediaInfoList == null) || (mediaInfoList.isEmpty()))
             return;
 
         if (!checkDownloadDir(context, mediaInfoList.get(0).getAbsoluteDirectoryPath()))


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
George Kankava