### PR TITLE
squid:S1125 - Literal boolean values should not be used in condition expressions

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/MediaFileListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/MediaFileListFragment.java
@@ -217,7 +217,7 @@ public class MediaFileListFragment extends AbstractListFragment {
             return true;
         else
             // if we still see "..", it is not the real root directory
-            return fl.isRootDir() && (fl.title.contentEquals("..") == false);
+            return fl.isRootDir() && !fl.title.contentEquals("..");
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1125 - Literal boolean values should not be used in condition expressions.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1125
Please let me know if you have any questions.
George Kankava