### PR TITLE
Support getting favourites in Kore (#81)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -63,6 +63,7 @@
         <activity android:name="org.xbmc.kore.ui.sections.file.FileActivity"/>
         <activity android:name="org.xbmc.kore.ui.sections.video.PVRActivity"/>
         <activity android:name="org.xbmc.kore.ui.sections.video.AllCastActivity"/>
+        <activity android:name=".ui.sections.favourites.FavouritesActivity" />
 
         <!-- Providers -->
         <provider

--- a/app/src/main/java/org/xbmc/kore/jsonrpc/method/Favourites.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/method/Favourites.java
@@ -1,0 +1,60 @@
+package org.xbmc.kore.jsonrpc.method;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.xbmc.kore.jsonrpc.ApiException;
+import org.xbmc.kore.jsonrpc.ApiList;
+import org.xbmc.kore.jsonrpc.ApiMethod;
+import org.xbmc.kore.jsonrpc.type.FavouriteType;
+import org.xbmc.kore.jsonrpc.type.ListType;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+/**
+ * All JSON RPC methods in Favourites.*
+ */
+public class Favourites {
+
+    /**
+     * Retrieves the Details of the Favourites.
+     */
+    public static class GetFavourites extends ApiMethod<ApiList<FavouriteType.DetailsFavourite>> {
+        public static final String METHOD_NAME = "Favourites.GetFavourites";
+        private static final String LIST_NODE = "favourites";
+
+        /**
+         * Default ctor, gets all the properties by default.
+         */
+        public GetFavourites() {
+            addParameterToRequest("properties", new String[]{
+                    FavouriteType.DetailsFavourite.WINDOW, FavouriteType.DetailsFavourite.WINDOW_PARAMETER,
+                    FavouriteType.DetailsFavourite.THUMBNAIL, FavouriteType.DetailsFavourite.PATH
+            });
+        }
+
+        @Override
+        public String getMethodName() {
+            return METHOD_NAME;
+        }
+
+        @Override
+        public ApiList<FavouriteType.DetailsFavourite> resultFromJson(ObjectNode jsonObject) throws ApiException {
+            ListType.LimitsReturned limits = new ListType.LimitsReturned(jsonObject);
+
+            JsonNode resultNode = jsonObject.get(RESULT_NODE);
+            ArrayNode items = resultNode.has(LIST_NODE) ?
+                    (ArrayNode) resultNode.get(LIST_NODE) : null;
+            if (items == null) {
+                return new ApiList<>(Collections.<FavouriteType.DetailsFavourite>emptyList(), limits);
+            }
+            ArrayList<FavouriteType.DetailsFavourite> result = new ArrayList<>(items.size());
+            for (JsonNode item : items) {
+                result.add(new FavouriteType.DetailsFavourite(item));
+            }
+            return new ApiList<>(result, limits);
+        }
+    }
+}

--- a/app/src/main/java/org/xbmc/kore/jsonrpc/method/Favourites.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/method/Favourites.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 XBMC Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xbmc.kore.jsonrpc.method;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/app/src/main/java/org/xbmc/kore/jsonrpc/method/Player.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/method/Player.java
@@ -484,19 +484,6 @@ public class Player {
             addParameterToRequest("item", item);
         }
 
-        /**
-         * Starts playing from a file path.
-         * This path could also point to a media type provided by an addon. eg. Youtube
-         *
-         * @param path the path that the player will play from
-         */
-        public Open(String path) {
-            super();
-            final ObjectNode item = objectMapper.createObjectNode();
-            item.put("file", path);
-            addParameterToRequest("item", item);
-        }
-
         @Override
         public String getMethodName() { return METHOD_NAME; }
 

--- a/app/src/main/java/org/xbmc/kore/jsonrpc/method/Player.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/method/Player.java
@@ -18,6 +18,7 @@ package org.xbmc.kore.jsonrpc.method;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import org.xbmc.kore.jsonrpc.ApiException;
 import org.xbmc.kore.jsonrpc.ApiMethod;
 import org.xbmc.kore.jsonrpc.type.ListType;
@@ -480,6 +481,19 @@ public class Player {
                     item.put("recordingid", itemId);
                     break;
             }
+            addParameterToRequest("item", item);
+        }
+
+        /**
+         * Starts playing from a file path.
+         * This path could also point to a media type provided by an addon. eg. Youtube
+         *
+         * @param path the path that the player will play from
+         */
+        public Open(String path) {
+            super();
+            final ObjectNode item = objectMapper.createObjectNode();
+            item.put("file", path);
             addParameterToRequest("item", item);
         }
 

