### PR TITLE
Support playback of shared plain http-video urls

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/RemoteActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/RemoteActivity.java
@@ -386,16 +386,17 @@ public class RemoteActivity extends BaseActivity
         }
 
         final String videoId = getVideoId(videoUri);
-        if (videoId == null) {
-            Toast.makeText(RemoteActivity.this,
-                    R.string.error_share_video,
-                    Toast.LENGTH_SHORT).show();
-            return;
-        }
-
-        final String kodiAddonUrl = "plugin://plugin.video." +
+        String videoUrl;
+        if (videoId != null) {
+            videoUrl = "plugin://plugin.video." +
                 (videoUri.getHost().endsWith("vimeo.com") ? "vimeo" : "youtube") +
                 "/play/?video_id=" + videoId;
+
+        } else {
+            videoUrl = videoUri.toString();
+        }
+
+        final String fvideoUrl = videoUrl;
 
         // Check if any video player is active and clear the playlist before queuing if so
         final HostConnection connection = hostManager.getConnection();
@@ -413,9 +414,9 @@ public class RemoteActivity extends BaseActivity
 
                 if (!videoIsPlaying) {
                     // Clear the playlist
-                    clearPlaylistAndQueueFile(kodiAddonUrl, connection, callbackHandler);
+                    clearPlaylistAndQueueFile(fvideoUrl, connection, callbackHandler);
                 } else {
-                    queueFile(kodiAddonUrl, false, connection, callbackHandler);
+                    queueFile(fvideoUrl, false, connection, callbackHandler);
                 }
             }
 


### PR DESCRIPTION
Currently Kore does only support the playback of youtube and vimeo video
urls when invoked via the "Play with Kodi" share menu.

This commit adds support for plain video urls in the most straightforward way
possible.
The fix is rather minimal (actually it more seems like removing an artificial limitation?),
but I would be happy to adapt the patch based on any feedback provided :)