### PR TITLE
Fixes layout inflate exception due to missing width attribute

### DIFF
--- a/app/src/main/res/layout-land/fragment_remote.xml
+++ b/app/src/main/res/layout-land/fragment_remote.xml
@@ -37,11 +37,15 @@
 
         <TextView
             android:id="@+id/info_title"
+            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
             style="@style/TextAppearance.Info.Title"
             tools:ignore="InconsistentLayout"/>
 
         <TextView
             android:id="@+id/info_message"
+            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
             style="@style/TextAppearance.Info.Details"
             android:layout_below="@id/info_title"
             tools:ignore="InconsistentLayout"/>


### PR DESCRIPTION
I was not able to reproduce the issue. However, google dev console reports multiple crashes due to an inflate exception caused by a missing layout width attribute.
Hopefully this fixes it. 