### PR TITLE
Fixed issue with filenames that contain question marks

### DIFF
--- a/app/src/main/java/org/xbmc/kore/utils/FileDownloadHelper.java
+++ b/app/src/main/java/org/xbmc/kore/utils/FileDownloadHelper.java
@@ -42,6 +42,9 @@ import java.util.List;
 public class FileDownloadHelper {
     private static final String TAG = LogUtils.makeLogTag(FileDownloadHelper.class);
 
+    // These chars cause problems with DownloadManager
+    private static final String RESERVED_CHARS_REGEX = "[?]";
+
     public static final int OVERWRITE_FILES = 0,
             DOWNLOAD_WITH_NEW_NAME = 1;
 
@@ -80,16 +83,18 @@ public class FileDownloadHelper {
 
         public String getAbsoluteDirectoryPath() {
             File externalFilesDir = Environment.getExternalStoragePublicDirectory(getExternalPublicDirType());
-            return externalFilesDir.getPath() + "/" + getRelativeDirectoryPath();
-
+            String filePath = externalFilesDir.getPath() + "/" + getRelativeDirectoryPath();
+            return filePath.replaceAll(RESERVED_CHARS_REGEX, "_");
         }
 
         public String getAbsoluteFilePath() {
-            return getAbsoluteDirectoryPath() + "/" + getDownloadFileName();
+            String filePath = getAbsoluteDirectoryPath() + "/" + getDownloadFileName();
+            return filePath.replaceAll(RESERVED_CHARS_REGEX, "_");
         }
 
         public String getRelativeFilePath() {
-            return getRelativeDirectoryPath() + "/" + getDownloadFileName();
+            String filePath = getRelativeDirectoryPath() + "/" + getDownloadFileName();
+            return filePath.replaceAll(RESERVED_CHARS_REGEX, "_");
         }
 
         public abstract String getExternalPublicDirType();


### PR DESCRIPTION
Question mark in album names result in very strange behaviour when downloading the album.
The album directory is created but all songs are placed inside the artist directory.

For instance 

```
Artist/
       Album?/
              1 - Song.mp3
              2 - Song.mp3
```

results on the Android device in

```
Artist/
      Album/
      Album-1
      Album-2
```

This seems to be an issue with DownloadManager not escaping the question mark character. I don't know if other characters cause problems as well. We can add them when we encounter them.