### PR TITLE
fix text formatting in german translation

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -343,7 +343,7 @@
         \u00A9 2017 XBMC Foundation<br><br>
         Bitte bewerten Sie uns bei <b><a href="market://details?id=org.xbmc.kore">Google Play</a></b><br><br>
 
-        Wenn Sie Hilfe brauchen, sehen Sie sich unser <b><a href="http://forum.kodi.tv/forumdisplay.php?fid=129">Forum</a> an.</b>
+        Wenn Sie Hilfe brauchen, schauen Sie in unserem <b><a href="http://forum.kodi.tv/forumdisplay.php?fid=129">Forum</a></b> vorbei.
     ]]></string>
 
     <!--&lt;!&ndash; String for coffee &ndash;&gt;-->


### PR DESCRIPTION
Before the "an" was bold