### PR TITLE
Refactored applying tint color on control pad

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/widgets/ControlPad.java
+++ b/app/src/main/java/org/xbmc/kore/ui/widgets/ControlPad.java
@@ -108,7 +108,7 @@ public class ControlPad extends SquareGridLayout
         inflater.inflate(R.layout.remote_control_pad, this);
         ButterKnife.inject(this, this);
 
-        applyTheme();
+        setBackgroundImage();
         setupListeners(context);
     }
 
@@ -160,27 +160,12 @@ public class ControlPad extends SquareGridLayout
     }
 
     @TargetApi(21)
-    private void applyTheme() {
+    private void setBackgroundImage() {
         Resources.Theme theme = getContext().getTheme();
-        TypedArray styledAttributes = theme.obtainStyledAttributes(new int[] {
-                R.attr.remoteButtonColorFilter,
-                R.attr.contentBackgroundColor});
-        Resources resources = getResources();
-        int remoteButtonsColor =  styledAttributes.getColor(styledAttributes.getIndex(0), resources.getColor(R.color.white)),
-                remoteBackgroundColor = styledAttributes.getColor(styledAttributes.getIndex(1), resources.getColor(R.color.dark_content_background_dim_70pct));
+        TypedArray styledAttributes = theme.obtainStyledAttributes(new int[] {R.attr.contentBackgroundColor});
+        int remoteBackgroundColor = styledAttributes.getColor(styledAttributes.getIndex(0),
+                                                              getResources().getColor(R.color.dark_content_background_dim_70pct));
         styledAttributes.recycle();
-
-        leftButton.setColorFilter(remoteButtonsColor);
-        rightButton.setColorFilter(remoteButtonsColor);
-        upButton.setColorFilter(remoteButtonsColor);
-        downButton.setColorFilter(remoteButtonsColor);
-
-        selectButton.setColorFilter(remoteButtonsColor);
-        backButton.setColorFilter(remoteButtonsColor);
-        infoButton.setColorFilter(remoteButtonsColor);
-        osdButton.setColorFilter(remoteButtonsColor);
-        contextButton.setColorFilter(remoteButtonsColor);
-
 
         // On ICS the remote background isn't shown as the tinting isn't supported
         //int backgroundResourceId = R.drawable.remote_background_square_black_alpha;

--- a/app/src/main/res/layout/remote_control_pad.xml
+++ b/app/src/main/res/layout/remote_control_pad.xml
@@ -14,61 +14,71 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-<merge xmlns:android="http://schemas.android.com/apk/res/android">
-    <ImageView
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:app="http://schemas.android.com/apk/res-auto">
+    <android.support.v7.widget.AppCompatImageView
         android:id="@+id/context"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:src="?attr/iconContext"
+        app:tint="?attr/remoteButtonColorFilter"
         android:contentDescription="@string/codec_info"/>
-    <ImageView
+    <android.support.v7.widget.AppCompatImageView
         android:id="@+id/up"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:src="?attr/iconUp"
+        app:tint="?attr/remoteButtonColorFilter"
         android:contentDescription="@string/up"/>
-    <ImageView
+    <android.support.v7.widget.AppCompatImageView
         android:id="@+id/info"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:src="?attr/iconInfo"
+        app:tint="?attr/remoteButtonColorFilter"
         android:contentDescription="@string/info"/>
 
-    <ImageView
+    <android.support.v7.widget.AppCompatImageView
         android:id="@+id/left"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:src="?attr/iconLeft"
+        app:tint="?attr/remoteButtonColorFilter"
         android:contentDescription="@string/left"/>
-    <ImageView
+    <android.support.v7.widget.AppCompatImageView
         android:id="@+id/select"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:src="?attr/iconSelect"
+        app:tint="?attr/remoteButtonColorFilter"
         android:contentDescription="@string/select"/>
-    <ImageView
+    <android.support.v7.widget.AppCompatImageView
         android:id="@+id/right"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:src="?attr/iconRight"
+        app:tint="?attr/remoteButtonColorFilter"
         android:contentDescription="@string/right"/>
 
-    <ImageView
+    <android.support.v7.widget.AppCompatImageView
         android:id="@+id/back"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:src="?attr/iconBack"
+        app:tint="?attr/remoteButtonColorFilter"
         android:contentDescription="@string/back"/>
-    <ImageView
+    <android.support.v7.widget.AppCompatImageView
         android:id="@+id/down"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:src="?attr/iconDown"
+        app:tint="?attr/remoteButtonColorFilter"
         android:contentDescription="@string/down"/>
-    <ImageView
+    <android.support.v7.widget.AppCompatImageView
         android:id="@+id/osd"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:src="?attr/iconMenu"
+        app:tint="?attr/remoteButtonColorFilter"
         android:contentDescription="@string/osd"/>
 </merge>


### PR DESCRIPTION
ControlPad now uses AppCompatImageView to support theme colors.
Instead of applying the colors programmatically they are now defined
in the layout file.