### PR TITLE
squid:S1197 -  Array designators [] should be on the type, not the variable

### DIFF
--- a/app/src/androidTest/java/org/xbmc/kore/testhelpers/Database.java
+++ b/app/src/androidTest/java/org/xbmc/kore/testhelpers/Database.java
@@ -70,7 +70,7 @@ public class Database {
         ArrayList<VideoType.DetailsMovie> movieList = (ArrayList) getMovies.resultFromJson(result);
 
 
-        ContentValues movieValuesBatch[] = new ContentValues[movieList.size()];
+        ContentValues[] movieValuesBatch = new ContentValues[movieList.size()];
         int castCount = 0;
 
         // Iterate on each movie
@@ -82,7 +82,7 @@ public class Database {
 
         context.getContentResolver().bulkInsert(MediaContract.Movies.CONTENT_URI, movieValuesBatch);
 
-        ContentValues movieCastValuesBatch[] = new ContentValues[castCount];
+        ContentValues[] movieCastValuesBatch = new ContentValues[castCount];
         int count = 0;
         // Iterate on each movie/cast
         for (VideoType.DetailsMovie movie : movieList) {
@@ -101,7 +101,7 @@ public class Database {
         String result = Utils.readFile(context, "AudioLibrary.GetArtists.json");
         ArrayList<AudioType.DetailsArtist> artistList = (ArrayList) getArtists.resultFromJson(result).items;
 
-        ContentValues artistValuesBatch[] = new ContentValues[artistList.size()];
+        ContentValues[] artistValuesBatch = new ContentValues[artistList.size()];
         for (int i = 0; i < artistList.size(); i++) {
             AudioType.DetailsArtist artist = artistList.get(i);
             artistValuesBatch[i] = SyncUtils.contentValuesFromArtist(hostId, artist);
@@ -114,7 +114,7 @@ public class Database {
         AudioLibrary.GetGenres getGenres = new AudioLibrary.GetGenres();
         ArrayList<LibraryType.DetailsGenre> genreList = (ArrayList) getGenres.resultFromJson(Utils.readFile(context, "AudioLibrary.GetGenres.json"));
 
-        ContentValues genresValuesBatch[] = new ContentValues[genreList.size()];
+        ContentValues[] genresValuesBatch = new ContentValues[genreList.size()];
         for (int i = 0; i < genreList.size(); i++) {
             LibraryType.DetailsGenre genre = genreList.get(i);
             genresValuesBatch[i] = SyncUtils.contentValuesFromAudioGenre(hostId, genre);
@@ -130,7 +130,7 @@ public class Database {
 
         ContentResolver contentResolver = context.getContentResolver();
 
-        ContentValues albumValuesBatch[] = new ContentValues[albumList.size()];
+        ContentValues[] albumValuesBatch = new ContentValues[albumList.size()];
         int artistsCount = 0, genresCount = 0;
         for (int i = 0; i < albumList.size(); i++) {
             AudioType.DetailsAlbum album = albumList.get(i);
@@ -142,8 +142,8 @@ public class Database {
         contentResolver.bulkInsert(MediaContract.Albums.CONTENT_URI, albumValuesBatch);
 
         // Iterate on each album, collect the artists and the genres and insert them
-        ContentValues albumArtistsValuesBatch[] = new ContentValues[artistsCount];
-        ContentValues albumGenresValuesBatch[] = new ContentValues[genresCount];
+        ContentValues[] albumArtistsValuesBatch = new ContentValues[artistsCount];
+        ContentValues[] albumGenresValuesBatch = new ContentValues[genresCount];
         int artistCount = 0, genreCount = 0;
         for (AudioType.DetailsAlbum album : albumList) {
             for (int artistId : album.artistid) {
@@ -171,7 +171,7 @@ public class Database {
         AudioLibrary.GetSongs getSongs = new AudioLibrary.GetSongs();
         ArrayList<AudioType.DetailsSong> songList = (ArrayList) getSongs.resultFromJson(Utils.readFile(context, "AudioLibrary.GetSongs.json")).items;
 
-        ContentValues songValuesBatch[] = new ContentValues[songList.size()];
+        ContentValues[] songValuesBatch = new ContentValues[songList.size()];
         for (int i = 0; i < songList.size(); i++) {
             AudioType.DetailsSong song = songList.get(i);
             songValuesBatch[i] = SyncUtils.contentValuesFromSong(hostId, song);

--- a/app/src/main/java/org/xbmc/kore/host/HostConnectionObserver.java
+++ b/app/src/main/java/org/xbmc/kore/host/HostConnectionObserver.java
@@ -372,7 +372,7 @@ public class HostConnectionObserver
      * On success chains execution to chainCallGetItem
      */
     private void chainCallGetProperties(final PlayerType.GetActivePlayersReturnType getActivePlayersResult) {
-        String propertiesToGet[] = new String[] {
+        String[] propertiesToGet = new String[] {
                 // Check is something more is needed
                 PlayerType.PropertyName.SPEED,
                 PlayerType.PropertyName.PERCENTAGE,

--- a/app/src/main/java/org/xbmc/kore/service/library/SyncMovies.java
+++ b/app/src/main/java/org/xbmc/kore/service/library/SyncMovies.java
@@ -84,7 +84,7 @@ public class SyncMovies extends SyncItem {
                      final HostConnection hostConnection,
                      final Handler callbackHandler,
                      final ContentResolver contentResolver) {
-        String properties[] = {
+        String[] properties = {
                 VideoType.FieldsMovie.TITLE, VideoType.FieldsMovie.GENRE,
                 VideoType.FieldsMovie.YEAR, VideoType.FieldsMovie.RATING,
                 VideoType.FieldsMovie.DIRECTOR, VideoType.FieldsMovie.TRAILER,
@@ -141,7 +141,7 @@ public class SyncMovies extends SyncItem {
                                final HostConnection hostConnection,
                                final Handler callbackHandler,
                                final ContentResolver contentResolver,
-                               final String properties[],
+                               final String[] properties,
                                final int startIdx) {
         // Call GetMovies with the current limits set
         ListType.Limits limits = new ListType.Limits(startIdx, startIdx + LIMIT_SYNC_MOVIES);
@@ -209,7 +209,7 @@ public class SyncMovies extends SyncItem {
     private void insertMovies(final SyncOrchestrator orchestrator,
                               final ContentResolver contentResolver,
                               final List<VideoType.DetailsMovie> movies) {
-        ContentValues movieValuesBatch[] = new ContentValues[movies.size()];
+        ContentValues[] movieValuesBatch = new ContentValues[movies.size()];
         int castCount = 0;
 
         // Iterate on each movie
@@ -222,7 +222,7 @@ public class SyncMovies extends SyncItem {
         // Insert the movies
         contentResolver.bulkInsert(MediaContract.Movies.CONTENT_URI, movieValuesBatch);
 
-        ContentValues movieCastValuesBatch[] = new ContentValues[castCount];
+        ContentValues[] movieCastValuesBatch = new ContentValues[castCount];
         int count = 0;
         // Iterate on each movie/cast
         for (VideoType.DetailsMovie movie : movies) {

--- a/app/src/main/java/org/xbmc/kore/service/library/SyncMusic.java
+++ b/app/src/main/java/org/xbmc/kore/service/library/SyncMusic.java
@@ -74,7 +74,7 @@ public class SyncMusic extends SyncItem {
         chainCallSyncArtists(orchestrator, hostConnection, callbackHandler, contentResolver, 0);
     }
 
-    private final static String getArtistsProperties[] = {
+    private final static String[] getArtistsProperties = {
             // AudioType.FieldsArtists.INSTRUMENT, AudioType.FieldsArtists.STYLE,
             // AudioType.FieldsArtists.MOOD, AudioType.FieldsArtists.BORN,
             // AudioType.FieldsArtists.FORMED,
@@ -116,7 +116,7 @@ public class SyncMusic extends SyncItem {
                 if (startIdx == 0) deleteMusicInfo(contentResolver, hostId);
 
                 // Insert artists
-                ContentValues artistValuesBatch[] = new ContentValues[items.size()];
+                ContentValues[] artistValuesBatch = new ContentValues[items.size()];
                 for (int i = 0; i < items.size(); i++) {
                     AudioType.DetailsArtist artist = items.get(i);
                     artistValuesBatch[i] = SyncUtils.contentValuesFromArtist(hostId, artist);
@@ -162,7 +162,7 @@ public class SyncMusic extends SyncItem {
     }
 
 
-    private final static String getGenresProperties[] = {
+    private final static String[] getGenresProperties = {
             LibraryType.FieldsGenre.TITLE, LibraryType.FieldsGenre.THUMBNAIL
     };
     /**
@@ -179,7 +179,7 @@ public class SyncMusic extends SyncItem {
             @Override
             public void onSuccess(List<LibraryType.DetailsGenre> result) {
                 if (result == null) result = new ArrayList<>(0); // Safeguard
-                ContentValues genresValuesBatch[] = new ContentValues[result.size()];
+                ContentValues[] genresValuesBatch = new ContentValues[result.size()];
 
                 for (int i = 0; i < result.size(); i++) {
                     LibraryType.DetailsGenre genre = result.get(i);
@@ -199,7 +199,7 @@ public class SyncMusic extends SyncItem {
         }, callbackHandler);
     }
 
-    private static final String getAlbumsProperties[] = {
+    private static final String[] getAlbumsProperties = {
             AudioType.FieldsAlbum.TITLE, AudioType.FieldsAlbum.DESCRIPTION,
             AudioType.FieldsAlbum.ARTIST, AudioType.FieldsAlbum.GENRE,
             //AudioType.FieldsAlbum.THEME, AudioType.FieldsAlbum.MOOD,
@@ -240,7 +240,7 @@ public class SyncMusic extends SyncItem {
                 }
 
                 // Insert the partial results
-                ContentValues albumValuesBatch[] = new ContentValues[items.size()];
+                ContentValues[] albumValuesBatch = new ContentValues[items.size()];
                 int artistsCount = 0, genresCount = 0;
                 for (int i = 0; i < items.size(); i++) {
                     AudioType.DetailsAlbum album = items.get(i);
@@ -255,8 +255,8 @@ public class SyncMusic extends SyncItem {
                                    (System.currentTimeMillis() - albumSyncStartTime));
 
                 // Iterate on each album, collect the artists and the genres and insert them
-                ContentValues albumArtistsValuesBatch[] = new ContentValues[artistsCount];
-                ContentValues albumGenresValuesBatch[] = new ContentValues[genresCount];
+                ContentValues[] albumArtistsValuesBatch = new ContentValues[artistsCount];
+                ContentValues[] albumGenresValuesBatch = new ContentValues[genresCount];
                 int artistCount = 0, genreCount = 0;
                 for (AudioType.DetailsAlbum album : items) {
                     for (int artistId : album.artistid) {
@@ -302,7 +302,7 @@ public class SyncMusic extends SyncItem {
         }, callbackHandler);
     }
 
-    private static final String getSongsProperties[] = {
+    private static final String[] getSongsProperties = {
             AudioType.FieldsSong.TITLE,
             //AudioType.FieldsSong.ARTIST, AudioType.FieldsSong.ALBUMARTIST, AudioType.FieldsSong.GENRE,
             //AudioType.FieldsSong.YEAR, AudioType.FieldsSong.RATING,
@@ -346,7 +346,7 @@ public class SyncMusic extends SyncItem {
                 }
 
                 // Save partial results to DB
-                ContentValues songValuesBatch[] = new ContentValues[items.size()];
+                ContentValues[] songValuesBatch = new ContentValues[items.size()];
                 for (int i = 0; i < items.size(); i++) {
                     AudioType.DetailsSong song = items.get(i);
                     songValuesBatch[i] = SyncUtils.contentValuesFromSong(hostId, song);

--- a/app/src/main/java/org/xbmc/kore/service/library/SyncMusicVideos.java
+++ b/app/src/main/java/org/xbmc/kore/service/library/SyncMusicVideos.java
@@ -65,7 +65,7 @@ public class SyncMusicVideos extends SyncItem {
                      final HostConnection hostConnection,
                      final Handler callbackHandler,
                      final ContentResolver contentResolver) {
-        String properties[] = {
+        String[] properties = {
                 VideoType.FieldsMusicVideo.TITLE, VideoType.FieldsMusicVideo.PLAYCOUNT,
                 VideoType.FieldsMusicVideo.RUNTIME, VideoType.FieldsMusicVideo.DIRECTOR,
                 VideoType.FieldsMusicVideo.STUDIO, VideoType.FieldsMusicVideo.YEAR,
@@ -107,7 +107,7 @@ public class SyncMusicVideos extends SyncItem {
     private void insertMusicVideos(final SyncOrchestrator orchestrator,
                                    final ContentResolver contentResolver,
                                    final List<VideoType.DetailsMusicVideo> musicVideos) {
-        ContentValues musicVideosValuesBatch[] = new ContentValues[musicVideos.size()];
+        ContentValues[] musicVideosValuesBatch = new ContentValues[musicVideos.size()];
 
         // Iterate on each music video
         for (int i = 0; i < musicVideos.size(); i++) {

--- a/app/src/main/java/org/xbmc/kore/service/library/SyncTVShows.java
+++ b/app/src/main/java/org/xbmc/kore/service/library/SyncTVShows.java
@@ -81,7 +81,7 @@ public class SyncTVShows extends SyncItem {
         return syncExtras;
     }
 
-    private final static String getTVShowsProperties[] = {
+    private final static String[] getTVShowsProperties = {
             VideoType.FieldsTVShow.TITLE, VideoType.FieldsTVShow.GENRE,
             //VideoType.FieldsTVShow.YEAR,
             VideoType.FieldsTVShow.RATING, VideoType.FieldsTVShow.PLOT,
@@ -201,7 +201,7 @@ public class SyncTVShows extends SyncItem {
                                             final Handler callbackHandler,
                                             final ContentResolver contentResolver,
                                             List<VideoType.DetailsTVShow> tvShows) {
-        ContentValues tvshowsValuesBatch[] = new ContentValues[tvShows.size()];
+        ContentValues[] tvshowsValuesBatch = new ContentValues[tvShows.size()];
         int castCount = 0;
 
         // Iterate on each show
@@ -214,7 +214,7 @@ public class SyncTVShows extends SyncItem {
         contentResolver.bulkInsert(MediaContract.TVShows.CONTENT_URI, tvshowsValuesBatch);
         LogUtils.LOGD(TAG, "Inserted " + tvShows.size() + " tv shows.");
 
-        ContentValues tvshowsCastValuesBatch[] = new ContentValues[castCount];
+        ContentValues[] tvshowsCastValuesBatch = new ContentValues[castCount];
         int count = 0;
         // Iterate on each show/cast
         for (VideoType.DetailsTVShow tvshow : tvShows) {
@@ -232,7 +232,7 @@ public class SyncTVShows extends SyncItem {
                          contentResolver, tvShows, 0);
     }
 
-    private final static String seasonsProperties[] = {
+    private final static String[] seasonsProperties = {
             VideoType.FieldsSeason.SEASON, VideoType.FieldsSeason.SHOWTITLE,
             //VideoType.FieldsSeason.PLAYCOUNT,
             VideoType.FieldsSeason.EPISODE,
@@ -269,7 +269,7 @@ public class SyncTVShows extends SyncItem {
             action.execute(hostConnection, new ApiCallback<List<VideoType.DetailsSeason>>() {
                 @Override
                 public void onSuccess(List<VideoType.DetailsSeason> result) {
-                    ContentValues seasonsValuesBatch[] = new ContentValues[result.size()];
+                    ContentValues[] seasonsValuesBatch = new ContentValues[result.size()];
                     int totalWatchedEpisodes = 0;
                     for (int i = 0; i < result.size(); i++) {
                         VideoType.DetailsSeason season = result.get(i);
@@ -309,7 +309,7 @@ public class SyncTVShows extends SyncItem {
         }
     }
 
-    private final static String getEpisodesProperties[] = {
+    private final static String[] getEpisodesProperties = {
             VideoType.FieldsEpisode.TITLE, VideoType.FieldsEpisode.PLOT,
             //VideoType.FieldsEpisode.VOTES,
             VideoType.FieldsEpisode.RATING,
@@ -357,7 +357,7 @@ public class SyncTVShows extends SyncItem {
             action.execute(hostConnection, new ApiCallback<List<VideoType.DetailsEpisode>>() {
                 @Override
                 public void onSuccess(List<VideoType.DetailsEpisode> result) {
-                    ContentValues episodesValuesBatch[] = new ContentValues[result.size()];
+                    ContentValues[] episodesValuesBatch = new ContentValues[result.size()];
                     for (int i = 0; i < result.size(); i++) {
                         VideoType.DetailsEpisode episode = result.get(i);
                         episodesValuesBatch[i] = SyncUtils.contentValuesFromEpisode(hostId, episode);

--- a/app/src/main/java/org/xbmc/kore/ui/AbstractDetailsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractDetailsFragment.java
@@ -197,7 +197,7 @@ abstract public class AbstractDetailsFragment extends Fragment
     }
 
     @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[], @NonNull int[] grantResults) {
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         switch (requestCode) {
             case Utils.PERMISSION_REQUEST_WRITE_STORAGE:
                 // If request is cancelled, the result arrays are empty.

--- a/app/src/main/java/org/xbmc/kore/ui/AlbumListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AlbumListFragment.java
@@ -120,7 +120,7 @@ public class AlbumListFragment extends AbstractCursorListFragment {
         }
 
         String selection = null;
-        String selectionArgs[] = null;
+        String[] selectionArgs = null;
         String searchFilter = getSearchFilter();
         if (!TextUtils.isEmpty(searchFilter)) {
             selection = MediaContract.Albums.TITLE + " LIKE ?";

--- a/app/src/main/java/org/xbmc/kore/ui/ArtistListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/ArtistListFragment.java
@@ -80,7 +80,7 @@ public class ArtistListFragment extends AbstractCursorListFragment {
         Uri uri = MediaContract.Artists.buildArtistsListUri(hostInfo != null ? hostInfo.getId() : -1);
 
         String selection = null;
-        String selectionArgs[] = null;
+        String[] selectionArgs = null;
         String searchFilter = getSearchFilter();
         if (!TextUtils.isEmpty(searchFilter)) {
             selection = MediaContract.ArtistsColumns.ARTIST + " LIKE ?";

--- a/app/src/main/java/org/xbmc/kore/ui/AudioGenresListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AudioGenresListFragment.java
@@ -77,7 +77,7 @@ public class AudioGenresListFragment extends AbstractCursorListFragment {
         Uri uri = MediaContract.AudioGenres.buildAudioGenresListUri(hostInfo != null ? hostInfo.getId() : -1);
 
         String selection = null;
-        String selectionArgs[] = null;
+        String[] selectionArgs = null;
         String searchFilter = getSearchFilter();
         if (!TextUtils.isEmpty(searchFilter)) {
             selection = MediaContract.AudioGenres.TITLE + " LIKE ?";

--- a/app/src/main/java/org/xbmc/kore/ui/MovieListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/MovieListFragment.java
@@ -82,7 +82,7 @@ public class MovieListFragment extends AbstractCursorListFragment {
         Uri uri = MediaContract.Movies.buildMoviesListUri(hostInfo != null? hostInfo.getId() : -1);
 
         StringBuilder selection = new StringBuilder();
-        String selectionArgs[] = null;
+        String[] selectionArgs = null;
         String searchFilter = getSearchFilter();
         if (!TextUtils.isEmpty(searchFilter)) {
             selection.append(MediaContract.MoviesColumns.TITLE + " LIKE ?");

--- a/app/src/main/java/org/xbmc/kore/ui/MusicVideoListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/MusicVideoListFragment.java
@@ -76,7 +76,7 @@ public class MusicVideoListFragment extends AbstractCursorListFragment {
         Uri uri = MediaContract.MusicVideos.buildMusicVideosListUri(hostInfo != null ? hostInfo.getId() : -1);
 
         String selection = null;
-        String selectionArgs[] = null;
+        String[] selectionArgs = null;
         String searchFilter = getSearchFilter();
         if (!TextUtils.isEmpty(searchFilter)) {
             selection = MediaContract.MusicVideosColumns.TITLE + " LIKE ?";

--- a/app/src/main/java/org/xbmc/kore/ui/SettingsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/SettingsFragment.java
@@ -141,7 +141,7 @@ public class SettingsFragment extends PreferenceFragment
     }
 
     @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[], @NonNull int[] grantResults) {
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         switch (requestCode) {
             case Utils.PERMISSION_REQUEST_READ_PHONE_STATE:
                 // If request is cancelled, the result arrays are empty.

--- a/app/src/main/java/org/xbmc/kore/ui/SongsListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/SongsListFragment.java
@@ -86,7 +86,7 @@ public class SongsListFragment extends AbstractCursorListFragment {
         }
 
         String selection = null;
-        String selectionArgs[] = null;
+        String[] selectionArgs = null;
         String searchFilter = getSearchFilter();
         if (!TextUtils.isEmpty(searchFilter)) {
             selection = MediaDatabase.Tables.SONGS + "." + MediaContract.Songs.TITLE + " LIKE ?";

--- a/app/src/main/java/org/xbmc/kore/ui/TVShowListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/TVShowListFragment.java
@@ -82,7 +82,7 @@ public class TVShowListFragment extends AbstractCursorListFragment {
         Uri uri = MediaContract.TVShows.buildTVShowsListUri(hostInfo != null ? hostInfo.getId() : -1);
 
         StringBuilder selection = new StringBuilder();
-        String selectionArgs[] = null;
+        String[] selectionArgs = null;
         String searchFilter = getSearchFilter();
         if (!TextUtils.isEmpty(searchFilter)) {
             selection.append(MediaContract.TVShowsColumns.TITLE + " LIKE ?");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1197 -  Array designators [] should be on the type, not the variable.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1197
Please let me know if you have any questions.
George Kankava