### PR TITLE
Fixed issue with control pad button tests

### DIFF
--- a/app/src/androidTest/java/org/xbmc/kore/tests/ui/remote/controlpad/eventserver/KodiPreV17Tests.java
+++ b/app/src/androidTest/java/org/xbmc/kore/tests/ui/remote/controlpad/eventserver/KodiPreV17Tests.java
@@ -59,7 +59,6 @@ public class KodiPreV17Tests extends AbstractTestClass<RemoteActivity> {
 
     @Override
     protected void configureHostInfo(HostInfo hostInfo) {
-        hostInfo.setKodiVersionMajor(16);
     }
 
     @BeforeClass

--- a/app/src/androidTest/java/org/xbmc/kore/tests/ui/remote/controlpad/http/ButtonTests.java
+++ b/app/src/androidTest/java/org/xbmc/kore/tests/ui/remote/controlpad/http/ButtonTests.java
@@ -52,7 +52,6 @@ public class ButtonTests extends AbstractTestClass<RemoteActivity> {
 
     @Override
     protected void configureHostInfo(HostInfo hostInfo) {
-        hostInfo.setKodiVersionMajor(17);
     }
 
     @Override


### PR DESCRIPTION
   * Fixed tests to determine which Kodi version Kore is connected too.
     This caused the long press tests to fail as Kore didn't see v17 as
     the version that should use the new JSON RPC call.
   * Refactored setting the Kodi version during testing to also set the
     correct version in the database, instead of only setting it in the HostInfo
     instance.