### PR TITLE
Unified translations in settings page

### DIFF
--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -323,6 +323,8 @@
     <string name="ignore_prefixes">התעלמות מקידומות</string>
 
     <!-- Preferences strings -->
+    <string name="application">אפליקציה</string>
+
     <string name="theme">ערכת נושא</string>
     <string name="theme_night">לילה</string>
     <string name="theme_day">יום</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -321,8 +321,7 @@
     <string name="ignore_prefixes">Ігнорувати префікси</string>
 
     <!-- Preferences strings -->
-    <string name="title_remote">Управління</string>
-    <string name="title_application">Застосунок</string>
+    <string name="application">Застосунок</string>
 	
     <string name="theme">Тема</string>
     <string name="theme_night">Ніч</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -322,8 +322,7 @@
     <string name="ignore_prefixes">Ignore prefixes</string>
 
     <!-- Preferences strings -->
-    <string name="title_remote">Remote</string>
-    <string name="title_application">Application</string>
+    <string name="application">Application</string>
 	
     <string name="theme">Theme</string>
     <string name="theme_night">Night</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -17,7 +17,7 @@
 <!--suppress AndroidElementNotAllowed -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <PreferenceCategory android:title="@string/title_remote">
+    <PreferenceCategory android:title="@string/remote">
         <SwitchPreferenceCompat
             android:key="pref_switch_to_remote_after_media_start"
             android:title="@string/switch_to_remote"
@@ -39,7 +39,7 @@
             android:defaultValue="false"/>
     </PreferenceCategory>
 
-    <PreferenceCategory android:title="@string/title_application">
+    <PreferenceCategory android:title="@string/application">
         <ListPreference
             android:key="pref_theme"
             android:title="@string/theme"


### PR DESCRIPTION
Unified translations (no need to translate "Remote" fragment title and settings title twice).