### PR TITLE
Upgraded android gradle plugin to 2.3.3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -162,3 +162,14 @@ afterEvaluate {
         }
     }
 }
+
+/**
+ * Android gradle plugin 2.3.x contains a bug where the assets for fullDebug
+ * are not copied. The task assembleFullDebug does copy the required assets,
+ * so this dependency fixes the issue.
+ */
+tasks.whenTaskAdded { task ->
+    if (task.name.contains("testFullDebugUnitTest")) {
+        task.dependsOn assembleFullDebug
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Aug 24 16:59:02 CEST 2016
+#Fri Aug 04 21:29:21 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
   * Added dependency on assembleFullDebug before running unit tests.
     Apparently assembleFullDebugUnitTest does not include
     the sourceset for fullDebug as defined in app/build.gradle