### PR TITLE
Local play: Support in-device video playing as 2nd screen

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/MovieDetailsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/MovieDetailsFragment.java
@@ -436,17 +436,10 @@ public class MovieDetailsFragment extends AbstractDetailsFragment
             return;
         }
 
-        HostInfo hostinfo = getHostInfo();
-        String pathforUrl = movieDownloadInfo.fileName.replaceAll(" ", "%20").replaceAll("'","%27");
-        String videoUrl = String.format("http://%s:%d/vfs/%s", hostinfo.getAddress(),
-                    hostinfo.getHttpPort(), pathforUrl);
-
+        String videoUrl =  movieDownloadInfo.getMediaUrl(getHostInfo());
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(videoUrl));
         intent.setDataAndType(Uri.parse(videoUrl), "video/*");
         startActivity(intent);
-
-
-
     }
 
     @Override

--- a/app/src/main/java/org/xbmc/kore/ui/MovieDetailsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/MovieDetailsFragment.java
@@ -18,6 +18,7 @@ package org.xbmc.kore.ui;
 import android.annotation.TargetApi;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.database.Cursor;
@@ -48,6 +49,7 @@ import com.melnykov.fab.ObservableScrollView;
 
 import org.xbmc.kore.R;
 import org.xbmc.kore.Settings;
+import org.xbmc.kore.host.HostInfo;
 import org.xbmc.kore.jsonrpc.ApiCallback;
 import org.xbmc.kore.jsonrpc.event.MediaSyncEvent;
 import org.xbmc.kore.jsonrpc.method.Player;
@@ -114,6 +116,7 @@ public class MovieDetailsFragment extends AbstractDetailsFragment
     @InjectView(R.id.go_to_imdb) ImageButton imdbButton;
     @InjectView(R.id.download) ImageButton downloadButton;
     @InjectView(R.id.seen) ImageButton seenButton;
+    @InjectView(R.id.local_play) ImageButton localPlayButton;
 
     // Detail views
     @InjectView(R.id.media_panel) ScrollView mediaPanel;
@@ -423,6 +426,27 @@ public class MovieDetailsFragment extends AbstractDetailsFragment
         // Change the button, to provide imeddiate feedback, even if it isn't yet stored in the db
         // (will be properly updated and refreshed after the refresh callback ends)
         setupSeenButton(newPlaycount);
+    }
+
+    @OnClick(R.id.local_play)
+    public void onLocalPlayClicked(View v) {
+        if (movieDownloadInfo == null) {
+            // Nothing to play on local
+            Toast.makeText(getActivity(), R.string.no_files_to_play, Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        HostInfo hostinfo = getHostInfo();
+        String pathforUrl = movieDownloadInfo.fileName.replaceAll(" ", "%20").replaceAll("'","%27");
+        String videoUrl = String.format("http://%s:%d/vfs/%s", hostinfo.getAddress(),
+                    hostinfo.getHttpPort(), pathforUrl);
+
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(videoUrl));
+        intent.setDataAndType(Uri.parse(videoUrl), "video/*");
+        startActivity(intent);
+
+
+
     }
 
     @Override

--- a/app/src/main/java/org/xbmc/kore/utils/FileDownloadHelper.java
+++ b/app/src/main/java/org/xbmc/kore/utils/FileDownloadHelper.java
@@ -100,6 +100,13 @@ public class FileDownloadHelper {
         public String getDownloadDescrition(Context context) {
             return context.getString(R.string.download_file_description);
         }
+
+        public String getMediaUrl(HostInfo hostInfo) {
+            String pathforUrl = fileName.replaceAll(" ", "%20").replaceAll("'","%27");
+            String videoUrl = String.format("http://%s:%d/vfs/%s", hostInfo.getAddress(),
+                    hostInfo.getHttpPort(), pathforUrl);
+            return videoUrl;
+        }
     }
 
     /**

--- a/app/src/main/res/layout/fragment_movie_details.xml
+++ b/app/src/main/res/layout/fragment_movie_details.xml
@@ -138,6 +138,14 @@
                         style="@style/Widget.Button.Borderless"
                         android:src="?attr/iconSeen"
                         android:contentDescription="@string/seen"/>
+                    <ImageButton
+                        android:id="@+id/local_play"
+                        android:layout_width="@dimen/buttonbar_button_width"
+                        android:layout_height="match_parent"
+                        style="@style/Widget.Button.Borderless"
+                        android:src="?attr/iconPlay"
+                        android:contentDescription="LocalPlay"/>
+
                 </LinearLayout>
 
                 <RelativeLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -295,6 +295,7 @@
     <string name="music_videos">Videos</string>
 
     <string name="no_files_to_download">No files to download.</string>
+    <string name="no_files_to_play">No files to play.</string>
     <string name="error_getting_file_information">Couldn\'t get information to download file %1$s.</string>
 
     <string name="author">Author:</string>


### PR DESCRIPTION
# Feature
1. Add a new play button in Movie detail view.
2. When user click the button, if the video is accessible , a video playing intent is initiated. 
   A list of other in-device video player apps pops up, then user can choose one of them to play video.
# Comment
1. A different button may be needed to give user cue that it's playing in-device instead of the Kodi  host.
2. The same feature will be implemented for TV Show later.
