### PR TITLE
Fix ClassCastException when Favourites returned are empty.

### DIFF
--- a/app/src/main/java/org/xbmc/kore/jsonrpc/method/Favourites.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/method/Favourites.java
@@ -60,7 +60,7 @@ public class Favourites {
             ListType.LimitsReturned limits = new ListType.LimitsReturned(jsonObject);
 
             JsonNode resultNode = jsonObject.get(RESULT_NODE);
-            ArrayNode items = resultNode.has(LIST_NODE) ?
+            ArrayNode items = resultNode.has(LIST_NODE) && !resultNode.get(LIST_NODE).isNull() ?
                     (ArrayNode) resultNode.get(LIST_NODE) : null;
             if (items == null) {
                 return new ApiList<>(Collections.<FavouriteType.DetailsFavourite>emptyList(), limits);


### PR DESCRIPTION
The exception happens because Kodi returns `null` inside the list node when the list returned is empty.