### PR TITLE
Fixed retrieving wrong handler for applicationNotificationsObserver

### DIFF
--- a/app/src/main/java/org/xbmc/kore/host/HostConnectionObserver.java
+++ b/app/src/main/java/org/xbmc/kore/host/HostConnectionObserver.java
@@ -326,7 +326,7 @@ public class HostConnectionObserver
      * Unregisters a previously registered observer
      * @param observer Observer to unregister
      */
-    public void unregisterApplicationObserver(PlayerEventsObserver observer) {
+    public void unregisterApplicationObserver(ApplicationEventsObserver observer) {
         applicationEventsObservers.remove(observer);
 
         LogUtils.LOGD(TAG, "Unregistering application observer " + observer.getClass().getSimpleName() +

--- a/app/src/main/java/org/xbmc/kore/jsonrpc/HostConnection.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/HostConnection.java
@@ -847,7 +847,7 @@ public class HostConnection {
                         new Application.OnVolumeChanged(params);
                 for (final ApplicationNotificationsObserver observer :
                         applicationNotificationsObservers.keySet()) {
-                    Handler handler = inputNotificationsObservers.get(observer);
+                    Handler handler = applicationNotificationsObservers.get(observer);
                     handler.post(new Runnable() {
                         @Override
                         public void run() {


### PR DESCRIPTION
Working on unittests I noticed a sincere bug introduced in PR #312. This currently does not cause any issues but probably will in the future.