### PR TITLE
Fix memory leaks in lists that use CursorAdapter

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/AlbumListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/AlbumListFragment.java
@@ -269,7 +269,7 @@ public class AlbumListFragment extends AbstractCursorListFragment {
         private int artWidth, artHeight;
 
         public AlbumsAdapter(Context context) {
-            super(context, null, false);
+            super(context, null, 0);
             this.hostManager = HostManager.getInstance(context);
 
             // Get the art dimensions

--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/AlbumSongsListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/AlbumSongsListFragment.java
@@ -322,7 +322,7 @@ public class AlbumSongsListFragment extends AbstractAdditionalInfoFragment
     private class AlbumSongsAdapter extends CursorAdapter {
 
         public AlbumSongsAdapter(Context context) {
-            super(context, null, false);
+            super(context, null, 0);
         }
 
         @Override

--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/ArtistListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/ArtistListFragment.java
@@ -141,7 +141,7 @@ public class ArtistListFragment extends AbstractCursorListFragment {
         private int artWidth, artHeight;
 
         public ArtistsAdapter(Context context) {
-            super(context, null, false);
+            super(context, null, 0);
             this.hostManager = HostManager.getInstance(context);
 
             // Get the art dimensions

--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/AudioGenresListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/AudioGenresListFragment.java
@@ -131,7 +131,7 @@ public class AudioGenresListFragment extends AbstractCursorListFragment {
         private int artWidth, artHeight;
 
         public AudioGenresAdapter(Context context) {
-            super(context, null, false);
+            super(context, null, 0);
             this.hostManager = HostManager.getInstance(context);
 
             // Get the art dimensions

--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/MusicVideoListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/MusicVideoListFragment.java
@@ -143,7 +143,7 @@ public class MusicVideoListFragment extends AbstractCursorListFragment {
         private int artWidth, artHeight;
 
         public MusicVideosAdapter(Context context) {
-            super(context, null, false);
+            super(context, null, 0);
             this.hostManager = HostManager.getInstance(context);
 
             // Get the art dimensions

--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/SongsListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/SongsListFragment.java
@@ -240,7 +240,7 @@ public class SongsListFragment extends AbstractCursorListFragment {
         private int artWidth, artHeight;
 
         public SongsAdapter(Context context) {
-            super(context, null, false);
+            super(context, null, 0);
             this.hostManager = HostManager.getInstance(context);
 
             // Get the art dimensions
@@ -321,7 +321,7 @@ public class SongsListFragment extends AbstractCursorListFragment {
     private class AlbumSongsAdapter extends CursorAdapter {
 
         public AlbumSongsAdapter(Context context) {
-            super(context, null, false);
+            super(context, null, 0);
         }
 
         @Override

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/MovieListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/MovieListFragment.java
@@ -317,7 +317,7 @@ public class MovieListFragment extends AbstractCursorListFragment {
         private int themeAccentColor;
 
         public MoviesAdapter(Context context) {
-            super(context, null, false);
+            super(context, null, 0);
 
             // Get the default accent color
             Resources.Theme theme = context.getTheme();

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowEpisodeListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowEpisodeListFragment.java
@@ -225,7 +225,7 @@ public class TVShowEpisodeListFragment extends AbstractCursorListFragment {
         private int themeAccentColor;
 
         public SeasonsEpisodesAdapter(Context context) {
-            super(context, null, false);
+            super(context, null, 0);
 
             // Get the default accent color
             Resources.Theme theme = context.getTheme();

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowListFragment.java
@@ -317,7 +317,7 @@ public class TVShowListFragment extends AbstractCursorListFragment {
                 inProgressColor, finishedColor;
 
         public TVShowsAdapter(Context context) {
-            super(context, null, false);
+            super(context, null, 0);
 
             // Get the default accent color
             Resources.Theme theme = context.getTheme();


### PR DESCRIPTION
Following issue #514, activities that have lists were being leaked, the reason being the internal `Cursors` (which seem to be reused/pooled in Android, so they have a lifecycle separate from activities) were keeping references to the activity's `Adapter`, therefore keeping it from being GC'ed.

The constructor for `CursorAdapter` being used up until now is [this one](https://developer.android.com/reference/android/widget/CursorAdapter.html#CursorAdapter(android.content.Context,%20android.database.Cursor,%20boolean)), which sets the flag `FLAG_REGISTER_CONTENT_OBSERVER`, unnecessary in `CursorAdapters` that will be used with `CursorLoaders` (according to [the docs](https://developer.android.com/reference/android/widget/CursorAdapter.html#FLAG_REGISTER_CONTENT_OBSERVER)).

Using the other constructor doesn't set that flag, so the `Cursor` doesn't hold up the `Adapter` and the enclosing activities.