### PR TITLE
unit test IDE execution improvements

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,6 +38,19 @@ android {
         }
     }
 
+    testOptions {
+        unitTests.all {
+            // All the usual Gradle options.
+            testLogging {
+                events "failed", "standardOut", "standardError"
+                outputs.upToDateWhen {
+                    false
+                }
+                showStandardStreams = true
+            }
+        }
+    }
+    
     sourceSets {
         fullDebug {
             assets.srcDirs += 'src/testUtils/assets'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -160,6 +160,9 @@ afterEvaluate {
         if (task.name.startsWith('assembleInstrumentationTestDebugAndroidTest')) {
             task.dependsOn grantAnimationPermissionDev
         }
+        else if (task.name.endsWith('UnitTestSources')) {
+            task.dependsOn copyUnitTestResources
+        }
     }
 }
 
@@ -172,4 +175,9 @@ tasks.whenTaskAdded { task ->
     if (task.name.contains("testFullDebugUnitTest")) {
         task.dependsOn assembleFullDebug
     }
+}
+
+task copyUnitTestResources(type: Copy) {
+    from "$rootDir.absoluteFile/app/src/testUtils/assets";
+    into "$buildDir/assets"
 }

--- a/app/src/test/java/org/xbmc/kore/provider/mediaprovider/AbstractTestClass.java
+++ b/app/src/test/java/org/xbmc/kore/provider/mediaprovider/AbstractTestClass.java
@@ -50,6 +50,6 @@ public class AbstractTestClass {
 
         hostInfo = Database.addHost(RuntimeEnvironment.application);
 
-        Database.fill(hostInfo, RuntimeEnvironment.application, contentResolver);
+        Database.fill(hostInfo, RuntimeEnvironment.application, contentResolver, true);
     }
 }

--- a/app/src/testUtils/java/org/xbmc/kore/testutils/Database.java
+++ b/app/src/testUtils/java/org/xbmc/kore/testutils/Database.java
@@ -44,18 +44,42 @@ public class Database {
     public static final String TAG = LogUtils.makeLogTag(Database.class);
 
     public static HostInfo fill(HostInfo hostInfo, Context context, ContentResolver contentResolver) throws ApiException, IOException {
+        return fill(hostInfo, context, contentResolver, false);
+    }
+
+    public static HostInfo fill(HostInfo hostInfo, Context context, ContentResolver contentResolver,
+            boolean isJVMTest) throws ApiException, IOException {
         SyncMusic syncMusic = new SyncMusic(hostInfo.getId(), null);
-        insertMovies(context, contentResolver, hostInfo.getId());
-        insertArtists(context, contentResolver, syncMusic);
-        insertGenres(context, contentResolver, syncMusic);
-        insertAlbums(context, contentResolver, syncMusic);
-        insertSongs(context, contentResolver, syncMusic);
+        if (isJVMTest) {
+            insertMovies(contentResolver, hostInfo.getId());
+            insertArtists(contentResolver, syncMusic);
+            insertGenres(contentResolver, syncMusic);
+            insertAlbums(contentResolver, syncMusic);
+            insertSongs(contentResolver, syncMusic);
+        }
+        else {
+            insertMovies(context, contentResolver, hostInfo.getId());
+            insertArtists(context, contentResolver, syncMusic);
+            insertGenres(context, contentResolver, syncMusic);
+            insertAlbums(context, contentResolver, syncMusic);
+            insertSongs(context, contentResolver, syncMusic);
+        }
 
         SyncTVShows syncTVShows = new SyncTVShows(hostInfo.getId(), null);
-        insertTVShows(context, contentResolver, syncTVShows);
+        if (isJVMTest) {
+            insertTVShows(contentResolver, syncTVShows);
+        }
+        else {
+            insertTVShows(context, contentResolver, syncTVShows);
+        }
 
         SyncMusicVideos syncMusicVideos = new SyncMusicVideos(hostInfo.getId(), null);
-        insertMusicVideos(context, contentResolver, syncMusicVideos);
+        if (isJVMTest) {
+            insertMusicVideos(contentResolver, syncMusicVideos);
+        }
+        else {
+            insertMusicVideos(context, contentResolver, syncMusicVideos);
+        }
 
         return hostInfo;
     }
@@ -81,12 +105,21 @@ public class Database {
                                                         false);
     }
 
