### PR TITLE
remove [] formatting

### DIFF
--- a/app/src/main/java/org/xbmc/kore/jsonrpc/method/Files.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/method/Files.java
@@ -157,6 +157,12 @@ public class Files {
             ArrayNode items = (ArrayNode) fileNode;
             ArrayList<ListType.ItemFile> result = new ArrayList<ListType.ItemFile>(items.size());
             for (JsonNode item : items) {
+                String regex = "\\[.*?\\]";
+                JsonNode label = item.get("label");
+                if (!label.isNull()) {
+                    String new_label = label.textValue().replaceAll(regex, "");
+                    ((ObjectNode) item).put("label", new_label);
+                }
                 result.add(new ListType.ItemFile(item));
             }
             return result;

--- a/app/src/main/java/org/xbmc/kore/jsonrpc/type/AddonType.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/type/AddonType.java
@@ -103,16 +103,16 @@ public class AddonType {
         public static final String VERSION = "version";
 
         public final String addonid;
-        public final String author;
+        public String author;
         public final boolean broken;
-        public final String description;
+        public String description;
         public final String disclaimer;
         public final Boolean enabled;
         public final String fanart;
-        public final String name;
+        public String name;
         public final String path;
         public final int rating;
-        public final String summary;
+        public String summary;
         public final String thumbnail;
         public final String type;
         public final String version;

--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListFragment.java
@@ -42,6 +42,8 @@ import org.xbmc.kore.utils.LogUtils;
 import org.xbmc.kore.utils.UIUtils;
 import org.xbmc.kore.utils.Utils;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import butterknife.ButterKnife;
@@ -167,7 +169,12 @@ public class AddonListFragment extends Fragment
                  .show();
         }
     }
-
+    public class AddonNameComparator implements Comparator<AddonType.Details>
+    {
+        public int compare(AddonType.Details left, AddonType.Details right) {
+            return left.name.toLowerCase().compareTo(right.name.toLowerCase());
+        }
+    }
     /**
      * Get the addons list and setup the gridview
      */
@@ -186,7 +193,14 @@ public class AddonListFragment extends Fragment
             @Override
             public void onSuccess(List<AddonType.Details> result) {
                 if (!isAdded()) return;
-
+                for (AddonType.Details addon : result) {
+                    String regex = "\\[.*?\\]";
+                    addon.name = addon.name.replaceAll(regex, "");
+                    addon.description = addon.description.replaceAll(regex, "");
+                    addon.summary = addon.summary.replaceAll(regex, "");
+                    addon.author = addon.author.replaceAll(regex, "");
+                }
+                Collections.sort(result, new AddonNameComparator());
                 adapter.clear();
                 for (AddonType.Details addon : result) {
                     if (addon.type.equals(AddonType.Types.UNKNOWN) ||

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Here is a less controversial PR.
It removes all the [.*?] formatting and sorts the addons by lowercase name.
If you want to make it more precise the regex needs to look for these label codes:
http://kodi.wiki/view/Label_Formatting