### PR TITLE
Fixed some problems in the remote fragment layout when in landscape mode

### DIFF
--- a/app/src/main/res/layout-land/fragment_remote.xml
+++ b/app/src/main/res/layout-land/fragment_remote.xml
@@ -31,7 +31,8 @@
         android:paddingTop="@dimen/remote_page_indicator_height"
         android:layout_marginLeft="@dimen/remote_content_hmargin"
         android:layout_marginRight="@dimen/remote_content_hmargin"
-        tools:ignore="InconsistentLayout">
+        tools:ignore="InconsistentLayout"
+        tools:visibility="gone">
         <!--android:background="?attr/cardBackground">-->
 
         <TextView
@@ -51,9 +52,9 @@
         android:layout_width="0dp"
         android:layout_weight="1"
         android:layout_height="wrap_content"
+        android:layout_gravity="center"
         android:layout_marginLeft="@dimen/remote_content_hmargin"
-        android:layout_marginRight="@dimen/remote_content_hmargin"
-        android:paddingTop="@dimen/remote_page_indicator_height">
+        android:layout_marginRight="@dimen/remote_content_hmargin">
 
         <ImageView
             android:id="@+id/art"
@@ -68,9 +69,10 @@
             android:id="@+id/title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@id/art"
-            android:layout_alignLeft="@id/art"
-            android:layout_alignStart="@id/art"
+            android:layout_toRightOf="@id/art"
+            android:layout_toEndOf="@id/art"
+            android:layout_alignParentRight="true"
+            android:layout_alignParentEnd="true"
             style="@style/TextAppearance.Media.Remote.Title"
             android:background="?attr/contentBackgroundColor"/>
         <TextView
@@ -89,6 +91,7 @@
             android:layout_below="@id/details"
             android:layout_alignLeft="@id/details"
             android:layout_alignStart="@id/details"
+            android:layout_alignBottom="@+id/art"
             android:orientation="horizontal"
             style="@style/ButtonBar"
             android:background="?attr/contentBackgroundColor">
@@ -129,12 +132,11 @@
 
     <RelativeLayout
         android:id="@+id/remote"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="@dimen/remote_size"
+        android:layout_height="@dimen/remote_size"
         android:layout_marginRight="@dimen/remote_content_hmargin"
         android:layout_marginEnd="@dimen/remote_content_hmargin"
-        android:layout_marginBottom="@dimen/default_padding"
-        android:layout_gravity="bottom">
+        android:layout_gravity="center">
 
         <ImageView
             android:id="@+id/context"
@@ -230,6 +232,7 @@
             android:layout_width="match_parent"
             style="@style/Widget.Button.Borderless"
             android:src="?attr/iconHome"
+            android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/home"/>
         <ImageButton
             android:id="@+id/movies"
@@ -238,6 +241,7 @@
             android:layout_width="match_parent"
             style="@style/Widget.Button.Borderless"
             android:src="?attr/iconMovies"
+            android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/movies"/>
         <ImageButton
             android:id="@+id/tv_shows"
@@ -246,6 +250,7 @@
             android:layout_width="match_parent"
             style="@style/Widget.Button.Borderless"
             android:src="?attr/iconTvShows"
+            android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/tv_shows"/>
         <ImageButton
             android:id="@+id/music"
@@ -254,6 +259,7 @@
             android:layout_width="match_parent"
             style="@style/Widget.Button.Borderless"
             android:src="?attr/iconMusic"
+            android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/music"/>
         <ImageButton
             android:id="@+id/pictures"
@@ -262,6 +268,7 @@
             android:layout_width="match_parent"
             style="@style/Widget.Button.Borderless"
             android:src="?attr/iconPicture"
+            android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/pictures"/>
     </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
- added missing tint attribs in the vertical navigation icons
- parameterized pad buttons container dimensions like in portrait mode
- put art and media info/controls side-by-side like in portrait mode