--- a/app/src/main/java/org/xbmc/kore/jsonrpc/type/FavouriteType.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/type/FavouriteType.java
@@ -1,0 +1,49 @@
+package org.xbmc.kore.jsonrpc.type;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.xbmc.kore.utils.JsonUtils;
+
+/**
+ * Types from Favourite.*
+ */
+public class FavouriteType {
+
+    /**
+     * Favourite.Type
+     */
+    public interface FavouriteTypeEnum {
+        String MEDIA = "media";
+        String WINDOW = "window";
+        String SCRIPT = "script";
+        String UNKNOWN = "unknown";
+    }
+
+    /**
+     * Favourite.Details.Favourite
+     */
+    public static class DetailsFavourite {
+        public static final String PATH = "path";
+        public static final String THUMBNAIL = "thumbnail";
+        public static final String TITLE = "title";
+        public static final String TYPE = "type";
+        public static final String WINDOW = "window";
+        public static final String WINDOW_PARAMETER = "windowparameter";
+
+        public final String thumbnail;
+        public final String path;
+        public final String title;
+        public final String type;
+        public final String window;
+        public final String windowParameter;
+
+        public DetailsFavourite(JsonNode node) {
+            thumbnail = JsonUtils.stringFromJsonNode(node, THUMBNAIL);
+            path = JsonUtils.stringFromJsonNode(node, PATH);
+            title = JsonUtils.stringFromJsonNode(node, TITLE);
+            type = JsonUtils.stringFromJsonNode(node, TYPE, FavouriteTypeEnum.MEDIA);
+            window = JsonUtils.stringFromJsonNode(node, WINDOW);
+            windowParameter = JsonUtils.stringFromJsonNode(node, WINDOW_PARAMETER);
+        }
+    }
+}

--- a/app/src/main/java/org/xbmc/kore/jsonrpc/type/FavouriteType.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/type/FavouriteType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 XBMC Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xbmc.kore.jsonrpc.type;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/app/src/main/java/org/xbmc/kore/ui/generic/NavigationDrawerFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/generic/NavigationDrawerFragment.java
@@ -47,6 +47,7 @@ import org.xbmc.kore.host.HostInfo;
 import org.xbmc.kore.host.HostManager;
 import org.xbmc.kore.ui.sections.addon.AddonsActivity;
 import org.xbmc.kore.ui.sections.audio.MusicActivity;
+import org.xbmc.kore.ui.sections.favourites.FavouritesActivity;
 import org.xbmc.kore.ui.sections.file.FileActivity;
 import org.xbmc.kore.ui.sections.hosts.HostManagerActivity;
 import org.xbmc.kore.ui.sections.remote.RemoteActivity;
