### PR TITLE
Implemented a HighlightButton widget

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
@@ -17,7 +17,6 @@ package org.xbmc.kore.ui.sections.remote;
 
 import android.app.Activity;
 import android.content.res.Resources;
-import android.content.res.TypedArray;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.v4.app.Fragment;
@@ -55,9 +54,10 @@ import org.xbmc.kore.jsonrpc.type.PlayerType;
 import org.xbmc.kore.jsonrpc.type.VideoType;
 import org.xbmc.kore.ui.generic.GenericSelectDialog;
 import org.xbmc.kore.ui.sections.video.AllCastActivity;
+import org.xbmc.kore.ui.widgets.HighlightButton;
 import org.xbmc.kore.ui.widgets.MediaProgressIndicator;
-import org.xbmc.kore.ui.widgets.VolumeLevelIndicator;
 import org.xbmc.kore.ui.widgets.RepeatModeButton;
+import org.xbmc.kore.ui.widgets.VolumeLevelIndicator;
 import org.xbmc.kore.utils.LogUtils;
 import org.xbmc.kore.utils.UIUtils;
 import org.xbmc.kore.utils.Utils;
@@ -136,9 +136,9 @@ public class NowPlayingFragment extends Fragment
     @InjectView(R.id.rewind) ImageButton rewindButton;
     @InjectView(R.id.fast_forward) ImageButton fastForwardButton;
 
-    @InjectView(R.id.volume_mute) ImageButton volumeMuteButton;
-    @InjectView(R.id.shuffle) ImageButton shuffleButton;
     @InjectView(R.id.repeat) RepeatModeButton repeatButton;
+    @InjectView(R.id.volume_mute) HighlightButton volumeMuteButton;
+    @InjectView(R.id.shuffle) HighlightButton shuffleButton;
     @InjectView(R.id.overflow) ImageButton overflowButton;
 
     @InjectView(R.id.info_panel) RelativeLayout infoPanel;
@@ -775,21 +775,9 @@ public class NowPlayingFragment extends Fragment
             mediaDescription.setVisibility(View.GONE);
         }
 
-        Resources.Theme theme = getActivity().getTheme();
-        TypedArray styledAttributes = theme.obtainStyledAttributes(new int[]{
-                R.attr.colorAccent,
-                R.attr.iconRepeat,
-                R.attr.iconRepeatOne});
-        int accentDefaultColor = getResources().getColor(R.color.accent_default);
-
         UIUtils.setRepeatButton(repeatButton, getPropertiesResult.repeat);
 
-        if (!getPropertiesResult.shuffled) {
-            shuffleButton.clearColorFilter();
-        } else {
-            shuffleButton.setColorFilter(styledAttributes.getColor(styledAttributes.getIndex(0), accentDefaultColor));
-        }
-        styledAttributes.recycle();
+        shuffleButton.setHighlight(getPropertiesResult.shuffled);
 
         Resources resources = getActivity().getResources();
         DisplayMetrics displayMetrics = new DisplayMetrics();

--- a/app/src/main/java/org/xbmc/kore/ui/widgets/HighlightButton.java
+++ b/app/src/main/java/org/xbmc/kore/ui/widgets/HighlightButton.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 Martijn Brekhof. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.xbmc.kore.ui.widgets;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.content.res.TypedArray;
+import android.support.v7.widget.AppCompatImageButton;
+import android.util.AttributeSet;
+
+import org.xbmc.kore.R;
+
+public class HighlightButton extends AppCompatImageButton {
+    private int colorFilter;
+
+    private boolean highlight;
+
+    public HighlightButton(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        Resources.Theme theme = context.getTheme();
+        TypedArray styledAttributes = theme.obtainStyledAttributes(new int[]{
+                R.attr.colorAccent});
+        colorFilter = styledAttributes.getColor(styledAttributes.getIndex(0),
+                                  context.getResources().getColor(R.color.accent_default));
+        styledAttributes.recycle();
+    }
+
+    public void setHighlight(boolean highlight) {
+        if (highlight) {
+            setColorFilter(colorFilter);
+        } else {
+            clearColorFilter();
+        }
+        this.highlight = highlight;
+    }
+
+    public boolean isHighlighted() {
+        return highlight;
+    }
+}

--- a/app/src/main/res/layout/fragment_now_playing.xml
+++ b/app/src/main/res/layout/fragment_now_playing.xml
@@ -161,7 +161,7 @@
                 style="@style/ButtonBar"
                 android:background="?attr/contentBackgroundColor">
 
-                <ImageButton
+                <org.xbmc.kore.ui.widgets.HighlightButton
                     android:id="@+id/volume_mute"
                     android:layout_width="0dp"
                     android:layout_weight="1"
@@ -183,7 +183,7 @@
                     style="@style/Widget.Button.Borderless"
                     android:src="?attr/iconRepeat"
                     android:contentDescription="@string/repeat"/>
-                <ImageButton
+                <org.xbmc.kore.ui.widgets.HighlightButton
                     android:id="@+id/shuffle"
                     android:layout_width="0dp"
                     android:layout_weight="1"


### PR DESCRIPTION
This can be used by buttons that need to be highlighted such as
the shuffle and the mute buttons.

I've refactored NowPlayingFragment to use the new widget.
The main reason for implementing this widget is to allow testing of mute and shuffle button states.