### PR TITLE
Fixed issue testing TVShowActivity

### DIFF
--- a/app/src/androidTest/java/org/xbmc/kore/tests/ui/tvshows/TVShowsActivityTests.java
+++ b/app/src/androidTest/java/org/xbmc/kore/tests/ui/tvshows/TVShowsActivityTests.java
@@ -96,7 +96,7 @@ public class TVShowsActivityTests extends BaseMediaActivityTests<TVShowsActivity
     @Test
     public void setActionBarTitleOnSeasonList() {
         EspressoTestUtils.clickAdapterViewItem(0, R.id.list);
-        onView( withId(R.id.seasons_list)).perform( nestedScrollTo(), click());
+        onView( withId(R.id.seasons_list)).perform(nestedScrollTo(), click());
 
         onView(allOf(instanceOf(TextView.class), withParent(withId(R.id.default_toolbar))))
                 .check(matches(withText("Season 01")));


### PR DESCRIPTION
As we now use a nested scroll view the tests for TV shows all
failed because the scroll action was performed on a normal scroll
view only. This has simply been fixed by implementing a custom action
that also accepts a nested scroll view.