### PR TITLE
Prevent the refresh animation from appearing in a silent sync

### DIFF
--- a/app/src/main/java/org/xbmc/kore/service/library/SyncUtils.java
+++ b/app/src/main/java/org/xbmc/kore/service/library/SyncUtils.java
@@ -457,29 +457,28 @@ public class SyncUtils {
     };
 
     /**
-     * Checks if a running LibrarySyncService is syncing any given SyncType from a specific host
+     * Returns the first {@link SyncItem} of the given type that is currently
+     * syncing in a running {@link LibrarySyncService} for a specific host
      * @param service running LibrarySyncService. Use {@link #connectToLibrarySyncService(Context, OnServiceListener)} to connect to a running LibrarySyncService
      * @param hostInfo host to check for sync items currently running or queued
-     * @param syncTypes sync types to check
-     * @return true if any of the given syncTypes is running or queued, false otherwise
+     * @param syncType sync type to check
+     * @return The first {@link SyncItem} of the given syncType if any is running or queued, null otherwise
      */
-    public static boolean isLibrarySyncing(LibrarySyncService service, HostInfo hostInfo, String... syncTypes) {
-        if (service == null || hostInfo == null || syncTypes == null)
-            return false;
+    public static SyncItem getCurrentSyncItem(LibrarySyncService service, HostInfo hostInfo, String syncType) {
+        if (service == null || hostInfo == null || syncType == null)
+            return null;
 
         ArrayList<SyncItem> itemsSyncing = service.getItemsSyncing(hostInfo);
-        if( itemsSyncing == null )
-            return false;
+        if (itemsSyncing == null)
+            return null;
 
         for (SyncItem syncItem : itemsSyncing) {
-            for( String syncType : syncTypes ) {
-                if (syncItem.getSyncType().equals(syncType)) {
-                    return true;
-                }
+            if (syncItem.getSyncType().equals(syncType)) {
+                return syncItem;
             }
         }
 
-        return false;
+        return null;
     }
 
     /**

--- a/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
@@ -57,6 +57,7 @@ import org.xbmc.kore.jsonrpc.ApiCallback;
 import org.xbmc.kore.jsonrpc.method.Player;
 import org.xbmc.kore.jsonrpc.type.PlaylistType;
 import org.xbmc.kore.service.library.LibrarySyncService;
+import org.xbmc.kore.service.library.SyncItem;
 import org.xbmc.kore.service.library.SyncUtils;
 import org.xbmc.kore.ui.generic.RefreshItem;
 import org.xbmc.kore.ui.widgets.fabspeeddial.FABSpeedDial;
@@ -282,10 +283,14 @@ abstract public class AbstractInfoFragment extends AbstractFragment
             return;
         }
 
-        if (SyncUtils.isLibrarySyncing(librarySyncService,
-                                       HostManager.getInstance(getActivity()).getHostInfo(),
-                                       refreshItem.getSyncType())) {
-            UIUtils.showRefreshAnimation(swipeRefreshLayout);
+        SyncItem syncItem = SyncUtils.getCurrentSyncItem(librarySyncService,
+            HostManager.getInstance(getActivity()).getHostInfo(),
+            refreshItem.getSyncType());
+        if (syncItem != null) {
+            boolean silentRefresh = (syncItem.getSyncExtras() != null) &&
+                syncItem.getSyncExtras().getBoolean(LibrarySyncService.SILENT_SYNC, false);
+            if (!silentRefresh)
+                UIUtils.showRefreshAnimation(swipeRefreshLayout);
             refreshItem.setSwipeRefreshLayout(swipeRefreshLayout);
             refreshItem.register();
         }

--- a/app/src/main/java/org/xbmc/kore/ui/AbstractListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractListFragment.java
@@ -52,7 +52,7 @@ public abstract class AbstractListFragment extends Fragment implements
 
 	private boolean gridViewUsesMultipleColumns;
 
-	@InjectView(R.id.swipe_refresh_layout) SwipeRefreshLayout swipeRefreshLayout;
+	protected @InjectView(R.id.swipe_refresh_layout) SwipeRefreshLayout swipeRefreshLayout;
 	@InjectView(R.id.list) GridView gridView;
 	@InjectView(android.R.id.empty) TextView emptyView;
 
@@ -173,19 +173,6 @@ public abstract class AbstractListFragment extends Fragment implements
 		}
 		editor.apply();
 		adapter.notifyDataSetChanged(); //force gridView to redraw
-	}
-
-	public void showRefreshAnimation() {
-		/**
-		 * Fixes issue with refresh animation not showing when using appcompat library (from version 20?)
-		 * See https://code.google.com/p/android/issues/detail?id=77712
-		 */
-		swipeRefreshLayout.post(new Runnable() {
-			@Override
-			public void run() {
-				swipeRefreshLayout.setRefreshing(true);
-			}
-		});
 	}
 
 	public void hideRefreshAnimation() {

--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListFragment.java
@@ -130,7 +130,8 @@ public class AddonListFragment extends AbstractListFragment {
     private void callGetAddonsAndSetup() {
         final AddonsAdapter adapter = (AddonsAdapter) getAdapter();
 
-        showRefreshAnimation();
+        UIUtils.showRefreshAnimation(swipeRefreshLayout);
+
         // Get the addon list, this is done asyhnchronously
         String[] properties = new String[] {
                 AddonType.Fields.NAME, AddonType.Fields.VERSION, AddonType.Fields.SUMMARY,
@@ -141,51 +142,52 @@ public class AddonListFragment extends AbstractListFragment {
         };
         Addons.GetAddons action = new Addons.GetAddons(properties);
         action.execute(HostManager.getInstance(getActivity()).getConnection(),
-                       new ApiCallback<List<AddonType.Details>>() {
-                           @Override
-                           public void onSuccess(List<AddonType.Details> result) {
-                               if (!isAdded()) return;
+            new ApiCallback<List<AddonType.Details>>() {
+                @Override
+                public void onSuccess(List<AddonType.Details> result) {
+                    if (!isAdded()) return;
 
-                               for (AddonType.Details addon : result) {
-                                   String regex = "\\[.*?\\]";
-                                   addon.name = addon.name.replaceAll(regex, "");
-                                   addon.description = addon.description.replaceAll(regex, "");
-                                   addon.summary = addon.summary.replaceAll(regex, "");
-                                   addon.author = addon.author.replaceAll(regex, "");
-                               }
-                               Collections.sort(result, new AddonNameComparator());
+                    for (AddonType.Details addon : result) {
+                        String regex = "\\[.*?\\]";
+                        addon.name = addon.name.replaceAll(regex, "");
+                        addon.description = addon.description.replaceAll(regex, "");
+                        addon.summary = addon.summary.replaceAll(regex, "");
+                        addon.author = addon.author.replaceAll(regex, "");
+                    }
+                    Collections.sort(result, new AddonNameComparator());
 
-                               adapter.clear();
-                               for (AddonType.Details addon : result) {
-                                   if (addon.type.equals(AddonType.Types.UNKNOWN) ||
-                                       addon.type.equals(AddonType.Types.XBMC_PYTHON_PLUGINSOURCE) ||
-                                       addon.type.equals(AddonType.Types.XBMC_PYTHON_SCRIPT) ||
-                                       addon.type.equals(AddonType.Types.XBMC_ADDON_AUDIO) ||
-                                       addon.type.equals(AddonType.Types.XBMC_ADDON_EXECUTABLE) ||
-                                       addon.type.equals(AddonType.Types.XBMC_ADDON_VIDEO) ||
-                                       addon.type.equals(AddonType.Types.XBMC_ADDON_IMAGE)) {
-                                       adapter.add(addon);
-                                   }
-                               }
+                    adapter.clear();
+                    for (AddonType.Details addon : result) {
+                        if (addon.type.equals(AddonType.Types.UNKNOWN) ||
+                            addon.type.equals(AddonType.Types.XBMC_PYTHON_PLUGINSOURCE) ||
+                            addon.type.equals(AddonType.Types.XBMC_PYTHON_SCRIPT) ||
+                            addon.type.equals(AddonType.Types.XBMC_ADDON_AUDIO) ||
+                            addon.type.equals(AddonType.Types.XBMC_ADDON_EXECUTABLE) ||
+                            addon.type.equals(AddonType.Types.XBMC_ADDON_VIDEO) ||
+                            addon.type.equals(AddonType.Types.XBMC_ADDON_IMAGE)) {
+                            adapter.add(addon);
+                        }
+                    }
 
-                               adapter.notifyDataSetChanged();
-                               hideRefreshAnimation();
+                    adapter.notifyDataSetChanged();
+                    hideRefreshAnimation();
 
-                               if(adapter.getCount() == 0) {
-                                   getEmptyView().setText(R.string.no_addons_found_refresh);
-                               }
-                           }
+                    if (adapter.getCount() == 0) {
+                        getEmptyView().setText(R.string.no_addons_found_refresh);
+                    }
+                }
 
-                           @Override
-                           public void onError(int errorCode, String description) {
-                               if (!isAdded()) return;
+                @Override
+                public void onError(int errorCode, String description) {
+                    if (!isAdded()) return;
 
-                               Toast.makeText(getActivity(),
-                                              String.format(getString(R.string.error_getting_addon_info), description),
-                                              Toast.LENGTH_SHORT).show();
-                               hideRefreshAnimation();
-                           }
-                       }, callbackHandler);
+                    Toast.makeText(getActivity(),
+                        String.format(getString(R.string.error_getting_addon_info), description),
+                        Toast.LENGTH_SHORT).show();
+                    hideRefreshAnimation();
+                }
+            },
+            callbackHandler);
     }
 
     private class AddonsAdapter extends ArrayAdapter<AddonType.Details> {


### PR DESCRIPTION
When a silent sync is running the refresh animation shouldn't appear and this wasn't being respected in some situations. For instance, when not connected to Kodi, starting from a TV Show details, selecting one episode or season and hitting back, the animation would appear. This PR makes sure that it is only shown if it isn't silent.