### PR TITLE
Fixed the return transition for the shared element

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -105,12 +105,16 @@ android {
     }
 }
 
+ext {
+    supportLibVersion = '25.0.1'
+}
+
 dependencies {
-    compile 'com.android.support:support-v4:25.1.0'
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:cardview-v7:25.1.0'
-    compile 'com.android.support:preference-v14:25.1.0'
-    compile 'com.android.support:support-v13:25.1.0'
+    compile "com.android.support:support-v4:${supportLibVersion}"
+    compile "com.android.support:appcompat-v7:${supportLibVersion}"
+    compile "com.android.support:cardview-v7:${supportLibVersion}"
+    compile "com.android.support:preference-v14:${supportLibVersion}"
+    compile "com.android.support:support-v13:${supportLibVersion}"
 
     compile 'com.fasterxml.jackson.core:jackson-databind:2.5.2'
     compile 'com.jakewharton:butterknife:6.1.0'
@@ -127,7 +131,7 @@ dependencies {
     androidTestCompile 'org.hamcrest:hamcrest-library:1.3'
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
     androidTestCompile 'com.android.support.test.espresso:espresso-idling-resource:2.2.2'
-    androidTestCompile 'com.android.support:support-v13:25.1.0'
+    androidTestCompile "com.android.support:support-v13:${supportLibVersion}"
     instrumentationTestCompile 'junit:junit:4.12'
 
     testCompile 'org.robolectric:robolectric:3.1.1'


### PR DESCRIPTION
Support library 25.1.0 contains a bug that causes the shared element return transition
to fail.