### PR TITLE
Fixes reported crashes caused by a NullPointerException

### DIFF
--- a/app/src/main/java/org/xbmc/kore/service/ConnectionObserversManagerService.java
+++ b/app/src/main/java/org/xbmc/kore/service/ConnectionObserversManagerService.java
@@ -127,8 +127,10 @@ public class ConnectionObserversManagerService extends Service
     @Override
     public void onTaskRemoved (Intent rootIntent) {
         // Gracefully stop
-        for (HostConnectionObserver.PlayerEventsObserver observer : mConnectionObservers) {
-            observer.playerOnConnectionError(0, "Task removed");
+        if (mConnectionObservers != null) {
+            for (HostConnectionObserver.PlayerEventsObserver observer : mConnectionObservers) {
+                observer.playerOnConnectionError(0, "Task removed");
+            }
         }
 
         LogUtils.LOGD(TAG, "Shutting down observer service - Task removed");


### PR DESCRIPTION
Multiple NullPointerExceptions have been reported in Google Play (dev).
Probably caused by calling onTaskRemoved more than once.