### PR TITLE
Disabled shared element transitions from API 27

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
@@ -145,7 +145,7 @@ public abstract class BaseMediaActivity extends BaseActivity
         if (fragment == null) {
             fragment = createFragment();
 
-            if (Utils.isLollipopOrLater()) {
+            if (Utils.isLollipopAndPreOreo()) {
                 fragment.setExitTransition(null);
                 fragment.setReenterTransition(TransitionInflater
                                                       .from(this)
@@ -158,7 +158,7 @@ public abstract class BaseMediaActivity extends BaseActivity
                     .commit();
         }
 
-        if (Utils.isLollipopOrLater()) {
+        if (Utils.isLollipopAndPreOreo()) {
             sharedElementTransition.setupExitTransition(this, fragment);
         }
 
@@ -280,7 +280,7 @@ public abstract class BaseMediaActivity extends BaseActivity
         FragmentTransaction fragTrans = getSupportFragmentManager().beginTransaction();
 
         // Set up transitions
-        if (Utils.isLollipopOrLater()) {
+        if (Utils.isLollipopAndPreOreo()) {
             dataHolder.setPosterTransitionName(sharedImageView.getTransitionName());
             sharedElementTransition.setupEnterTransition(this, fragTrans, fragment, sharedImageView);
         } else {

--- a/app/src/main/java/org/xbmc/kore/utils/Utils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/Utils.java
@@ -69,6 +69,11 @@ public class Utils {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
     }
 
+    public static boolean isLollipopAndPreOreo() {
+        return (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) &&
+               (Build.VERSION.SDK_INT < 27);
+    }
+
     /**
      * Concats a list of strings...
      * @param list


### PR DESCRIPTION
AdapterView is not supported by the transition framework. This
became an issue with the release of API 27. In Android 8.1 the
shared element view is removed from the exiting fragment. This
causes Android to call the removeView method from AdapterView
which is not implemented and causes the app to crash.

We can reenable shared element transitions for API 27 and up by
refactoring the GridView usage to RecycleView.

AFAICT PVR section does not support shared element transitions right?