### PR TITLE
Added fdroid link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Links
 -----
 
 - [Kodi forum thread](http://forum.kodi.tv/forumdisplay.php?fid=129)
+- [F-Droid](https://f-droid.org/repository/browse/?fdid=org.xbmc.kore)
 - [Google Play][1]
 - [Google+ community](https://plus.google.com/communities/115506510322045554124)
 


### PR DESCRIPTION
IMO fdroid should be prefered over play store, because fdroid is FOSS
Related: #220 
If you want, I could replace the fdroid and play store links with "get it on ..." buttons