### PR TITLE
Add support for handling `Player.OnResume` event through TCP

### DIFF
--- a/app/src/main/java/org/xbmc/kore/host/HostConnectionObserver.java
+++ b/app/src/main/java/org/xbmc/kore/host/HostConnectionObserver.java
@@ -384,14 +384,17 @@ public class HostConnectionObserver
         chainCallGetActivePlayers();
     }
 
-    public void onPause(org.xbmc.kore.jsonrpc.notification.Player.OnPause
-                                notification) {
+    public void onResume(org.xbmc.kore.jsonrpc.notification.Player.OnResume notification) {
         // Just start our chain calls
         chainCallGetActivePlayers();
     }
 
-    public void onSpeedChanged(org.xbmc.kore.jsonrpc.notification.Player
-                                       .OnSpeedChanged notification) {
+    public void onPause(org.xbmc.kore.jsonrpc.notification.Player.OnPause notification) {
+        // Just start our chain calls
+        chainCallGetActivePlayers();
+    }
+
+    public void onSpeedChanged(org.xbmc.kore.jsonrpc.notification.Player.OnSpeedChanged notification) {
         // Just start our chain calls
         chainCallGetActivePlayers();
     }

--- a/app/src/main/java/org/xbmc/kore/jsonrpc/ApiNotification.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/ApiNotification.java
@@ -54,16 +54,25 @@ public abstract class ApiNotification {
         ObjectNode params = (ObjectNode)node.get(PARAMS_NODE);
 
         ApiNotification result = null;
-        if (method.equals(Player.OnPause.NOTIFICATION_NAME)) {
+        switch (method) {
+        case Player.OnPause.NOTIFICATION_NAME:
             result = new Player.OnPause(params);
-        } else if (method.equals(Player.OnPlay.NOTIFICATION_NAME)) {
+            break;
+        case Player.OnPlay.NOTIFICATION_NAME:
             result = new Player.OnPlay(params);
-        } else if (method.equals(Player.OnSeek.NOTIFICATION_NAME)) {
+            break;
+        case Player.OnResume.NOTIFICATION_NAME:
+            result = new Player.OnResume(params);
+            break;
+        case Player.OnSeek.NOTIFICATION_NAME:
             result = new Player.OnSeek(params);
-        } else if (method.equals(Player.OnSpeedChanged.NOTIFICATION_NAME)) {
+            break;
+        case Player.OnSpeedChanged.NOTIFICATION_NAME:
             result = new Player.OnSpeedChanged(params);
-        } else if (method.equals(Player.OnStop.NOTIFICATION_NAME)) {
+            break;
+        case Player.OnStop.NOTIFICATION_NAME:
             result = new Player.OnStop(params);
+            break;
         }
 
         return result;

--- a/app/src/main/java/org/xbmc/kore/jsonrpc/HostConnection.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/HostConnection.java
@@ -70,32 +70,33 @@ public class HostConnection {
      * Interface that an observer must implement to be notified of player notifications
      */
     public interface PlayerNotificationsObserver {
-        public void onPropertyChanged(Player.OnPropertyChanged notification);
-        public void onPlay(Player.OnPlay notification);
-        public void onPause(Player.OnPause notification);
-        public void onSpeedChanged(Player.OnSpeedChanged notification);
-        public void onSeek(Player.OnSeek notification);
-        public void onStop(Player.OnStop notification);
+        void onPropertyChanged(Player.OnPropertyChanged notification);
+        void onPlay(Player.OnPlay notification);
+        void onResume(Player.OnResume notification);
+        void onPause(Player.OnPause notification);
+        void onSpeedChanged(Player.OnSpeedChanged notification);
+        void onSeek(Player.OnSeek notification);
+        void onStop(Player.OnStop notification);
     }
 
     /**
      * Interface that an observer must implement to be notified of System notifications
      */
     public interface SystemNotificationsObserver {
-        public void onQuit(System.OnQuit notification);
-        public void onRestart(System.OnRestart notification);
-        public void onSleep(System.OnSleep notification);
+        void onQuit(System.OnQuit notification);
+        void onRestart(System.OnRestart notification);
+        void onSleep(System.OnSleep notification);
     }
 
     /**
      * Interface that an observer must implement to be notified of Input notifications
      */
     public interface InputNotificationsObserver {
-        public void onInputRequested(Input.OnInputRequested notification);
+        void onInputRequested(Input.OnInputRequested notification);
     }
 
     public interface ApplicationNotificationsObserver {
-        public void onVolumeChanged(Application.OnVolumeChanged notification);
+        void onVolumeChanged(Application.OnVolumeChanged notification);
     }
 
     /**
@@ -725,6 +726,18 @@ public class HostConnection {
                         @Override
                         public void run() {
                             observer.onPlay(apiNotification);
+                        }
+                    });
+                }
+            } else if (notificationName.equals(Player.OnResume.NOTIFICATION_NAME)) {
+                final Player.OnResume apiNotification = new Player.OnResume(params);
+                for (final PlayerNotificationsObserver observer :
+                    playerNotificationsObservers.keySet()) {
+                    Handler handler = playerNotificationsObservers.get(observer);
+                    postOrRunNow(handler, new Runnable() {
+                        @Override
+                        public void run() {
+                            observer.onResume(apiNotification);
                         }
                     });
                 }

--- a/app/src/main/java/org/xbmc/kore/jsonrpc/notification/Player.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/notification/Player.java
@@ -16,8 +16,8 @@
 package org.xbmc.kore.jsonrpc.notification;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import org.xbmc.kore.jsonrpc.ApiNotification;
 import org.xbmc.kore.jsonrpc.type.GlobalType;
 import org.xbmc.kore.utils.JsonUtils;
@@ -72,6 +72,23 @@ public class Player {
         public final NotificationsData data;
 
         public OnPlay(ObjectNode node) {
+            super(node);
+            data = new NotificationsData(node.get(NotificationsData.DATA_NODE));
+        }
+
+        public String getNotificationName() { return NOTIFICATION_NAME; }
+    }
+
+    /**
+     * Player.OnResume notification
+     * Playback of a media item has been resumed. If there is no ID available extra information will be provided.
+     */
+    public static class OnResume extends ApiNotification {
+        public static final String  NOTIFICATION_NAME = "Player.OnResume";
+
+        public final NotificationsData data;
+
+        public OnResume(ObjectNode node) {
             super(node);
             data = new NotificationsData(node.get(NotificationsData.DATA_NODE));
         }


### PR DESCRIPTION
As detailed [here](https://github.com/xbmc/xbmc/pull/13726#issuecomment-378188082), Kodi will stop sending the event `Player.OnPlay` when resuming a video, sending a `Player.OnResume` event instead. This PR handles that change.