+    private static void insertMovies(ContentResolver contentResolver, int hostId)
+            throws ApiException, IOException {
+        String result = FileUtils.readFile("Video.Details.Movie.json");
+        insertMovies(contentResolver, hostId, result);
+    }
+
     private static void insertMovies(Context context, ContentResolver contentResolver, int hostId)
             throws ApiException, IOException {
-        VideoLibrary.GetMovies getMovies = new VideoLibrary.GetMovies();
         String result = FileUtils.readFile(context, "Video.Details.Movie.json");
-        ApiList<VideoType.DetailsMovie> movieList = getMovies.resultFromJson(result);
+        insertMovies(contentResolver, hostId, result);
+    }
 
+    private static void insertMovies(ContentResolver contentResolver, int hostId, String result)
+            throws ApiException {VideoLibrary.GetMovies getMovies = new VideoLibrary.GetMovies();
+        ApiList<VideoType.DetailsMovie> movieList = getMovies.resultFromJson(result);
 
         ContentValues movieValuesBatch[] = new ContentValues[movieList.items.size()];
         int castCount = 0;
@@ -115,34 +148,69 @@ public class Database {
     }
 
     private static void insertArtists(Context context, ContentResolver contentResolver, SyncMusic syncMusic) throws ApiException, IOException {
-        AudioLibrary.GetArtists getArtists = new AudioLibrary.GetArtists(false);
         String result = FileUtils.readFile(context, "AudioLibrary.GetArtists.json");
+        insertArtists(contentResolver, syncMusic, result);
+    }
+
+    private static void insertArtists(ContentResolver contentResolver, SyncMusic syncMusic) throws ApiException, IOException {
+        String result = FileUtils.readFile("AudioLibrary.GetArtists.json");
+        insertArtists(contentResolver, syncMusic, result);
+    }
+
+    private static void insertArtists(ContentResolver contentResolver, SyncMusic syncMusic,
+            String result) throws ApiException {AudioLibrary.GetArtists getArtists = new AudioLibrary.GetArtists(false);
         ArrayList<AudioType.DetailsArtist> artistList = (ArrayList) getArtists.resultFromJson(result).items;
 
         syncMusic.insertArtists(artistList, contentResolver);
     }
 
     private static void insertGenres(Context context, ContentResolver contentResolver, SyncMusic syncMusic) throws ApiException, IOException {
-        AudioLibrary.GetGenres getGenres = new AudioLibrary.GetGenres();
-        ArrayList<LibraryType.DetailsGenre> genreList =
-                (ArrayList) getGenres.resultFromJson(FileUtils.readFile(context,
-                                                                        "AudioLibrary.GetGenres.json"));
+        String result = FileUtils.readFile(context, "AudioLibrary.GetGenres.json");
+        insertGenres(contentResolver, syncMusic, result);
+    }
+
+    private static void insertGenres(ContentResolver contentResolver, SyncMusic syncMusic) throws ApiException, IOException {
+        String result = FileUtils.readFile("AudioLibrary.GetGenres.json");
+        insertGenres(contentResolver, syncMusic, result);
+    }
+
+    private static void insertGenres(ContentResolver contentResolver, SyncMusic syncMusic,
+            String result) throws ApiException {AudioLibrary.GetGenres getGenres = new AudioLibrary.GetGenres();
+        ArrayList<LibraryType.DetailsGenre> genreList = (ArrayList) getGenres.resultFromJson(result);
 
         syncMusic.insertGenresItems(genreList, contentResolver);
     }
 
     private static void insertAlbums(Context context, ContentResolver contentResolver, SyncMusic syncMusic) throws ApiException, IOException {
-        AudioLibrary.GetAlbums getAlbums = new AudioLibrary.GetAlbums();
         String result = FileUtils.readFile(context, "AudioLibrary.GetAlbums.json");
+        insertAlbums(contentResolver, syncMusic, result);
+    }
+
+    private static void insertAlbums(ContentResolver contentResolver, SyncMusic syncMusic) throws ApiException, IOException {
+        String result = FileUtils.readFile("AudioLibrary.GetAlbums.json");
+        insertAlbums(contentResolver, syncMusic, result);
+    }
+
+    private static void insertAlbums(ContentResolver contentResolver, SyncMusic syncMusic,
+            String result) throws ApiException {AudioLibrary.GetAlbums getAlbums = new AudioLibrary.GetAlbums();
         ArrayList<AudioType.DetailsAlbum> albumList = (ArrayList) getAlbums.resultFromJson(result).items;
 
         syncMusic.insertAlbumsItems(albumList, contentResolver);
     }
 
     private static void insertSongs(Context context, ContentResolver contentResolver, SyncMusic syncMusic) throws ApiException, IOException {
-        AudioLibrary.GetSongs getSongs = new AudioLibrary.GetSongs();
-        ArrayList<AudioType.DetailsSong> songList = (ArrayList)
-                getSongs.resultFromJson(FileUtils.readFile(context, "AudioLibrary.GetSongs.json")).items;
+        String result = FileUtils.readFile(context, "AudioLibrary.GetSongs.json");
+        insertSongs(contentResolver, syncMusic, result);
+    }
+
+    private static void insertSongs(ContentResolver contentResolver, SyncMusic syncMusic) throws ApiException, IOException {
+        String result = FileUtils.readFile("AudioLibrary.GetSongs.json");
+        insertSongs(contentResolver, syncMusic, result);
+    }
+
+    private static void insertSongs(ContentResolver contentResolver, SyncMusic syncMusic,
+            String result) throws ApiException {AudioLibrary.GetSongs getSongs = new AudioLibrary.GetSongs();
+        ArrayList<AudioType.DetailsSong> songList = (ArrayList) getSongs.resultFromJson(result).items;
 
         syncMusic.insertSongsItems(songList, contentResolver);
     }
@@ -168,10 +236,41 @@ public class Database {
         syncTVShows.insertEpisodes(detailsEpisodes, contentResolver);
     }
 
+    private static void insertTVShows(ContentResolver contentResolver, SyncTVShows syncTVShows)
+            throws ApiException, IOException {
+        VideoLibrary.GetTVShows getTVShows = new VideoLibrary.GetTVShows();
+        String result = FileUtils.readFile("VideoLibrary.GetTVShows.json");
+        ArrayList<VideoType.DetailsTVShow> tvShowList = (ArrayList) getTVShows.resultFromJson(result).items;
+
+        syncTVShows.insertTVShows(tvShowList, contentResolver);
+
+        for ( VideoType.DetailsTVShow tvShow : tvShowList ) {
+            VideoLibrary.GetSeasons getSeasons = new VideoLibrary.GetSeasons(tvShow.tvshowid);
+            result = FileUtils.readFile("VideoLibrary.GetSeasons.json");
+            ArrayList<VideoType.DetailsSeason> detailsSeasons = (ArrayList) getSeasons.resultFromJson(result);
+            syncTVShows.insertSeason(tvShow.tvshowid, detailsSeasons, contentResolver);
+        }
+
+        VideoLibrary.GetEpisodes getEpisodes = new VideoLibrary.GetEpisodes(0);
+        result = FileUtils.readFile("VideoLibrary.GetEpisodes.json");
+        ArrayList<VideoType.DetailsEpisode> detailsEpisodes = (ArrayList) getEpisodes.resultFromJson(result);
+        syncTVShows.insertEpisodes(detailsEpisodes, contentResolver);
+    }
+
     private static void insertMusicVideos(Context context, ContentResolver contentResolver, SyncMusicVideos syncMusicVideos)
         throws ApiException, IOException {
-        VideoLibrary.GetMusicVideos getMusicVideos = new VideoLibrary.GetMusicVideos();
         String result = FileUtils.readFile(context, "VideoLibrary.GetMusicVideos.json");
+        insertMusicVideos(contentResolver, syncMusicVideos, result);
+    }
+
+    private static void insertMusicVideos(ContentResolver contentResolver, SyncMusicVideos syncMusicVideos)
+            throws ApiException, IOException {
+        String result = FileUtils.readFile("VideoLibrary.GetMusicVideos.json");
+        insertMusicVideos(contentResolver, syncMusicVideos, result);
+    }
+
+    private static void insertMusicVideos(ContentResolver contentResolver,
+            SyncMusicVideos syncMusicVideos, String result) throws ApiException {VideoLibrary.GetMusicVideos getMusicVideos = new VideoLibrary.GetMusicVideos();
         ArrayList<VideoType.DetailsMusicVideo> musicVideoList = (ArrayList) getMusicVideos.resultFromJson(result);
 
         syncMusicVideos.insertMusicVideos(musicVideoList, contentResolver);

--- a/app/src/testUtils/java/org/xbmc/kore/testutils/FileUtils.java
+++ b/app/src/testUtils/java/org/xbmc/kore/testutils/FileUtils.java
@@ -43,6 +43,7 @@ public class FileUtils {
     @SuppressLint("NewApi")
     static String readFile(String filename) throws IOException {
         String pathToFile = getPathToThisFile() + "assets" + File.separator + filename;
+        System.out.println("radFile: " + pathToFile);
         String fileContent;
 
         try(BufferedReader bufferedReader = new BufferedReader(new FileReader(pathToFile))) {
@@ -74,12 +75,12 @@ public class FileUtils {
         className = className + ".class";
         Object url = FileUtils.class.getResource(className);
         String path = url.toString();
-	    String fileSchemePrefix = "file:/";
-	    path = path.replace(fileSchemePrefix, "");
+        String fileSchemePrefix = "file:/";
+        path = path.replace(fileSchemePrefix, "");
 
         String osName = System.getProperty("os.name").toLowerCase();
-	    if (!isWindows(osName)) {
-		    path = "//" + path;
+        if (!isWindows(osName)) {
+            path = "//" + path;
         }
         path = path.replaceAll("build/.*", "build/");
         return path;

--- a/app/src/testUtils/java/org/xbmc/kore/testutils/FileUtils.java
+++ b/app/src/testUtils/java/org/xbmc/kore/testutils/FileUtils.java
@@ -16,8 +16,12 @@
 
 package org.xbmc.kore.testutils;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -34,5 +38,44 @@ public class FileUtils {
         is.close();
 
         return new String(buffer, "UTF-8");
+    }
+
+    @SuppressLint("NewApi")
+    static String readFile(String filename) throws IOException {
+        String pathToFile = getPathToThisFile() + "assets" + File.separator + filename;
+        String fileContent;
+
+        try(BufferedReader bufferedReader = new BufferedReader(new FileReader(pathToFile))) {
+            StringBuilder stringBuilder = new StringBuilder();
+            String line = bufferedReader.readLine();
+
+            while (line != null) {
+                stringBuilder.append(line);
+                stringBuilder.append(System.lineSeparator());
+                line = bufferedReader.readLine();
+            }
+            fileContent = stringBuilder.toString();
+        }
+
+        return fileContent;
+    }
+
+    /**
+     * Returns the path of this file, there are some heavy assumptions here (tested on Windows)
+     *
+     * @return path to this file
+     */
+    private static String getPathToThisFile() {
+        String className = FileUtils.class.getName();
+        int i = className.lastIndexOf(".");
+        if (i > -1) {
+            className = className.substring(i + 1);
+        }
+        className = className + ".class";
+        Object url = FileUtils.class.getResource(className);
+        String path = url.toString();
+        path = path.replace("file:/", "");
+        path = path.replaceAll("build/.*", "build/");
+        return path;
     }
 }

--- a/app/src/testUtils/java/org/xbmc/kore/testutils/FileUtils.java
+++ b/app/src/testUtils/java/org/xbmc/kore/testutils/FileUtils.java
@@ -74,8 +74,18 @@ public class FileUtils {
         className = className + ".class";
         Object url = FileUtils.class.getResource(className);
         String path = url.toString();
-        path = path.replace("file:/", "");
+	    String fileSchemePrefix = "file:/";
+	    path = path.replace(fileSchemePrefix, "");
+
+        String osName = System.getProperty("os.name").toLowerCase();
+	    if (!isWindows(osName)) {
+		    path = "//" + path;
+        }
         path = path.replaceAll("build/.*", "build/");
         return path;
+    }
+
+    private static boolean isWindows(String osName) {
+        return (osName.contains("win"));
     }
 }

--- a/app/src/testUtils/java/org/xbmc/kore/testutils/FileUtils.java
+++ b/app/src/testUtils/java/org/xbmc/kore/testutils/FileUtils.java
@@ -43,7 +43,7 @@ public class FileUtils {
     @SuppressLint("NewApi")
     static String readFile(String filename) throws IOException {
         String pathToFile = getPathToThisFile() + "assets" + File.separator + filename;
-        System.out.println("radFile: " + pathToFile);
+        System.out.println("readFile: " + pathToFile);
         String fileContent;
 
         try(BufferedReader bufferedReader = new BufferedReader(new FileReader(pathToFile))) {
@@ -75,6 +75,7 @@ public class FileUtils {
         className = className + ".class";
         Object url = FileUtils.class.getResource(className);
         String path = url.toString();
+	    System.out.println("getPathToThisFile URL: " + path);
         String fileSchemePrefix = "file:/";
         path = path.replace(fileSchemePrefix, "");
 

--- a/app/src/testUtils/java/org/xbmc/kore/testutils/FileUtils.java
+++ b/app/src/testUtils/java/org/xbmc/kore/testutils/FileUtils.java
@@ -83,7 +83,7 @@ public class FileUtils {
         if (!isWindows(osName)) {
             path = "//" + path;
         }
-        path = path.replaceAll("build/.*", "build/");
+        path = path.replaceAll("app/build/.*", "app/build/");
         return path;
     }
 


### PR DESCRIPTION
I was having trouble with running the unit tests locally. With this solution the unit tests can be run one by one from the IDE on the already checked in test json files.

What I did is: load the test data json files from the file system with standard java instead of through android context in order to allow more convenient execution of unit tests.

I've only tested this on Windows.