### PR TITLE
Fixed issue with sharing code between local and instrumentation tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,14 +40,16 @@ android {
 
     sourceSets {
         fullDebug {
-            assets.srcDirs = ['src/testUtils/assets']
+            assets.srcDirs += 'src/testUtils/assets'
         }
         test {
-            java.srcDirs = ['src/test/java', 'src/testUtils/java']
+            java.srcDirs += 'src/testUtils/java'
+        }
+        androidTest {
+            java.srcDirs += 'src/testUtils/java'
         }
         instrumentationTest {
-            java.srcDirs = ['src/testUtils/java']
-            assets.srcDirs = ['src/testUtils/assets']
+            assets.srcDirs += 'src/testUtils/assets'
         }
     }
 


### PR DESCRIPTION
Using the **fullDebug** build variant, building from Android failed. I didn't notice this before as I was constantly using the **instrumentationDebug** build variant.