### PR TITLE
Fixed lint errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ android:
 before_script:
 
 script: 
-  - ./gradlew testFullDebugUnitTest assembleFullRelease
+  - ./gradlew lintFullRelease testFullDebugUnitTest assembleFullRelease

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -83,9 +83,10 @@ android {
         // Too much trouble keeping all translations in sync
         disable 'MissingTranslation'
 
-        // okio generates a lint error which should be ignored. Demote it to warning
-        // See https://github.com/square/okio/issues/58
-        warning 'InvalidPackage'
+        //The xml launcher icon introduced in API 26 causes lint to generate
+        //an error that the icon is not a PNG format
+        //This reduces the error to a warning
+        warning 'IconLauncherFormat'
     }
 
 //    allprojects {

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowProgressFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowProgressFragment.java
@@ -259,6 +259,7 @@ public class TVShowProgressFragment extends AbstractAdditionalInfoFragment imple
      *
      * @param cursor Cursor with the data
      */
+    @TargetApi(21)
     private void displaySeasonList(Cursor cursor) {
         TextView seasonsListTitle = (TextView) getActivity().findViewById(R.id.seasons_title);
         GridLayout seasonsList = (GridLayout) getActivity().findViewById(R.id.seasons_list);

--- a/app/src/main/res/values-sw360dp-land/styles.xml
+++ b/app/src/main/res/values-sw360dp-land/styles.xml
@@ -4,7 +4,6 @@
         <item name="android:layout_width">@dimen/remote_size</item>
         <item name="android:layout_height">@dimen/remote_size</item>
         <item name="android:layout_marginRight">@dimen/remote_content_hmargin</item>
-        <item name="android:layout_marginEnd">@dimen/remote_content_hmargin</item>
     </style>
 
     <style name="ControlPad">


### PR DESCRIPTION
Lint is complaining about the new launcher icons in 'res/mipmap-anydpi-v26'
are not in PNG format. These are now defined in XML and lint is probably
not aware of the new XML format for API v26 and higher.

This also fixes usage of "android:layout_marginEnd". Which is only
supported from API v17.

Added running lintFullRelease to travis-CI build.