### PR TITLE
Fixed Toolbar height small for sdk version < Android Llollipop

### DIFF
--- a/app/src/main/res/layout/toolbar_default.xml
+++ b/app/src/main/res/layout/toolbar_default.xml
@@ -19,7 +19,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/default_toolbar"
-    android:layout_height="?android:attr/actionBarSize"
+    android:layout_height="?attr/actionBarSize"
     android:layout_width="match_parent"
     android:theme="?attr/actionBarTheme"
     app:popupTheme="?attr/actionBarPopupTheme"


### PR DESCRIPTION
Fixes #264 

The Toolbar (if not extended) has the height of:
- 56dp (default)
- 48dp (landscape)
- 64dp (sw600dp; i.e. tablet)

The ActionBar pre-lollipop has a height of:
 - 48dp (default)
 - 40dp (landscape)
 - 56dp (sw600dp; i.e. tablet)