### PR TITLE
Trying to fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ sudo: false
 env:
   matrix:
     - ANDROID_TARGET=android-25
+  global:
+    - GRADLE_OPTS="-Xms128m"
 
 android:
   components:


### PR DESCRIPTION
Hypothesis 1: The gradle executor gets killed because it consumes too much memory.
Confirmed.
