### PR TITLE
Implemented showing mute state in action bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Credits
 - [PagerSlidingTabStrip](https://github.com/astuetz/PagerSlidingTabStrip)
 - [FloatingActionButton](https://github.com/makovkastar/FloatingActionButton)
 - [ExpandableTextView](https://github.com/Blogcat/Android-ExpandableTextView)
+- [AndroidSlidingUpPanel](https://github.com/umano/AndroidSlidingUpPanel)
 
 Links
 -----

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -125,6 +125,7 @@ dependencies {
     compile 'com.astuetz:pagerslidingtabstrip:1.0.1'
     compile 'com.melnykov:floatingactionbutton:1.3.0'
     compile 'at.blogc:expandabletextview:1.0.3'
+    compile 'com.sothree.slidinguppanel:library:3.3.1'
 
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'

--- a/app/src/main/java/org/xbmc/kore/Settings.java
+++ b/app/src/main/java/org/xbmc/kore/Settings.java
@@ -77,6 +77,10 @@ public class Settings {
     public static final String KEY_PREF_SHOW_NOTIFICATION = "pref_show_notification";
     public static final boolean DEFAULT_PREF_SHOW_NOTIFICATION = false;
 
+    // Show now playing panel
+    public static final String KEY_PREF_SHOW_NOW_PLAYING_PANEL = "pref_show_nowplayingpanel";
+    public static final boolean DEFAULT_PREF_SHOW_NOW_PLAYING_PANEL = true;
+
     // Pause during calls
     public static final String KEY_PREF_PAUSE_DURING_CALLS = "pref_pause_during_calls";
     public static final boolean DEFAULT_PREF_PAUSE_DURING_CALLS = false;

--- a/app/src/main/java/org/xbmc/kore/jsonrpc/HostConnection.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/HostConnection.java
@@ -42,7 +42,6 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.net.InetSocketAddress;
-import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.Proxy;
 import java.net.Socket;
@@ -70,6 +69,7 @@ public class HostConnection {
      * Interface that an observer must implement to be notified of player notifications
      */
     public interface PlayerNotificationsObserver {
+        public void onPropertyChanged(Player.OnPropertyChanged notification);
         public void onPlay(Player.OnPlay notification);
         public void onPause(Player.OnPause notification);
         public void onSpeedChanged(Player.OnSpeedChanged notification);
@@ -274,7 +274,7 @@ public class HostConnection {
      * Unregisters and observer from the input notifications
      * @param observer The {@link InputNotificationsObserver}
      */
-    public void unregisterApplicationotificationsObserver(ApplicationNotificationsObserver observer) {
+    public void unregisterApplicationNotificationsObserver(ApplicationNotificationsObserver observer) {
         applicationNotificationsObservers.remove(observer);
     }
 
@@ -658,6 +658,18 @@ public class HostConnection {
                         @Override
                         public void run() {
                             observer.onStop(apiNotification);
+                        }
+                    });
+                }
+            } else if (notificationName.equals(Player.OnPropertyChanged.NOTIFICATION_NAME)) {
+                final Player.OnPropertyChanged apiNotification = new Player.OnPropertyChanged(params);
+                for (final PlayerNotificationsObserver observer :
+                        playerNotificationsObservers.keySet()) {
+                    Handler handler = playerNotificationsObservers.get(observer);
+                    handler.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            observer.onPropertyChanged(apiNotification);
                         }
                     });
                 }

--- a/app/src/main/java/org/xbmc/kore/jsonrpc/notification/Player.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/notification/Player.java
@@ -16,6 +16,7 @@
 package org.xbmc.kore.jsonrpc.notification;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.xbmc.kore.jsonrpc.ApiNotification;
 import org.xbmc.kore.jsonrpc.type.GlobalType;
@@ -25,6 +26,23 @@ import org.xbmc.kore.utils.JsonUtils;
  * All Player.* notifications
  */
 public class Player {
+
+    /**
+     * Player.OnPropertyChanged notification
+     * Player properties have changed. Such as repeat type and shuffle mode
+     */
+    public static class OnPropertyChanged extends ApiNotification {
+        public static final String  NOTIFICATION_NAME = "Player.OnPropertyChanged";
+
+        public final NotificationsData data;
+
+        public OnPropertyChanged(ObjectNode node) {
+            super(node);
+            data = new NotificationsData(node.get(NotificationsData.DATA_NODE));
+        }
+
+        public String getNotificationName() { return NOTIFICATION_NAME; }
+    }
 
     /**
      * Player.OnPause notification
@@ -179,15 +197,44 @@ public class Player {
         }
     }
 
+    /**
+     * Notification data for player properties
+     */
+    public static class NotificationsProperty {
+        public static final String PROPERTY_NODE = "property";
+
+        public final Boolean shuffled;
+        public final String repeatMode;
+
+        public NotificationsProperty(JsonNode node) {
+            JsonNode shuffledNode = node.get("shuffled");
+            if (shuffledNode != null)
+                shuffled = shuffledNode.asBoolean();
+            else
+                shuffled = null;
+
+            repeatMode = JsonUtils.stringFromJsonNode(node, "repeat");
+        }
+    }
+
     public static class NotificationsData {
         public static final String DATA_NODE = "data";
 
         public final NotificationsPlayer player;
         public final NotificationsItem item;
+        public final NotificationsProperty property;
 
         public NotificationsData(JsonNode node) {
-            item = new NotificationsItem((ObjectNode)node.get(NotificationsItem.ITEM_NODE));
-            player = new NotificationsPlayer((ObjectNode)node.get(NotificationsPlayer.PLAYER_NODE));
+            JsonNode jsonNode = node.get(NotificationsItem.ITEM_NODE);
+            item = (jsonNode != null) ? new NotificationsItem(jsonNode) : null;
+
+            jsonNode = node.get(NotificationsPlayer.PLAYER_NODE);
+            player = (jsonNode != null)
+                     ? new NotificationsPlayer(jsonNode)
+                     : null;
+
+            jsonNode = node.get(NotificationsProperty.PROPERTY_NODE);
+            property = (jsonNode != null) ? new NotificationsProperty(jsonNode) : null;
         }
     }
 

--- a/app/src/main/java/org/xbmc/kore/service/ConnectionObserversManagerService.java
+++ b/app/src/main/java/org/xbmc/kore/service/ConnectionObserversManagerService.java
@@ -26,6 +26,7 @@ import android.support.v4.content.ContextCompat;
 import org.xbmc.kore.Settings;
 import org.xbmc.kore.host.HostConnectionObserver;
 import org.xbmc.kore.host.HostManager;
+import org.xbmc.kore.jsonrpc.notification.Player;
 import org.xbmc.kore.jsonrpc.type.ListType;
 import org.xbmc.kore.jsonrpc.type.PlayerType;
 import org.xbmc.kore.utils.LogUtils;
@@ -148,6 +149,11 @@ public class ConnectionObserversManagerService extends Service
         if (mHostConnectionObserver != null) {
             mHostConnectionObserver.unregisterPlayerObserver(this);
         }
+    }
+
+    @Override
+    public void playerOnPropertyChanged(Player.NotificationsData notificationsData) {
+
     }
 
     /**

--- a/app/src/main/java/org/xbmc/kore/service/NotificationObserver.java
+++ b/app/src/main/java/org/xbmc/kore/service/NotificationObserver.java
@@ -17,10 +17,8 @@ package org.xbmc.kore.service;
 
 import android.annotation.TargetApi;
 import android.app.Notification;
-import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
-import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
@@ -36,6 +34,7 @@ import com.squareup.picasso.Target;
 import org.xbmc.kore.R;
 import org.xbmc.kore.host.HostConnectionObserver;
 import org.xbmc.kore.host.HostManager;
+import org.xbmc.kore.jsonrpc.notification.Player;
 import org.xbmc.kore.jsonrpc.type.ListType;
 import org.xbmc.kore.jsonrpc.type.PlayerType;
 import org.xbmc.kore.ui.sections.remote.RemoteActivity;
@@ -66,6 +65,11 @@ public class NotificationObserver
         stackBuilder.addParentStack(RemoteActivity.class);
         stackBuilder.addNextIntent(new Intent(mService, RemoteActivity.class));
         mRemoteStartPendingIntent = stackBuilder.getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT);
+    }
+
+    @Override
+    public void playerOnPropertyChanged(Player.NotificationsData notificationsData) {
+
     }
 
     /**

--- a/app/src/main/java/org/xbmc/kore/service/PauseCallObserver.java
+++ b/app/src/main/java/org/xbmc/kore/service/PauseCallObserver.java
@@ -75,6 +75,11 @@ public class PauseCallObserver extends PhoneStateListener
     }
 
     @Override
+    public void playerOnPropertyChanged(org.xbmc.kore.jsonrpc.notification.Player.NotificationsData notificationsData) {
+
+    }
+
+    @Override
     public void playerOnPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                              PlayerType.PropertyValue getPropertiesResult,
                              ListType.ItemsAll getItemResult) {

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/PlaylistFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/PlaylistFragment.java
@@ -194,6 +194,12 @@ public class PlaylistFragment extends Fragment
     private PlayerType.PropertyValue lastGetPropertiesResult;
     private List<ListType.ItemsAll> lastGetPlaylistItemsResult = null;
 
+    @Override
+    public void playerOnPropertyChanged(org.xbmc.kore.jsonrpc.notification.Player.NotificationsData notificationsData) {
+        if (notificationsData.property.shuffled != null)
+            setupPlaylistInfo(lastGetActivePlayerResult, lastGetPropertiesResult, lastGetItemResult);
+    }
+
     /**
      * HostConnectionObserver.PlayerEventsObserver interface callbacks
      */

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
@@ -610,6 +610,12 @@ public class RemoteActivity extends BaseActivity
      * HostConnectionObserver.PlayerEventsObserver interface callbacks
      */
     private String lastImageUrl = null;
+
+    @Override
+    public void playerOnPropertyChanged(org.xbmc.kore.jsonrpc.notification.Player.NotificationsData notificationsData) {
+
+    }
+
     public void playerOnPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                              PlayerType.PropertyValue getPropertiesResult,
                              ListType.ItemsAll getItemResult) {
@@ -688,11 +694,6 @@ public class RemoteActivity extends BaseActivity
      */
     public void SwitchToRemotePanel() {
         viewPager.setCurrentItem(1);
-    }
-
-    @Override
-    public void onShuffleClicked() {
-        refreshPlaylist();
     }
 
     private void refreshPlaylist() {

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteFragment.java
@@ -552,12 +552,17 @@ public class RemoteFragment extends Fragment
         @Override
         public void onSuccess(Integer result) {
             if (!isAdded()) return;
-            UIUtils.setPlayPauseButtonIcon(getActivity(), playButton, result);
+            UIUtils.setPlayPauseButtonIcon(getActivity(), playButton, result == 1);
         }
 
         @Override
         public void onError(int errorCode, String description) { }
     };
+
+    @Override
+    public void playerOnPropertyChanged(org.xbmc.kore.jsonrpc.notification.Player.NotificationsData notificationsData) {
+
+    }
 
     /**
      * HostConnectionObserver.PlayerEventsObserver interface callbacks
@@ -569,7 +574,7 @@ public class RemoteFragment extends Fragment
         currentActivePlayerId = getActivePlayerResult.playerid;
         currentNowPlayingItemType = getItemResult.type;
         // Switch icon
-        UIUtils.setPlayPauseButtonIcon(getActivity(), playButton, getPropertiesResult.speed);
+        UIUtils.setPlayPauseButtonIcon(getActivity(), playButton, getPropertiesResult.speed == 1);
     }
 
     public void playerOnPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
@@ -579,7 +584,7 @@ public class RemoteFragment extends Fragment
         currentActivePlayerId = getActivePlayerResult.playerid;
         currentNowPlayingItemType = getItemResult.type;
         // Switch icon
-        UIUtils.setPlayPauseButtonIcon(getActivity(), playButton, getPropertiesResult.speed);
+        UIUtils.setPlayPauseButtonIcon(getActivity(), playButton, getPropertiesResult.speed == 1);
     }
 
     public void playerOnStop() {

--- a/app/src/main/java/org/xbmc/kore/ui/widgets/MediaProgressIndicator.java
+++ b/app/src/main/java/org/xbmc/kore/ui/widgets/MediaProgressIndicator.java
@@ -18,6 +18,8 @@ package org.xbmc.kore.ui.widgets;
 
 
 import android.content.Context;
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.widget.LinearLayout;
@@ -25,6 +27,7 @@ import android.widget.SeekBar;
 import android.widget.TextView;
 
 import org.xbmc.kore.R;
+import org.xbmc.kore.utils.LogUtils;
 import org.xbmc.kore.utils.UIUtils;
 
 public class MediaProgressIndicator extends LinearLayout {
@@ -94,6 +97,24 @@ public class MediaProgressIndicator extends LinearLayout {
         });
     }
 
+    @Override
+    protected Parcelable onSaveInstanceState() {
+        SavedState savedState = new SavedState(super.onSaveInstanceState());
+        savedState.progress = progress;
+        savedState.maxProgress = maxProgress;
+        return savedState;
+    }
+
+    @Override
+    protected void onRestoreInstanceState(Parcelable state) {
+        SavedState savedState = (SavedState) state;
+        super.onRestoreInstanceState(savedState.getSuperState());
+        progress = savedState.progress;
+        maxProgress = savedState.maxProgress;
+        setProgress(progress);
+        setMaxProgress(maxProgress);
+    }
+
     private Runnable seekBarUpdater = new Runnable() {
         @Override
         public void run() {
@@ -119,6 +140,10 @@ public class MediaProgressIndicator extends LinearLayout {
         progressTextView.setText(UIUtils.formatTime(progress));
     }
 
+    public int getProgress() {
+        return progress;
+    }
+
     public void setMaxProgress(int max) {
         maxProgress = max;
         seekBar.setMax(max);
@@ -139,5 +164,38 @@ public class MediaProgressIndicator extends LinearLayout {
         seekBar.removeCallbacks(seekBarUpdater);
         if (speed > 0)
             seekBar.postDelayed(seekBarUpdater, SEEK_BAR_UPDATE_INTERVAL);
+    }
+
+    private static class SavedState extends BaseSavedState {
+        int progress;
+        int maxProgress;
+
+        SavedState(Parcelable superState) {
+            super(superState);
+        }
+
+        private SavedState(Parcel in) {
+            super(in);
+            progress = in.readInt();
+            maxProgress = in.readInt();
+        }
+
+        @Override
+        public void writeToParcel(Parcel out, int flags) {
+            super.writeToParcel(out, flags);
+            out.writeInt(progress);
+            out.writeInt(maxProgress);
+        }
+
+        public static final Parcelable.Creator<SavedState> CREATOR
+                = new Parcelable.Creator<SavedState>() {
+            public SavedState createFromParcel(Parcel in) {
+                return new SavedState(in);
+            }
+
+            public SavedState[] newArray(int size) {
+                return new SavedState[size];
+            }
+        };
     }
 }

--- a/app/src/main/java/org/xbmc/kore/ui/widgets/NowPlayingPanel.java
+++ b/app/src/main/java/org/xbmc/kore/ui/widgets/NowPlayingPanel.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2017 Martijn Brekhof. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.xbmc.kore.ui.widgets;
+
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageButton;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.sothree.slidinguppanel.SlidingUpPanelLayout;
+
+import org.xbmc.kore.R;
+import org.xbmc.kore.jsonrpc.type.GlobalType;
+import org.xbmc.kore.utils.UIUtils;
+
+public class NowPlayingPanel extends SlidingUpPanelLayout {
+
+    public interface OnPanelButtonsClickListener {
+        void onPlayClicked();
+        void onPreviousClicked();
+        void onNextClicked();
+        void onVolumeMuteClicked();
+        void onShuffleClicked();
+        void onRepeatClicked();
+        void onVolumeMutedIndicatorClicked();
+    }
+
+    private OnPanelButtonsClickListener onPanelButtonsClickListener;
+
+    private TextView title;
+    private TextView details;
+    private ImageView poster;
+    private ImageButton previousButton;
+    private ImageButton nextButton;
+    private ImageButton playButton;
+    private MediaProgressIndicator mediaProgressIndicator;
+    private VolumeLevelIndicator volumeLevelIndicator;
+    private HighlightButton volumeMuteButton;
+    private HighlightButton volumeMutedIndicatorButton;
+    private RepeatModeButton repeatModeButton;
+    private HighlightButton shuffleButton;
+
+    public NowPlayingPanel(Context context) {
+        super(context);
+        initializeView(context);
+    }
+    public NowPlayingPanel(Context context, AttributeSet attributeSet) {
+        super(context, attributeSet);
+        initializeView(context);
+    }
+
+    public NowPlayingPanel(Context context, AttributeSet attributeSet, int defStyle) {
+        super(context, attributeSet, defStyle);
+        initializeView(context);
+    }
+
+    private void initializeView(Context context) {
+        LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        inflater.inflate(R.layout.now_playing_panel, this);
+    }
+
+    @Override
+    protected void onFinishInflate() {
+        super.onFinishInflate();
+
+        title = (TextView) findViewById(R.id.npp_title);
+        details = (TextView) findViewById(R.id.npp_details);
+        poster = (ImageView) findViewById(R.id.npp_poster);
+        previousButton = (ImageButton) findViewById(R.id.npp_previous);
+        nextButton = (ImageButton) findViewById(R.id.npp_next);
+        playButton = (ImageButton) findViewById(R.id.npp_play);
+        mediaProgressIndicator = (MediaProgressIndicator) findViewById(R.id.npp_progress_indicator);
+        volumeLevelIndicator = (VolumeLevelIndicator) findViewById(R.id.npp_volume_level_indicator);
+        volumeMuteButton = (HighlightButton) findViewById(R.id.npp_volume_mute);
+        repeatModeButton = (RepeatModeButton) findViewById(R.id.npp_repeat);
+        shuffleButton = (HighlightButton) findViewById(R.id.npp_shuffle);
+        volumeMutedIndicatorButton = (HighlightButton) findViewById(R.id.npp_volume_muted_indicator);
+
+        setupButtonClickListeners();
+    }
+
+    public void setOnPanelButtonsClickListener(OnPanelButtonsClickListener listener) {
+        onPanelButtonsClickListener = listener;
+    }
+
+    public void setOnVolumeChangeListener(VolumeLevelIndicator.OnVolumeChangeListener listener) {
+        volumeLevelIndicator.setOnVolumeChangeListener(listener);
+    }
+
+    public void setOnProgressChangeListener(MediaProgressIndicator.OnProgressChangeListener listener) {
+        mediaProgressIndicator.setOnProgressChangeListener(listener);
+    }
+
+    public void setVolume(int volume, boolean muted) {
+        volumeLevelIndicator.setVolume(muted, volume);
+
+        if (muted) {
+            volumeMutedIndicatorButton.setVisibility(View.VISIBLE);
+        } else {
+            volumeMutedIndicatorButton.setVisibility(View.GONE);
+        }
+
+        volumeMutedIndicatorButton.setHighlight(muted);
+        volumeMuteButton.setHighlight(muted);
+    }
+
+    public void setRepeatMode(String repeatMode) {
+        UIUtils.setRepeatButton(repeatModeButton, repeatMode);
+    }
+
+    public void setShuffled(boolean shuffled) {
+        shuffleButton.setHighlight(shuffled);
+    }
+
+    /**
+     * Sets the state of the play button
+     * @param play true if playing, false if paused
+     */
+    public void setPlayButton(boolean play) {
+        UIUtils.setPlayPauseButtonIcon(getContext(), playButton, play);
+    }
+
+    public void setMediaProgress(GlobalType.Time time, GlobalType.Time totalTime) {
+        mediaProgressIndicator.setMaxProgress(totalTime.ToSeconds());
+        mediaProgressIndicator.setProgress(time.ToSeconds());
+    }
+
+    /**
+     * Returns the progression indicator used for media progression
+     * @return
+     */
+    public MediaProgressIndicator getMediaProgress() {
+        return mediaProgressIndicator;
+    }
+
+    /**
+     *
+     * @param speed
+     */
+    public void setSpeed(int speed) {
+        mediaProgressIndicator.setSpeed(speed);
+    }
+
+    public CharSequence getTitle() {
+        return title.getText();
+    }
+
+    public void setTitle(String title) {
+        this.title.setText(title);
+    }
+
+    public void setDetails(String details) {
+        this.details.setText(details);
+    }
+
+    public void setNextPrevVisibility(int visibility) {
+        nextButton.setVisibility(visibility);
+        previousButton.setVisibility(visibility);
+    }
+
+    public void setSquarePoster(boolean square) {
+        if (square) {
+            ViewGroup.LayoutParams layoutParams = poster.getLayoutParams();
+            layoutParams.width = layoutParams.height;
+            poster.setLayoutParams(layoutParams);
+        }
+    }
+
+    public ImageView getPoster() {
+        return poster;
+    }
+
+    private void setupButtonClickListeners() {
+        playButton.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                handleButtonClickEvent(v);
+            }
+        });
+
+        previousButton.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                handleButtonClickEvent(v);
+            }
+        });
+
+        nextButton.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                handleButtonClickEvent(v);
+            }
+        });
+
+        volumeMuteButton.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                handleButtonClickEvent(v);
+            }
+        });
+
+        shuffleButton.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                handleButtonClickEvent(v);
+            }
+        });
+
+        repeatModeButton.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                handleButtonClickEvent(v);
+            }
+        });
+
+        volumeMutedIndicatorButton.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                handleButtonClickEvent(v);
+            }
+        });
+    }
+
+    private void handleButtonClickEvent(View view) {
+        if (onPanelButtonsClickListener == null)
+            return;
+
+        switch (view.getId()) {
+            case R.id.npp_previous:
+                onPanelButtonsClickListener.onPreviousClicked();
+                break;
+            case R.id.npp_next:
+                onPanelButtonsClickListener.onNextClicked();
+                break;
+            case R.id.npp_play:
+                onPanelButtonsClickListener.onPlayClicked();
+                break;
+            case R.id.npp_volume_mute:
+                onPanelButtonsClickListener.onVolumeMuteClicked();
+                break;
+            case R.id.npp_repeat:
+                onPanelButtonsClickListener.onRepeatClicked();
+                break;
+            case R.id.npp_shuffle:
+                onPanelButtonsClickListener.onShuffleClicked();
+                break;
+            case R.id.npp_volume_muted_indicator:
+                onPanelButtonsClickListener.onVolumeMutedIndicatorClicked();
+                break;
+        }
+    }
+}

