### PR TITLE
change "title" from itemFile.title to itemFile.label

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/MediaFileListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/MediaFileListFragment.java
@@ -712,7 +712,7 @@ public class MediaFileListFragment extends AbstractListFragment {
                     break;
                 case ListType.ItemBase.TYPE_ALBUM:
                 case ListType.ItemBase.TYPE_SONG:
-                    title = itemFile.title;
+                    title = itemFile.label;
                     details = itemFile.displayartist + " | " + itemFile.album;
                     artUrl = itemFile.thumbnail;
                     sizeDuration = (itemFile.size > 0) && (itemFile.duration > 0) ?


### PR DESCRIPTION
change "title" from itemFile.title to itemFile.label for TYPE_ALBUM and TYPE_SONG.

This fixes the View of some Addons for me (for example the Shoutcast2 addon, where only current playing tracks were displayed instead of the Station name).
It also aligns with ListType.Sort.SORT_METHOD_LABEL.