### PR TITLE
Removed dependency on GridLayout in SquareGridLayout

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -115,7 +115,6 @@ dependencies {
     compile "com.android.support:cardview-v7:${supportLibVersion}"
     compile "com.android.support:preference-v14:${supportLibVersion}"
     compile "com.android.support:support-v13:${supportLibVersion}"
-    compile "com.android.support:gridlayout-v7:${supportLibVersion}"
 
     compile 'com.fasterxml.jackson.core:jackson-databind:2.5.2'
     compile 'com.jakewharton:butterknife:6.1.0'

--- a/app/src/main/java/org/xbmc/kore/ui/viewgroups/SquareGridLayout.java
+++ b/app/src/main/java/org/xbmc/kore/ui/viewgroups/SquareGridLayout.java
@@ -15,46 +15,121 @@
  */
 package org.xbmc.kore.ui.viewgroups;
 
-
 import android.content.Context;
-import android.support.v7.widget.GridLayout;
+import android.content.res.TypedArray;
 import android.util.AttributeSet;
+import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewParent;
 import android.view.ViewTreeObserver;
 import android.widget.RelativeLayout;
 
-import org.xbmc.kore.utils.LogUtils;
+import org.xbmc.kore.R;
 
 /**
  * The square grid layout creates a square layout that will fit inside
- * the boundaries provided by the parent layout.
+ * the boundaries provided by the parent layout. Note that all cells
+ * will have the same size.
+ *
+ * The attribute columnCount is available to specify the amount of columns
+ * when using SquareGridLayout in a XML layout file.
  */
-public class SquareGridLayout extends GridLayout {
+public class SquareGridLayout extends ViewGroup {
+
+    private int columnCount = 1;
+    private int cellSize;
 
     public SquareGridLayout(Context context) {
-        super(context);
-        fixForRelativeLayout();
+        this(context, null);
     }
 
     public SquareGridLayout(Context context, AttributeSet attrs) {
-        super(context, attrs);
-        fixForRelativeLayout();
+        this(context, attrs, 0);
     }
 
     public SquareGridLayout(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
+        TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.SquareGridLayout, 0, 0);
+        setColumnCount(a.getInt(R.styleable.SquareGridLayout_columnCount, 1));
+        a.recycle();
         fixForRelativeLayout();
     }
 
-    @Override
-    protected void onMeasure(int widthSpec, int heightSpec) {
-        int width = MeasureSpec.getSize(widthSpec);
-        int height = MeasureSpec.getSize(heightSpec);
-        int size = Math.min(width, height);
+    public void setColumnCount(int columnCount) {
+        if (columnCount < 1) throw new IllegalArgumentException("Column count must be 1 or more");
+        this.columnCount = columnCount;
+    }
 
-        super.onMeasure(MeasureSpec.makeMeasureSpec(size, MeasureSpec.EXACTLY),
-                        MeasureSpec.makeMeasureSpec(size, MeasureSpec.EXACTLY));
+    /**
+     * Methods overridden to make sure we pass in the correct layout parameters for the child views
+     */
+    @Override
+    protected LayoutParams generateLayoutParams(LayoutParams p) {
+        return new MarginLayoutParams(p);
+    }
+
+    @Override
+    public LayoutParams generateLayoutParams(AttributeSet attrs) {
+        return new MarginLayoutParams(getContext(), attrs);
+    }
+
+    @Override
+    protected LayoutParams generateDefaultLayoutParams() {
+        return new MarginLayoutParams(MarginLayoutParams.WRAP_CONTENT,
+                                      MarginLayoutParams.WRAP_CONTENT);
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        int width = MeasureSpec.getSize(widthMeasureSpec);
+        int height = MeasureSpec.getSize(heightMeasureSpec);
+
+        int paddingWidth = getPaddingLeft() + getPaddingRight();
+        int paddingHeight = getPaddingTop() + getPaddingBottom();
+
+        int size;
+        int padding;
+        if ((width - paddingWidth) < (height - paddingHeight)) {
+            size = width;
+            padding = size - paddingWidth;
+        } else {
+            size = height;
+            padding = size - paddingHeight;
+        }
+
+        for (int y = 0; y < columnCount; y++) {
+            for (int x = 0; x < columnCount; x++) {
+                View child = getChildAt(y * size + x);
+                if (child != null) {
+                    measureChildWithMargins(child,
+                                            MeasureSpec.makeMeasureSpec((padding + x) / columnCount, MeasureSpec.EXACTLY),
+                                            0,
+                                            MeasureSpec.makeMeasureSpec((padding + y) / columnCount, MeasureSpec.EXACTLY),
+                                            0);
+                }
+            }
+        }
+
+        setMeasuredDimension(size, size);
+        cellSize = padding;
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        // top left is used to position child views
+        left = getPaddingLeft();
+        top = getPaddingTop();
+
+        for (int y = 0; y < columnCount; y++) {
+            for (int x = 0; x < columnCount; x++) {
+                View child = getChildAt(y * columnCount + x);
+                MarginLayoutParams childLayoutParams = (MarginLayoutParams) child.getLayoutParams();
+                child.layout(left + (cellSize *  x) / columnCount + childLayoutParams.leftMargin,
+                             top + (cellSize * y) / columnCount + childLayoutParams.topMargin,
+                             left + (cellSize * (x+1)) / columnCount - childLayoutParams.rightMargin,
+                             top + (cellSize * (y+1)) / columnCount - childLayoutParams.bottomMargin
+                            );
+            }
+        }
     }
 
     /**

--- a/app/src/main/res/layout/remote_control_pad.xml
+++ b/app/src/main/res/layout/remote_control_pad.xml
@@ -14,33 +14,23 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-<merge xmlns:android="http://schemas.android.com/apk/res/android"
-       xmlns:app="http://schemas.android.com/apk/res-auto">
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
     <ImageView
         android:id="@+id/context"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_columnWeight="1"
-        app:layout_rowWeight="1"
-        app:layout_gravity="fill"
         android:src="?attr/iconContext"
         android:contentDescription="@string/codec_info"/>
     <ImageView
         android:id="@+id/up"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_columnWeight="1"
-        app:layout_rowWeight="1"
-        app:layout_gravity="fill"
         android:src="?attr/iconUp"
         android:contentDescription="@string/up"/>
     <ImageView
         android:id="@+id/info"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_columnWeight="1"
-        app:layout_rowWeight="1"
-        app:layout_gravity="fill"
         android:src="?attr/iconInfo"
         android:contentDescription="@string/info"/>
 
@@ -48,27 +38,18 @@
         android:id="@+id/left"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_columnWeight="1"
-        app:layout_rowWeight="1"
-        app:layout_gravity="fill"
         android:src="?attr/iconLeft"
         android:contentDescription="@string/left"/>
     <ImageView
         android:id="@+id/select"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_columnWeight="1"
-        app:layout_rowWeight="1"
-        app:layout_gravity="fill"
         android:src="?attr/iconSelect"
         android:contentDescription="@string/select"/>
     <ImageView
         android:id="@+id/right"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_columnWeight="1"
-        app:layout_rowWeight="1"
-        app:layout_gravity="fill"
         android:src="?attr/iconRight"
         android:contentDescription="@string/right"/>
 
@@ -76,27 +57,18 @@
         android:id="@+id/back"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_columnWeight="1"
-        app:layout_rowWeight="1"
-        app:layout_gravity="fill"
         android:src="?attr/iconBack"
         android:contentDescription="@string/back"/>
     <ImageView
         android:id="@+id/down"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_columnWeight="1"
-        app:layout_rowWeight="1"
-        app:layout_gravity="fill"
         android:src="?attr/iconDown"
         android:contentDescription="@string/down"/>
     <ImageView
         android:id="@+id/osd"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_columnWeight="1"
-        app:layout_rowWeight="1"
-        app:layout_gravity="fill"
         android:src="?attr/iconMenu"
         android:contentDescription="@string/osd"/>
 </merge>

--- a/app/src/main/res/values/attr.xml
+++ b/app/src/main/res/values/attr.xml
@@ -38,20 +38,20 @@
 
     <attr name="separatorColor" format="reference|color" />
 
-	<attr name="drawerBackgroundColor" format="reference|color" />
+    <attr name="drawerBackgroundColor" format="reference|color" />
 
     <attr name="remoteButtonColorFilter" format="reference|color" />
     <attr name="defaultButtonColorFilter" format="reference|color" />
     <!--<attr name="remoteBackgroundColorFilter" format="reference|color" />-->
 
     <!-- Icons -->
-	<attr name="iconHosts" format="reference" />
-	<attr name="iconRemote" format="reference" />
+    <attr name="iconHosts" format="reference" />
+    <attr name="iconRemote" format="reference" />
     <attr name="iconRemoteToolbar" format="reference" />
-	<attr name="iconMovies" format="reference" />
-	<attr name="iconTvShows" format="reference" />
-	<attr name="iconMusic" format="reference" />
-	<attr name="iconPicture" format="reference" />
+    <attr name="iconMovies" format="reference" />
+    <attr name="iconTvShows" format="reference" />
+    <attr name="iconMusic" format="reference" />
+    <attr name="iconPicture" format="reference" />
     <attr name="iconHome" format="reference" />
     <attr name="iconAddons" format="reference" />
     <attr name="iconFiles" format="reference" />
@@ -113,4 +113,8 @@
 
     <attr name="iconOpenInNew" format="reference" />
     <attr name="iconBookmark" format="reference" />
+
+    <declare-styleable name="SquareGridLayout">
+        <attr name="columnCount" format="integer"/>
+    </declare-styleable>
 </resources>


### PR DESCRIPTION
Hopefully this fixes the heisenbug we encountered during the beta release as mentioned in #444 

   * Removed using the GridLayout from the support library
     as this might be causing problems on devices that don't
     include the library correctly.
   * Replaced using the GridLayout measurement and layout implementations
     by our own implementation of a simple grid layout that will evenly distribute
     its children among a square sized grid.