--- a/app/src/main/java/org/xbmc/kore/utils/LogUtils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/LogUtils.java
@@ -33,8 +33,8 @@ public class LogUtils {
 
     // TODO: Remove this later
     private static final List<String> doNotLogTags = Arrays.asList(
-            HostConnection.TAG,
-            HostConnectionObserver.TAG
+//            HostConnection.TAG,
+//            HostConnectionObserver.TAG
     );
 
     public static String makeLogTag(String str) {

--- a/app/src/main/java/org/xbmc/kore/utils/UIUtils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/UIUtils.java
@@ -94,6 +94,21 @@ public class UIUtils {
     }
 
     /**
+     * Converts the time format from {@link #formatTime(int, int, int)} to seconds
+     * @param time
+     * @return
+     */
+    public static int timeToSeconds(String time) {
+        String[] items = time.split(":");
+        if (items.length > 2) {
+            return (Integer.parseInt(items[0]) * 3600) + (Integer.parseInt(items[1]) * 60) +
+                   (Integer.parseInt(items[2]));
+        } else {
+            return (Integer.parseInt(items[0]) * 60) + (Integer.parseInt(items[1]));
+        }
+    }
+
+    /**
      * Formats a file size, ISO prefixes
      */
     public static String formatFileSize(int bytes) {
@@ -198,9 +213,9 @@ public class UIUtils {
         char charAvatar = TextUtils.isEmpty(str) ?
                           ' ' : str.charAt(0);
         int avatarColorsIdx = TextUtils.isEmpty(str) ? 0 :
-                Math.max(Character.getNumericValue(str.charAt(0)) +
-                        Character.getNumericValue(str.charAt(str.length() - 1)) +
-                        str.length(), 0) % characterAvatarColors.length();
+                              Math.max(Character.getNumericValue(str.charAt(0)) +
+                                       Character.getNumericValue(str.charAt(str.length() - 1)) +
+                                       str.length(), 0) % characterAvatarColors.length();
         int color = characterAvatarColors.getColor(avatarColorsIdx, 0xff000000);
 //            avatarColorsIdx = randomGenerator.nextInt(characterAvatarColors.length());
         return new CharacterDrawable(charAvatar, color);
@@ -210,12 +225,12 @@ public class UIUtils {
     static int iconPauseResId = R.drawable.ic_pause_white_24dp,
             iconPlayResId = R.drawable.ic_play_arrow_white_24dp;
     /**
-     * Sets play/pause button icon on a ImageView, based on speed
+     * Sets play/pause button icon on a ImageView
      * @param context Activity
      * @param view ImageView/ImageButton
-     * @param speed Current player speed
+     * @param play true if playing, false if paused
      */
-    public static void setPlayPauseButtonIcon(Context context, ImageView view, int speed) {
+    public static void setPlayPauseButtonIcon(Context context, ImageView view, boolean play) {
 
         if (!playPauseIconsLoaded) {
             TypedArray styledAttributes = context.obtainStyledAttributes(new int[]{R.attr.iconPause, R.attr.iconPlay});
@@ -225,7 +240,7 @@ public class UIUtils {
             playPauseIconsLoaded = true;
         }
 
-        view.setImageResource((speed == 1) ? iconPauseResId: iconPlayResId);
+        view.setImageResource(play ? iconPauseResId : iconPlayResId );
     }
 
     /**

--- a/app/src/main/res/layout/activity_generic_media.xml
+++ b/app/src/main/res/layout/activity_generic_media.xml
@@ -28,10 +28,17 @@
 
         <include layout="@layout/toolbar_default" />
 
-        <FrameLayout
-            android:id="@+id/fragment_container"
+        <org.xbmc.kore.ui.widgets.NowPlayingPanel
+            xmlns:sothree="http://schemas.android.com/apk/res-auto"
+            xmlns:android="http://schemas.android.com/apk/res/android"
+            android:id="@+id/now_playing_panel"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"/>
+            android:layout_height="match_parent"
+            android:gravity="bottom"
+            sothree:umanoPanelHeight="@dimen/notification_art_slim_height"
+            sothree:umanoShadowHeight="4dp"
+            sothree:umanoFadeColor="#00000000"
+            sothree:umanoInitialState="hidden"/>
     </LinearLayout>
 
     <fragment android:id="@+id/navigation_drawer"

--- a/app/src/main/res/layout/fragment_now_playing.xml
+++ b/app/src/main/res/layout/fragment_now_playing.xml
@@ -169,12 +169,14 @@
                     style="@style/Widget.Button.Borderless"
                     android:src="?attr/iconVolumeMute"
                     android:contentDescription="@string/volume_mute"/>
+
                 <org.xbmc.kore.ui.widgets.VolumeLevelIndicator
                     android:id="@+id/volume_level_indicator"
                     android:layout_width="0dp"
                     android:layout_height="match_parent"
                     android:layout_weight="2"
-                    android:orientation="vertical"/>
+                    android:orientation="vertical" />
+
                 <org.xbmc.kore.ui.widgets.RepeatModeButton
                     android:id="@+id/repeat"
                     android:layout_width="0dp"

--- a/app/src/main/res/layout/now_playing_panel.xml
+++ b/app/src/main/res/layout/now_playing_panel.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+   Copyright 2017 Martijn Brekhof. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <FrameLayout
+        android:id="@+id/fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
+    <LinearLayout android:layout_width="match_parent"
+                  android:layout_height="wrap_content"
+                  android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:background="?attr/colorPrimaryDark">
+
+            <ImageView android:id="@+id/npp_poster"
+                       android:layout_width="@dimen/notification_art_slim_width"
+                       android:layout_height="@dimen/notification_art_slim_height"
+                       android:layout_weight="0"
+                       android:scaleType="centerInside"
+                       android:contentDescription="@string/poster"/>
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="@dimen/notification_art_slim_height"
+                android:orientation="vertical"
+                android:layout_weight="1">
+                <TextView
+                    android:id="@+id/npp_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="@dimen/small_padding"
+                    android:paddingRight="@dimen/small_padding"
+                    android:textAppearance="@style/TextAppearance.Notification.Title"
+                    android:maxLines="1"
+                    android:ellipsize="marquee"
+                    android:fadingEdge="horizontal"
+                    android:gravity="center_vertical"/>
+
+                <TextView
+                    android:id="@+id/npp_details"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="@dimen/small_padding"
+                    android:paddingRight="@dimen/small_padding"
+                    android:textAppearance="@style/TextAppearance.Notification.Details"
+                    android:maxLines="1"
+                    android:ellipsize="marquee"
+                    android:fadingEdge="horizontal"
+                    android:gravity="center_vertical"/>
+            </LinearLayout>
+            <org.xbmc.kore.ui.widgets.HighlightButton
+                android:id="@+id/npp_volume_muted_indicator"
+                android:layout_width="@dimen/notification_art_slim_height"
+                android:layout_height="@dimen/notification_art_slim_height"
+                style="@style/Widget.Button.Borderless"
+                android:src="?attr/iconVolumeMute"
+                android:contentDescription="@string/volume_mute"
+                android:visibility="gone"/>
+
+            <ImageButton
+                android:id="@+id/npp_previous"
+                android:layout_width="@dimen/notification_art_slim_height"
+                android:layout_height="@dimen/notification_art_slim_height"
+                style="@style/Widget.Button.Borderless"
+                android:src="?attr/iconPrevious"
+                android:contentDescription="@string/previous"/>
+
+            <ImageButton
+                android:id="@+id/npp_play"
+                android:layout_width="@dimen/notification_art_slim_height"
+                android:layout_height="@dimen/notification_art_slim_height"
+                style="@style/Widget.Button.Borderless"
+                android:src="?attr/iconPlay"
+                android:contentDescription="@string/play"/>
+
+            <ImageButton
+                android:id="@+id/npp_next"
+                android:layout_width="@dimen/notification_art_slim_height"
+                android:layout_height="@dimen/notification_art_slim_height"
+                style="@style/Widget.Button.Borderless"
+                android:src="?attr/iconNext"
+                android:contentDescription="@string/next"/>
+        </LinearLayout>
+        <org.xbmc.kore.ui.widgets.MediaProgressIndicator
+            android:id="@+id/npp_progress_indicator"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="@dimen/default_padding"
+            android:paddingRight="@dimen/small_padding"
+            android:paddingLeft="@dimen/small_padding"
+            android:orientation="horizontal"
+            android:background="?attr/contentBackgroundColor"
+            style="@style/TextAppearance.Media.Progress"/>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/buttonbar_height"
+            android:orientation="horizontal"
+            style="@style/ButtonBar"
+            android:background="?attr/contentBackgroundColor">
+
+            <org.xbmc.kore.ui.widgets.HighlightButton
+                android:id="@+id/npp_volume_mute"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="match_parent"
+                style="@style/Widget.Button.Borderless"
+                android:src="?attr/iconVolumeMute"
+                android:contentDescription="@string/volume_mute"/>
+            <org.xbmc.kore.ui.widgets.VolumeLevelIndicator
+                android:id="@+id/npp_volume_level_indicator"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="2"
+                android:orientation="vertical">
+            </org.xbmc.kore.ui.widgets.VolumeLevelIndicator>
+
+            <org.xbmc.kore.ui.widgets.RepeatModeButton
+                android:id="@+id/npp_repeat"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="match_parent"
+                style="@style/Widget.Button.Borderless"
+                android:src="?attr/iconRepeat"
+                android:contentDescription="@string/repeat"/>
+            <org.xbmc.kore.ui.widgets.HighlightButton
+                android:id="@+id/npp_shuffle"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="match_parent"
+                style="@style/Widget.Button.Borderless"
+                android:src="?attr/iconShuffle"
+                android:contentDescription="@string/shuffle"/>
+        </LinearLayout>
+    </LinearLayout>
+</merge>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -128,7 +128,8 @@
     <dimen name="notification_expanded_height">128dp</dimen>
     <dimen name="notification_art_default_height">64dp</dimen>
     <dimen name="notification_art_default_width">64dp</dimen>
-    <dimen name="notification_art_slim_width">44dp</dimen>
+    <dimen name="notification_art_slim_width">31dp</dimen>
+    <dimen name="notification_art_slim_height">44dp</dimen>
     <dimen name="notification_expanded_art_default_height">128dp</dimen>
     <dimen name="notification_expanded_art_default_width">128dp</dimen>
     <dimen name="notification_expanded_art_slim_width">88dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -346,6 +346,8 @@
     <string name="keep_remote_above_lockscreen">Show over lockscreen</string>
     <string name="pref_keep_screen_on">Stay awake</string>
     <string name="show_notification">Show notification while playing</string>
+    <string name="show_now_playing_panel">Show now playing panel while playing</string>
+    <string name="show_now_playing_panel_summary">Displays an expandable panel at the bottom of the screen when media is playing or paused</string>
     <string name="pause_during_calls">Pause during phone call</string>
     <string name="use_hardware_volume_keys">Use device volume keys</string>
     <string name="vibrate_on_remote">Vibrate on touch</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -65,6 +65,12 @@
             android:defaultValue="false"/>
 
         <SwitchPreferenceCompat
+            android:key="pref_show_nowplayingpanel"
+            android:title="@string/show_now_playing_panel"
+            android:summary="@string/show_now_playing_panel_summary"
+            android:defaultValue="true"/>
+
+        <SwitchPreferenceCompat
             android:key="pref_pause_during_calls"
             android:title="@string/pause_during_calls"
             android:defaultValue="false"/>


### PR DESCRIPTION
When Kodi is muted a mute menu item is added to the action bar which can
be used to unmute Kodi. The mute icon is only displayed when Kodi is muted.

I'm not yet convinced this is the best solution. Another solution could be using a snackbar at the bottom to show the mute state. For instance like the example at [material.google.com](https://material.google.com/components/snackbars-toasts.html#snackbars-toasts-specs) shows.
However, I'm afraid some users might find the snackbar solution annoying and don't consider the mute state to be that important.

This should fix issue #199 