### PR TITLE
Fixed tinting on pre-lollipop devices for custom widgets

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/widgets/RepeatModeButton.java
+++ b/app/src/main/java/org/xbmc/kore/ui/widgets/RepeatModeButton.java
@@ -23,7 +23,7 @@ import android.util.AttributeSet;
 
 import org.xbmc.kore.R;
 
-public class RepeatModeButton extends AppCompatImageButton {
+public class RepeatModeButton extends HighlightButton {
     public enum MODE {
         OFF,
         ONE,
@@ -32,7 +32,6 @@ public class RepeatModeButton extends AppCompatImageButton {
 
     private MODE mode;
     private static TypedArray styledAttributes;
-    private static int accentDefaultColor;
 
     public RepeatModeButton(Context context) {
         super(context);
@@ -55,15 +54,15 @@ public class RepeatModeButton extends AppCompatImageButton {
         switch (mode) {
             case OFF:
                 setImageResource(styledAttributes.getResourceId(styledAttributes.getIndex(1), R.drawable.ic_repeat_white_24dp));
-                clearColorFilter();
+                setHighlight(false);
                 break;
             case ONE:
                 setImageResource(styledAttributes.getResourceId(styledAttributes.getIndex(2), R.drawable.ic_repeat_one_white_24dp));
-                setColorFilter(styledAttributes.getColor(styledAttributes.getIndex(0), accentDefaultColor));
+                setHighlight(true);
                 break;
             case ALL:
                 setImageResource(styledAttributes.getResourceId(styledAttributes.getIndex(1), R.drawable.ic_repeat_white_24dp));
-                setColorFilter(styledAttributes.getColor(styledAttributes.getIndex(0), accentDefaultColor));
+                setHighlight(true);
                 break;
         }
     }
@@ -77,6 +76,5 @@ public class RepeatModeButton extends AppCompatImageButton {
                 R.attr.colorAccent,
                 R.attr.iconRepeat,
                 R.attr.iconRepeatOne});
-        accentDefaultColor = getContext().getResources().getColor(R.color.accent_default);
     }
 }


### PR DESCRIPTION
This should fix issue #464 

Not a very elegant fix. I tried setting the color filter in the constructor as we do for the control pad, but that doesn't work here... I have no idea why...