### PR TITLE
Added default margin to control pad and bottom shortcuts

### DIFF
--- a/app/src/main/res/layout-land/fragment_remote.xml
+++ b/app/src/main/res/layout-land/fragment_remote.xml
@@ -172,7 +172,8 @@
             android:layout_weight="1"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:layout_marginLeft="@dimen/remote_content_hmargin">
+            android:layout_marginLeft="@dimen/remote_content_hmargin"
+            android:layout_marginStart="@dimen/remote_content_hmargin">
 
             <ImageView
                 android:id="@+id/art"

--- a/app/src/main/res/layout/fragment_remote.xml
+++ b/app/src/main/res/layout/fragment_remote.xml
@@ -230,7 +230,8 @@
     <FrameLayout
         style="@style/ControlPad.FrameLayout"
         android:layout_above="@id/button_bar"
-        android:layout_below="@id/top_panel">
+        android:layout_below="@id/top_panel"
+        android:layout_marginBottom="@dimen/default_padding">
         <org.xbmc.kore.ui.widgets.ControlPad
             android:id="@+id/remote"
             style="@style/ControlPad"


### PR DESCRIPTION
As reported in #383 the remote was placed too close to the bottom button bar for devices with sw360dp or lower. This adds the default margin to the control pad for these configurations as well.