@@ -81,9 +82,11 @@ public class NavigationDrawerFragment extends Fragment {
             ACTIVITY_TVSHOWS = 3,
             ACTIVITY_MUSIC = 4,
             ACTIVITY_PVR = 5,
-            ACTIVITY_FILES = 6,
-            ACTIVITY_ADDONS = 7,
-            ACTIVITY_SETTINGS = 8;
+            ACTIVITY_FAVOURITES = 6,
+            ACTIVITY_FILES = 7,
+            ACTIVITY_ADDONS = 8,
+            ACTIVITY_SETTINGS = 9;
+
 
     // The current selected item id (based on the activity)
     private static int selectedItemId = -1;
@@ -143,6 +146,7 @@ public class NavigationDrawerFragment extends Fragment {
                 R.attr.iconTvShows,
                 R.attr.iconMusic,
                 R.attr.iconPVR,
+                R.attr.iconFavourites,
                 R.attr.iconFiles,
                 R.attr.iconAddons,
                 R.attr.iconSettings,
@@ -179,6 +183,10 @@ public class NavigationDrawerFragment extends Fragment {
             items.add(new DrawerItem(DrawerItem.TYPE_NORMAL_ITEM, ACTIVITY_PVR,
                                      getString(R.string.pvr),
                                      styledAttributes.getResourceId(styledAttributes.getIndex(ACTIVITY_PVR), 0)));
+        if (shownItems.contains(String.valueOf(ACTIVITY_FAVOURITES)))
+            items.add(new DrawerItem(DrawerItem.TYPE_NORMAL_ITEM, ACTIVITY_FAVOURITES,
+                    getString(R.string.favourites),
+                    styledAttributes.getResourceId(styledAttributes.getIndex(ACTIVITY_FAVOURITES), 0)));
         if (shownItems.contains(String.valueOf(ACTIVITY_FILES)))
             items.add(new DrawerItem(DrawerItem.TYPE_NORMAL_ITEM, ACTIVITY_FILES,
                                      getString(R.string.files),
@@ -344,6 +352,8 @@ public class NavigationDrawerFragment extends Fragment {
             return ACTIVITY_MUSIC;
         else if (activity instanceof PVRActivity)
             return ACTIVITY_PVR;
+        else if (activity instanceof FavouritesActivity)
+            return ACTIVITY_FAVOURITES;
         else if (activity instanceof FileActivity)
             return ACTIVITY_FILES;
         else if (activity instanceof AddonsActivity)
@@ -364,6 +374,7 @@ public class NavigationDrawerFragment extends Fragment {
         activityItemIdMap.put(ACTIVITY_REMOTE, RemoteActivity.class);
         activityItemIdMap.put(ACTIVITY_MOVIES, MoviesActivity.class);
         activityItemIdMap.put(ACTIVITY_MUSIC, MusicActivity.class);
+        activityItemIdMap.put(ACTIVITY_FAVOURITES, FavouritesActivity.class);
         activityItemIdMap.put(ACTIVITY_FILES, FileActivity.class);
         activityItemIdMap.put(ACTIVITY_TVSHOWS, TVShowsActivity.class);
         activityItemIdMap.put(ACTIVITY_PVR, PVRActivity.class);

--- a/app/src/main/java/org/xbmc/kore/ui/generic/NavigationDrawerFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/generic/NavigationDrawerFragment.java
@@ -82,10 +82,10 @@ public class NavigationDrawerFragment extends Fragment {
             ACTIVITY_TVSHOWS = 3,
             ACTIVITY_MUSIC = 4,
             ACTIVITY_PVR = 5,
-            ACTIVITY_FAVOURITES = 6,
-            ACTIVITY_FILES = 7,
-            ACTIVITY_ADDONS = 8,
-            ACTIVITY_SETTINGS = 9;
+            ACTIVITY_FILES = 6,
+            ACTIVITY_ADDONS = 7,
+            ACTIVITY_SETTINGS = 8,
+            ACTIVITY_FAVOURITES = 9;
 
 
     // The current selected item id (based on the activity)
@@ -146,10 +146,10 @@ public class NavigationDrawerFragment extends Fragment {
                 R.attr.iconTvShows,
                 R.attr.iconMusic,
                 R.attr.iconPVR,
-                R.attr.iconFavourites,
                 R.attr.iconFiles,
                 R.attr.iconAddons,
                 R.attr.iconSettings,
+                R.attr.iconFavourites
         });
 
         HostInfo hostInfo = HostManager.getInstance(getActivity()).getHostInfo();

--- a/app/src/main/java/org/xbmc/kore/ui/sections/favourites/FavouritesActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/favourites/FavouritesActivity.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 XBMC Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xbmc.kore.ui.sections.favourites;
 
 import android.support.v4.app.Fragment;

--- a/app/src/main/java/org/xbmc/kore/ui/sections/favourites/FavouritesActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/favourites/FavouritesActivity.java
@@ -1,0 +1,19 @@
+package org.xbmc.kore.ui.sections.favourites;
+
+import android.support.v4.app.Fragment;
+
+import org.xbmc.kore.R;
+import org.xbmc.kore.ui.BaseMediaActivity;
+
+public class FavouritesActivity extends BaseMediaActivity {
+
+    @Override
+    protected String getActionBarTitle() {
+        return getString(R.string.favourites);
+    }
+
+    @Override
+    protected Fragment createFragment() {
+        return new FavouritesListFragment();
+    }
+}

--- a/app/src/main/java/org/xbmc/kore/ui/sections/favourites/FavouritesListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/favourites/FavouritesListFragment.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -169,7 +170,22 @@ public class FavouritesListFragment extends AbstractListFragment implements Swip
             vh.contextMenu.setVisibility(View.GONE);
 
             vh.titleView.setText(favouriteDetail.title);
-            vh.detailView.setText(favouriteDetail.type);
+
+            @StringRes final int typeRes;
+            switch (favouriteDetail.type) {
+                case FavouriteType.FavouriteTypeEnum.MEDIA:
+                    typeRes = R.string.media;
+                    break;
+                case FavouriteType.FavouriteTypeEnum.SCRIPT:
+                    typeRes = R.string.script;
+                    break;
+                case FavouriteType.FavouriteTypeEnum.WINDOW:
+                    typeRes = R.string.window;
+                    break;
+                default:
+                    typeRes = R.string.unknown;
+            }
+            vh.detailView.setText(typeRes);
 
             UIUtils.loadImageWithCharacterAvatar(getContext(), hostManager,
                     favouriteDetail.thumbnail, favouriteDetail.title,

--- a/app/src/main/java/org/xbmc/kore/ui/sections/favourites/FavouritesListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/favourites/FavouritesListFragment.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 XBMC Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xbmc.kore.ui.sections.favourites;
 
 import android.content.Context;

--- a/app/src/main/java/org/xbmc/kore/ui/sections/favourites/FavouritesListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/favourites/FavouritesListFragment.java
@@ -1,0 +1,224 @@
+package org.xbmc.kore.ui.sections.favourites;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.os.Bundle;
+import android.os.Handler;
+import android.support.annotation.LayoutRes;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v4.widget.SwipeRefreshLayout;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.GridView;
+import android.widget.ImageView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import org.xbmc.kore.R;
+import org.xbmc.kore.host.HostManager;
+import org.xbmc.kore.jsonrpc.ApiCallback;
+import org.xbmc.kore.jsonrpc.ApiList;
+import org.xbmc.kore.jsonrpc.method.Favourites;
+import org.xbmc.kore.jsonrpc.method.GUI;
+import org.xbmc.kore.jsonrpc.method.Player;
+import org.xbmc.kore.jsonrpc.type.FavouriteType;
+import org.xbmc.kore.utils.LogUtils;
+import org.xbmc.kore.utils.UIUtils;
+
+import java.util.List;
+
+import butterknife.ButterKnife;
+import butterknife.InjectView;
+
+public class FavouritesListFragment extends Fragment implements SwipeRefreshLayout.OnRefreshListener {
+    private static final String TAG = "FavouritesListFragment";
+
+    private Handler callbackHandler = new Handler();
+
+    private HostManager hostManager;
+    private FavouritesAdapter favouritesAdapter;
+
+    @InjectView(android.R.id.empty)
+    TextView emptyView;
+    @InjectView(R.id.list)
+    GridView gridView;
+    @InjectView(R.id.swipe_refresh_layout)
+    SwipeRefreshLayout swipeRefreshLayout;
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, Bundle savedInstanceState) {
+        final View root = inflater.inflate(R.layout.fragment_generic_media_list, container, false);
+        ButterKnife.inject(this, root);
+
+        hostManager = HostManager.getInstance(getActivity());
+
+        emptyView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                onRefresh();
+            }
+        });
+        gridView.setEmptyView(emptyView);
+
+        return root;
+    }
+
+    @Override
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        swipeRefreshLayout.setOnRefreshListener(this);
+        getFavourites();
+
+        final ApiCallback<String> genericApiCallback = new ApiCallback<String>() {
+            @Override
+            public void onSuccess(String result) {
+                // Do Nothing
+            }
+
+            @Override
+            public void onError(int errorCode, String description) {
+                Toast.makeText(getActivity(), description, Toast.LENGTH_SHORT).show();
+            }
+        };
+
+        gridView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+            @Override
+            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                if (favouritesAdapter == null) {
+                    return;
+                }
+
+                final FavouriteType.DetailsFavourite detailsFavourite =
+                        favouritesAdapter.getItem(position);
+                if (detailsFavourite == null) {
+                    return;
+                }
+                if (detailsFavourite.type.equals(FavouriteType.FavouriteTypeEnum.WINDOW)
+                        && !TextUtils.isEmpty(detailsFavourite.window)) {
+                    GUI.ActivateWindow activateWindow = new GUI.ActivateWindow(detailsFavourite.window,
+                            detailsFavourite.windowParameter);
+                    hostManager.getConnection().execute(activateWindow, genericApiCallback, callbackHandler);
+                } else if (detailsFavourite.type.equals(FavouriteType.FavouriteTypeEnum.MEDIA)
+                        && !TextUtils.isEmpty(detailsFavourite.path)) {
+                    Player.Open openPlayer = new Player.Open(detailsFavourite.path);
+                    hostManager.getConnection().execute(openPlayer, genericApiCallback, callbackHandler);
+                } else {
+                    Toast.makeText(getActivity(), R.string.unable_to_play_favourite_item,
+                            Toast.LENGTH_SHORT).show();
+                }
+            }
+        });
+    }
+
+    @Override
+    public void onRefresh() {
+        getFavourites();
+    }
+
+    private void getFavourites() {
+        final Favourites.GetFavourites action = new Favourites.GetFavourites();
+        hostManager.getConnection().execute(action, new ApiCallback<ApiList<FavouriteType.DetailsFavourite>>() {
+            @Override
+            public void onSuccess(ApiList<FavouriteType.DetailsFavourite> result) {
+                if (!isAdded()) return;
+                LogUtils.LOGD(TAG, "Got Favourites");
+
+                // To prevent the empty text from appearing on the first load, set it now
+                emptyView.setText(getString(R.string.no_channels_found_refresh));
+                setupFavouritesList(result.items);
+                swipeRefreshLayout.setRefreshing(false);
+            }
+
+            @Override
+            public void onError(int errorCode, String description) {
+                if (!isAdded()) return;
+                LogUtils.LOGD(TAG, "Error getting favourites: " + description);
+
+                emptyView.setText(getString(R.string.error_favourites, description));
+                Toast.makeText(getActivity(), getString(R.string.error_favourites, description),
+                        Toast.LENGTH_SHORT).show();
+                swipeRefreshLayout.setRefreshing(false);
+            }
+        }, callbackHandler);
+    }
+
+    /**
+     * Called to set the GridView with the favourites that are coming from the host.
+     *
+     * @param favourites the favourites list that is supplied to the GridView.
+     */
+    private void setupFavouritesList(List<FavouriteType.DetailsFavourite> favourites) {
+        if (favouritesAdapter == null) {
+            favouritesAdapter = new FavouritesAdapter(getActivity(), R.layout.grid_item_channel,
+                    hostManager);
+        }
+        gridView.setAdapter(favouritesAdapter);
+
+        favouritesAdapter.clear();
+        favouritesAdapter.addAll(favourites);
+        favouritesAdapter.notifyDataSetChanged();
+    }
+
+    private static class FavouritesAdapter extends ArrayAdapter<FavouriteType.DetailsFavourite> {
+
+        private final HostManager hostManager;
+        private final int artWidth, artHeight;
+
+        FavouritesAdapter(@NonNull Context context, @LayoutRes int resource, HostManager hostManager) {
+            super(context, resource);
+            this.hostManager = hostManager;
+            Resources resources = context.getResources();
+            artWidth = (int) (resources.getDimension(R.dimen.channellist_art_width) /
+                    UIUtils.IMAGE_RESIZE_FACTOR);
+            artHeight = (int) (resources.getDimension(R.dimen.channellist_art_heigth) /
+                    UIUtils.IMAGE_RESIZE_FACTOR);
+        }
+
+        @NonNull
+        @Override
+        public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+            if (convertView == null) {
+                convertView = LayoutInflater.from(getContext()).inflate(R.layout.grid_item_channel,
+                        parent, false);
+                final FavouriteItemViewHolder vh = new FavouriteItemViewHolder(convertView);
+                convertView.setTag(vh);
+            }
+
+            final FavouriteItemViewHolder vh = (FavouriteItemViewHolder) convertView.getTag();
+            final FavouriteType.DetailsFavourite favouriteDetail = getItem(position);
+
+            // We don't need the context menu here.
+            vh.contextMenu.setVisibility(View.GONE);
+
+            vh.titleView.setText(favouriteDetail.title);
+            vh.detailView.setText(favouriteDetail.type);
+
+            UIUtils.loadImageWithCharacterAvatar(getContext(), hostManager,
+                    favouriteDetail.thumbnail, favouriteDetail.title,
+                    vh.artView, artWidth, artHeight);
+
+            return convertView;
+        }
+    }
+
+    private static class FavouriteItemViewHolder {
+        final ImageView artView;
+        final ImageView contextMenu;
+        final TextView titleView;
+        final TextView detailView;
+
+        FavouriteItemViewHolder(View v) {
+            artView = ButterKnife.findById(v, R.id.art);
+            contextMenu = ButterKnife.findById(v, R.id.list_context_menu);
+            titleView = ButterKnife.findById(v, R.id.title);
+            detailView = ButterKnife.findById(v, R.id.details);
+        }
+    }
+}

