### PR TITLE
Refactored ApiFuture

### DIFF
--- a/app/src/main/java/org/xbmc/kore/MainApp.java
+++ b/app/src/main/java/org/xbmc/kore/MainApp.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Martijn Brekhof. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.xbmc.kore;
+
+import android.app.Application;
+import android.content.Context;
+
+/**
+ * Application class to make the context accessible from non UI threads without
+ * having to pass the context as argument to each method call.
+ * <br/>
+ * Usage: MainApp.getContext()
+ */
+public class MainApp extends Application {
+    private static Context context;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        context = this;
+    }
+    
+    public static Context getContext(){
+        return context;
+    }
+}

--- a/app/src/main/java/org/xbmc/kore/host/actions/HostAction.java
+++ b/app/src/main/java/org/xbmc/kore/host/actions/HostAction.java
@@ -1,0 +1,25 @@
+package org.xbmc.kore.host.actions;
+
+
+import org.xbmc.kore.host.HostManager;
+import org.xbmc.kore.jsonrpc.ApiException;
+import org.xbmc.kore.jsonrpc.HostConnection;
+
+public abstract class HostAction<T> {
+    /**
+     * @return the integer that uniquely identifies this action
+     */
+    public int getId() {
+        return this.getClass().hashCode();
+    }
+
+    /**
+     * Implement this to hold a sequence of ApiMethods that need to be executed on
+     * the given hostConnection.
+     * @see org.xbmc.kore.host.HostManager#withCurrentHost(HostAction, HostManager.OnActionListener)
+     * @param hostConnection connection on which to execute the ApiMethod
+     * @return result of the action
+     * @throws ApiException holds any errors that occured while executing
+     */
+    abstract public T using(HostConnection hostConnection) throws ApiException;
+}

--- a/app/src/main/java/org/xbmc/kore/jsonrpc/ApiException.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/ApiException.java
@@ -75,6 +75,11 @@ public class ApiException extends Exception {
      */
     public static int API_METHOD_WITH_SAME_ID_ALREADY_EXECUTING = 102;
 
+	/**
+	 * Waiting for the result of an API method took more then the given timeout.
+	 */
+	public static int API_WAIT_TIMEDOUT = 103;
+
     private int code;
 
 	/**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -211,6 +211,8 @@
     <string name="poster">Poster</string>
     <string name="thumbnail">Thumbnail</string>
 
+    <string name="api_method_timedout">Executing %1$s timed out.</string>
+    <string name="api_method_wait_interrupted">Waiting on %1$s was interrupted.</string>
     <string name="error_getting_properties">Couldn\'t get Kodi/XBMC properties.\nError message:
         %1$s.</string>
     <string name="error_executing_subtitles">Couldn\'t execute subtitles addon.\nError message: %1$s.</string>


### PR DESCRIPTION
Refactored the ApiFuture setup, introduced by @monzee in #473, to make the code more [SOLID](https://en.wikipedia.org/wiki/SOLID_(object-oriented_design)).

* Moved logic on how to execute an ApiMethod from ApiFuture to HostManager to make
  usage more clear and remove the cyclic dependency between ApiFuture and HostConnection.
  Cyclic dependency was found in ApiFuture.from() using the HostConnection to execute
  the ApiMethod, and the HostConnection containing an execute method that wraps
  the ApiMethod in an ApiFuture.
* Implemented a version of withCurrentHost to support using callbacks to
  simplify handling the result of an ApiFuture in an Activity or Fragment.
* Refactored ApiFuture and OpenSharedUrl to provide more meaningful error messages.
* Refactored Session interface into an HostAction abstract class to clarify
  its usage and be able to handle device configuration changes in Fragments
  as well as Activities.
* Added copyright statements to OpenSharedUrl and ApiFuture.
  Original author forgot to include them. I used the overall XBMC copyright
  as the project in general falls under the XBMC copyright license.
* Refactored RemoteActivity and moved waiting on an ApiMethod result to
  HostManager. RemoteActivity is notified of any result through callbacks
  now. This reduces code duplication.