### PR TITLE
Added handler for YouTube shares with both video and playlist IDs

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
@@ -501,7 +501,35 @@ public class RemoteActivity extends BaseActivity
      */
     private String toPluginUrl(Uri playuri) {
         String host = playuri.getHost();
-        if (host.endsWith("svtplay.se")) {
+        if (host.endsWith("youtube.com")) {
+            String videoId = playuri.getQueryParameter("v");
+            String playlistId = playuri.getQueryParameter("list");
+            Uri.Builder pluginUri = new Uri.Builder()
+                    .scheme("plugin")
+                    .authority("plugin.video.youtube")
+                    .path("play/");
+            boolean valid = false;
+            if (videoId != null) {
+                valid = true;
+                pluginUri.appendQueryParameter("video_id", videoId);
+            }
+            if (playlistId != null) {
+                valid = true;
+                pluginUri.appendQueryParameter("playlist_id", playlistId)
+                        .appendQueryParameter("order", "default");
+            }
+            if (valid) {
+                return pluginUri.build().toString();
+            }
+        } else if (host.endsWith("youtu.be")) {
+            return "plugin://plugin.video.youtube/play/?video_id="
+                    + playuri.getLastPathSegment();
+        } else if (host.endsWith("vimeo.com")) {
+            String last = playuri.getLastPathSegment();
+            if (last.matches("\\d+")) {
+                return "plugin://plugin.video.vimeo/play/?video_id=" + last;
+            }
+        } else if (host.endsWith("svtplay.se")) {
             Pattern pattern = Pattern.compile(
                     "^(?:https?:\\/\\/)?(?:www\\.)?svtplay\\.se\\/video\\/(\\d+\\/.*)",
                     Pattern.CASE_INSENSITIVE);
@@ -510,22 +538,6 @@ public class RemoteActivity extends BaseActivity
                 return "plugin://plugin.video.svtplay/?url=%2Fvideo%2F"
                         + URLEncoder.encode(matcher.group(1)) + "&mode=video";
             }
-        } else if (host.endsWith("vimeo.com")) {
-            String last = playuri.getLastPathSegment();
-            if (last.matches("\\d+")) {
-                return "plugin://plugin.video.vimeo/play/?video_id=" + last;
-            }
-        } else if (host.endsWith("youtube.com")) {
-            if (playuri.getPathSegments().contains("playlist")) {
-                return "plugin://plugin.video.youtube/play/?order=default&playlist_id="
-                        + playuri.getQueryParameter("list");
-            } else {
-                return "plugin://plugin.video.youtube/play/?video_id="
-                        + playuri.getQueryParameter("v");
-            }
-        } else if (host.endsWith("youtu.be")) {
-            return "plugin://plugin.video.youtube/play/?video_id="
-                    + playuri.getLastPathSegment();
         }
         return null;
     }


### PR DESCRIPTION
I just found out that it's possible to have both a video ID and playlist ID at the same time in a youtube share and that the Kodi YT plugin can handle it.

I found a couple of problems with YT playlist shares:
- the first item is always skipped
- if you share a playlist while Kodi is currently playing, it seems to lockup when it finishes the current item and tries to load the shared playlist.

I have a feeling these aren't caused by the client. The Kodi I'm using is also a version behind so these might not be true anymore.