--- a/app/src/main/java/org/xbmc/kore/ui/sections/favourites/FavouritesListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/favourites/FavouritesListFragment.java
@@ -40,10 +40,11 @@ import org.xbmc.kore.jsonrpc.ApiCallback;
 import org.xbmc.kore.jsonrpc.ApiList;
 import org.xbmc.kore.jsonrpc.method.Favourites;
 import org.xbmc.kore.jsonrpc.method.GUI;
-import org.xbmc.kore.jsonrpc.method.Player;
 import org.xbmc.kore.jsonrpc.type.FavouriteType;
+import org.xbmc.kore.jsonrpc.type.PlaylistType;
 import org.xbmc.kore.ui.AbstractListFragment;
 import org.xbmc.kore.utils.LogUtils;
+import org.xbmc.kore.utils.MediaPlayerUtils;
 import org.xbmc.kore.utils.UIUtils;
 
 import java.util.List;
@@ -92,8 +93,9 @@ public class FavouritesListFragment extends AbstractListFragment implements Swip
                     hostManager.getConnection().execute(activateWindow, genericApiCallback, callbackHandler);
                 } else if (detailsFavourite.type.equals(FavouriteType.FavouriteTypeEnum.MEDIA)
                         && !TextUtils.isEmpty(detailsFavourite.path)) {
-                    Player.Open openPlayer = new Player.Open(detailsFavourite.path);
-                    hostManager.getConnection().execute(openPlayer, genericApiCallback, callbackHandler);
+                    final PlaylistType.Item playlistItem = new PlaylistType.Item();
+                    playlistItem.file = detailsFavourite.path;
+                    MediaPlayerUtils.play(FavouritesListFragment.this, playlistItem);
                 } else {
                     Toast.makeText(getActivity(), R.string.unable_to_play_favourite_item,
                             Toast.LENGTH_SHORT).show();

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -62,9 +62,9 @@
         <item>@string/tv_shows</item>
         <item>@string/music</item>
         <item>@string/pvr</item>
+        <item>@string/favourites</item>
         <item>@string/files</item>
         <item>@string/addons</item>
-        <item>@string/favourites</item>
     </string-array>
 
     <!-- Download connection types -->
@@ -111,9 +111,9 @@
         <item>3</item>
         <item>4</item>
         <item>5</item>
+        <item>9</item>
         <item>6</item>
         <item>7</item>
-        <item>9</item>
     </string-array>
 
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -112,6 +112,7 @@
         <item>5</item>
         <item>6</item>
         <item>7</item>
+        <item>8</item>
     </string-array>
 
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -64,6 +64,7 @@
         <item>@string/pvr</item>
         <item>@string/files</item>
         <item>@string/addons</item>
+        <item>@string/favourites</item>
     </string-array>
 
     <!-- Download connection types -->
@@ -112,7 +113,7 @@
         <item>5</item>
         <item>6</item>
         <item>7</item>
-        <item>8</item>
+        <item>9</item>
     </string-array>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,10 @@
     <string name="files">Files</string>
     <string name="video">Video</string>
     <string name="videos">Videos</string>
+    <string name="media">Media</string>
+    <string name="window">Window</string>
+    <string name="script">Script</string>
+    <string name="unknown">Unknown</string>
     <string name="file_browser">File Browser</string>
     <string name="pvr">PVR</string>
     <string name="favourites">Favourites</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -248,6 +248,7 @@
     <string name="no_music_videos_found_refresh">No videos found\n\nSwipe down to refresh</string>
     <string name="no_channel_groups_found_refresh">No channel groups found.\n\nSwipe down to refresh</string>
     <string name="no_channels_found_refresh">No channels found.\n\nSwipe down to refresh</string>
+    <string name="no_favourites_found_refresh">No favourites found.\n\nSwipe down to refresh</string>
     <string name="no_recordings_found_refresh">No recordings found.\n\nSwipe down to refresh</string>
     <string name="no_broadcasts_found_refresh">No broadcasts found.\n\nSwipe down to refresh</string>
     <string name="pull_to_refresh">Pull to refresh</string>
@@ -373,6 +374,7 @@
     <string name="error_getting_pvr_info">An error occurred while getting pvr info: %1$s</string>
     <string name="might_not_have_pvr">An error occurred while getting channels info, probably because your media center doesn\'t have a tuner or it isn\'t configured.\n\nIf that\'s the case and you\'d like to remove this entry from the side menu, you can do it in the Settings.</string>
     <string name="error_starting_channel">An error occurred starting channel playback: %1$s</string>
+    <string name="error_favourites">An error occurred while getting the favourites with description: %1$s</string>
     <string name="error_starting_recording">An error occurred starting a recording: %1$s</string>
     <string name="error_starting_to_record">An error occurred while recording: %1$s</string>
     <string name="channel_switching">Switching to channel %1$s</string>
@@ -388,6 +390,7 @@
     <string name="record">Record</string>
     <string name="pvr_epg">Guide</string>
     <string name="unable_to_move_item">Unable to move item</string>
+    <string name="unable_to_play_favourite_item">Unable to play favourite item. Unsupported Type</string>
     <string name="cannot_move_playing_item">Cannot move currently playing/paused item</string>
     <string name="no_connection_type_selected">No connection type selected in settings</string>
     <string name="single_column">Single column</string>


### PR DESCRIPTION
This PR introduces getting favourites from Kodi to Kore. 
The favourite types that are supported are just the `window` and `media`.

Here is a demonstration of the favourites list that is retrieved from my Kodi box, please note that I'm using the same layout as in the PVRChannelsListFragment.

![favourites list](https://cloud.githubusercontent.com/assets/297007/25683973/fac9abd6-305e-11e7-9588-34a66909950f.png)

