### PR TITLE
Improved usability for NowPlayingPanel

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/widgets/NowPlayingPanel.java
+++ b/app/src/main/java/org/xbmc/kore/ui/widgets/NowPlayingPanel.java
@@ -24,6 +24,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageButton;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import com.sothree.slidinguppanel.SlidingUpPanelLayout;
@@ -49,6 +50,7 @@ public class NowPlayingPanel extends SlidingUpPanelLayout {
 
     private OnPanelButtonsClickListener onPanelButtonsClickListener;
 
+    @InjectView(R.id.npp_collapsed_view) LinearLayout collapsedView;
     @InjectView(R.id.npp_title) TextView title;
     @InjectView(R.id.npp_details) TextView details;
     @InjectView(R.id.npp_poster) ImageView poster;
@@ -80,6 +82,7 @@ public class NowPlayingPanel extends SlidingUpPanelLayout {
         LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         View view = inflater.inflate(R.layout.now_playing_panel, this);
         ButterKnife.inject(view);
+        setDragView(collapsedView);
         setupButtonClickListeners();
     }
 

--- a/app/src/main/res/layout/activity_generic_media.xml
+++ b/app/src/main/res/layout/activity_generic_media.xml
@@ -35,7 +35,6 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:gravity="bottom"
-            sothree:umanoPanelHeight="@dimen/now_playing_panel_height"
             sothree:umanoShadowHeight="4dp"
             sothree:umanoFadeColor="#00000000"
             sothree:umanoInitialState="hidden"/>

--- a/app/src/main/res/layout/media_progress_indicator.xml
+++ b/app/src/main/res/layout/media_progress_indicator.xml
@@ -25,7 +25,7 @@
         android:id="@+id/mpi_seek_bar"
         android:layout_width="0dp"
         android:layout_weight="1"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:layout_margin="4dp"/>
     <TextView
         android:id="@+id/mpi_duration"

--- a/app/src/main/res/layout/now_playing_panel.xml
+++ b/app/src/main/res/layout/now_playing_panel.xml
@@ -14,7 +14,9 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-<merge xmlns:android="http://schemas.android.com/apk/res/android">
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:sothree="http://schemas.android.com/apk/res-auto"
+       sothree:umanoPanelHeight="@dimen/now_playing_panel_height">
 
     <FrameLayout
         android:id="@+id/fragment_container"
@@ -26,6 +28,7 @@
                   android:orientation="vertical">
 
         <LinearLayout
+            android:id="@+id/npp_collapsed_view"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
@@ -111,8 +114,7 @@
         <org.xbmc.kore.ui.widgets.MediaProgressIndicator
             android:id="@+id/npp_progress_indicator"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="@dimen/default_padding"
+            android:layout_height="@dimen/buttonbar_height"
             android:paddingRight="@dimen/small_padding"
             android:paddingLeft="@dimen/small_padding"
             android:orientation="horizontal"


### PR DESCRIPTION
   * Panel now only closes when collapsed bar is clicked.
     This prevents unwanted closing when using the sliders and
     buttons.
   * Moved collapsed panel size to the compound view so users
     of the NowPlayingPanel don't need to look inside the
     compound view layout to determine the correct size.