### PR TITLE
Fixed issue using drawableRight with vector drawables

### DIFF
--- a/app/src/main/res/layout-land/fragment_remote.xml
+++ b/app/src/main/res/layout-land/fragment_remote.xml
@@ -36,7 +36,7 @@
             android:layout_weight="1"
             android:layout_width="match_parent"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconHome"
+            app:srcCompat="?attr/iconHome"
             android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/home"/>
         <ImageButton
@@ -45,7 +45,7 @@
             android:layout_weight="1"
             android:layout_width="match_parent"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconMovies"
+            app:srcCompat="?attr/iconMovies"
             android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/movies"/>
         <ImageButton
@@ -54,7 +54,7 @@
             android:layout_weight="1"
             android:layout_width="match_parent"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconTvShows"
+            app:srcCompat="?attr/iconTvShows"
             android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/tv_shows"/>
         <ImageButton
@@ -63,7 +63,7 @@
             android:layout_weight="1"
             android:layout_width="match_parent"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconMusic"
+            app:srcCompat="?attr/iconMusic"
             android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/music"/>
         <ImageButton
@@ -72,7 +72,7 @@
             android:layout_weight="1"
             android:layout_width="match_parent"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconPVR"
+            app:srcCompat="?attr/iconPVR"
             android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/pvr"/>
         <ImageButton
@@ -81,7 +81,7 @@
             android:layout_weight="1"
             android:layout_width="match_parent"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconPicture"
+            app:srcCompat="?attr/iconPicture"
             android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/pictures"/>
         <ImageButton
@@ -90,7 +90,7 @@
             android:layout_weight="1"
             android:layout_width="match_parent"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconVideo"
+            app:srcCompat="?attr/iconVideo"
             android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/videos"/>
         <!-- <ImageButton
@@ -99,7 +99,7 @@
             android:layout_weight="1"
             android:layout_width="match_parent"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconFavourites"
+            app:srcCompat="?attr/iconFavourites"
             android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/favourites"/> -->
         <ImageButton
@@ -108,7 +108,7 @@
             android:layout_weight="1"
             android:layout_width="match_parent"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconAddons"
+            app:srcCompat="?attr/iconAddons"
             android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/addons"/>
         <ImageButton
@@ -117,7 +117,7 @@
             android:layout_weight="1"
             android:layout_width="match_parent"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconWeather"
+            app:srcCompat="?attr/iconWeather"
             android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/weather"/>
         <ImageButton
@@ -126,7 +126,7 @@
             android:layout_weight="1"
             android:layout_width="match_parent"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconSettings"
+            app:srcCompat="?attr/iconSettings"
             android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/system"/>
     </LinearLayout>
@@ -220,7 +220,7 @@
                     android:layout_weight="1"
                     android:layout_height="match_parent"
                     style="@style/Widget.Button.Borderless"
-                    android:src="?attr/iconRewind"
+                    app:srcCompat="?attr/iconRewind"
                     android:contentDescription="@string/rewind"/>
                 <ImageButton
                     android:id="@+id/play"
@@ -228,7 +228,7 @@
                     android:layout_weight="1"
                     android:layout_height="match_parent"
                     style="@style/Widget.Button.Borderless"
-                    android:src="?attr/iconPlay"
+                    app:srcCompat="?attr/iconPlay"
                     android:contentDescription="@string/play"/>
                 <ImageButton
                     android:id="@+id/stop"
@@ -236,7 +236,7 @@
                     android:layout_weight="1"
                     android:layout_height="match_parent"
                     style="@style/Widget.Button.Borderless"
-                    android:src="?attr/iconStop"
+                    app:srcCompat="?attr/iconStop"
                     android:contentDescription="@string/stop"/>
                 <ImageButton
                     android:id="@+id/fast_forward"
@@ -244,7 +244,7 @@
                     android:layout_weight="1"
                     android:layout_height="match_parent"
                     style="@style/Widget.Button.Borderless"
-                    android:src="?attr/iconFastForward"
+                    app:srcCompat="?attr/iconFastForward"
                     android:contentDescription="@string/fast_forward"/>
             </LinearLayout>
         </RelativeLayout>

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
               android:orientation="vertical"
               android:layout_width="match_parent"
               android:layout_height="match_parent">
@@ -19,7 +20,7 @@
         <ImageView
             android:layout_height="wrap_content"
             android:layout_width="wrap_content"
-            android:src="@mipmap/ic_launcher"
+            app:srcCompat="@mipmap/ic_launcher"
             android:contentDescription="@string/app_name"/>
 
         <TextView

--- a/app/src/main/res/layout/fragment_info.xml
+++ b/app/src/main/res/layout/fragment_info.xml
@@ -34,6 +34,7 @@
 
     <android.support.v4.widget.SwipeRefreshLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
         android:id="@+id/swipe_refresh_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -109,14 +110,14 @@
                         android:layout_width="@dimen/buttonbar_button_width"
                         android:layout_height="match_parent"
                         style="@style/Widget.Button.Borderless"
-                        android:src="?attr/iconBookmark"
+                        app:srcCompat="?attr/iconBookmark"
                         android:contentDescription="@string/enable_disable"/>
                     <ImageButton
                         android:id="@+id/media_action_add_to_playlist"
                         android:layout_width="@dimen/buttonbar_button_width"
                         android:layout_height="match_parent"
                         style="@style/Widget.Button.Borderless"
-                        android:src="?attr/iconAddToQueue"
+                        app:srcCompat="?attr/iconAddToQueue"
                         android:contentDescription="@string/add_to_playlist"
                         android:visibility="gone"/>
                     <ImageButton
@@ -124,7 +125,7 @@
                         android:layout_width="@dimen/buttonbar_button_width"
                         android:layout_height="match_parent"
                         style="@style/Widget.Button.Borderless"
-                        android:src="?attr/iconDownload"
+                        app:srcCompat="?attr/iconDownload"
                         android:contentDescription="@string/download"
                         android:visibility="gone"/>
                     <ImageButton
@@ -132,7 +133,7 @@
                         android:layout_width="@dimen/buttonbar_button_width"
                         android:layout_height="match_parent"
                         style="@style/Widget.Button.Borderless"
-                        android:src="?attr/iconInfoWWW"
+                        app:srcCompat="?attr/iconInfoWWW"
                         android:contentDescription="@string/imdb"
                         android:visibility="gone"/>
                     <ImageButton
@@ -140,7 +141,7 @@
                         android:layout_width="@dimen/buttonbar_button_width"
                         android:layout_height="match_parent"
                         style="@style/Widget.Button.Borderless"
-                        android:src="?attr/iconSeen"
+                        app:srcCompat="?attr/iconSeen"
                         android:contentDescription="@string/seen"
                         android:visibility="gone"/>
                 </LinearLayout>
@@ -228,7 +229,7 @@
                         android:layout_marginRight="@dimen/small_padding"
                         android:layout_marginEnd="@dimen/small_padding"
                         style="@style/Widget.Button.Borderless"
-                        android:src="?attr/iconExpand"
+                        app:srcCompat="?attr/iconExpand"
                         android:contentDescription="@string/toggle_expand"/>
                 </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_now_playing.xml
+++ b/app/src/main/res/layout/fragment_now_playing.xml
@@ -16,6 +16,7 @@
 -->
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent">
 
@@ -107,7 +108,7 @@
                     android:layout_weight="1"
                     android:layout_height="match_parent"
                     style="@style/Widget.Button.Borderless"
-                    android:src="?attr/iconPrevious"
+                    app:srcCompat="?attr/iconPrevious"
                     android:contentDescription="@string/previous"/>
                 <ImageButton
                     android:id="@+id/rewind"
@@ -115,7 +116,7 @@
                     android:layout_weight="1"
                     android:layout_height="match_parent"
                     style="@style/Widget.Button.Borderless"
-                    android:src="?attr/iconRewind"
+                    app:srcCompat="?attr/iconRewind"
                     android:contentDescription="@string/rewind"/>
                 <ImageButton
                     android:id="@+id/play"
@@ -123,7 +124,7 @@
                     android:layout_weight="1"
                     android:layout_height="match_parent"
                     style="@style/Widget.Button.Borderless"
-                    android:src="?attr/iconPlay"
+                    app:srcCompat="?attr/iconPlay"
                     android:contentDescription="@string/play"/>
                 <ImageButton
                     android:id="@+id/stop"
@@ -131,7 +132,7 @@
                     android:layout_weight="1"
                     android:layout_height="match_parent"
                     style="@style/Widget.Button.Borderless"
-                    android:src="?attr/iconStop"
+                    app:srcCompat="?attr/iconStop"
                     android:contentDescription="@string/stop"/>
                 <ImageButton
                     android:id="@+id/fast_forward"
@@ -139,7 +140,7 @@
                     android:layout_weight="1"
                     android:layout_height="match_parent"
                     style="@style/Widget.Button.Borderless"
-                    android:src="?attr/iconFastForward"
+                    app:srcCompat="?attr/iconFastForward"
                     android:contentDescription="@string/fast_forward"/>
                 <ImageButton
                     android:id="@+id/next"
@@ -147,7 +148,7 @@
                     android:layout_weight="1"
                     android:layout_height="match_parent"
                     style="@style/Widget.Button.Borderless"
-                    android:src="?attr/iconNext"
+                    app:srcCompat="?attr/iconNext"
                     android:contentDescription="@string/next"/>
             </LinearLayout>
 
@@ -167,7 +168,7 @@
                     android:layout_weight="1"
                     android:layout_height="match_parent"
                     style="@style/Widget.Button.Borderless"
-                    android:src="?attr/iconVolumeMute"
+                    app:srcCompat="?attr/iconVolumeMute"
                     android:contentDescription="@string/volume_mute"/>
 
                 <org.xbmc.kore.ui.widgets.VolumeLevelIndicator
@@ -183,7 +184,7 @@
                     android:layout_weight="1"
                     android:layout_height="match_parent"
                     style="@style/Widget.Button.Borderless"
-                    android:src="?attr/iconRepeat"
+                    app:srcCompat="?attr/iconRepeat"
                     android:contentDescription="@string/repeat"/>
                 <org.xbmc.kore.ui.widgets.HighlightButton
                     android:id="@+id/shuffle"
@@ -191,7 +192,7 @@
                     android:layout_weight="1"
                     android:layout_height="match_parent"
                     style="@style/Widget.Button.Borderless"
-                    android:src="?attr/iconShuffle"
+                    app:srcCompat="?attr/iconShuffle"
                     android:contentDescription="@string/shuffle"/>
                 <ImageButton
                     android:id="@+id/overflow"
@@ -199,7 +200,7 @@
                     android:layout_weight="1"
                     android:layout_height="match_parent"
                     style="@style/Widget.Button.Borderless"
-                    android:src="?attr/iconOverflow"
+                    app:srcCompat="?attr/iconOverflow"
                     android:contentDescription="@string/subtitles"/>
             </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_remote.xml
+++ b/app/src/main/res/layout/fragment_remote.xml
@@ -65,7 +65,7 @@
                     android:layout_height="match_parent"
                     android:layout_weight="1"
                     android:contentDescription="@string/rewind"
-                    android:src="?attr/iconRewind"/>
+                    app:srcCompat="?attr/iconRewind"/>
 
                 <ImageButton
                     android:id="@+id/play"
@@ -74,7 +74,7 @@
                     android:layout_height="match_parent"
                     android:layout_weight="1"
                     android:contentDescription="@string/play"
-                    android:src="?attr/iconPlay"/>
+                    app:srcCompat="?attr/iconPlay"/>
 
                 <ImageButton
                     android:id="@+id/stop"
@@ -83,7 +83,7 @@
                     android:layout_height="match_parent"
                     android:layout_weight="1"
                     android:contentDescription="@string/stop"
-                    android:src="?attr/iconStop"/>
+                    app:srcCompat="?attr/iconStop"/>
 
                 <ImageButton
                     android:id="@+id/fast_forward"
@@ -92,7 +92,7 @@
                     android:layout_height="match_parent"
                     android:layout_weight="1"
                     android:contentDescription="@string/fast_forward"
-                    android:src="?attr/iconFastForward"/>
+                    app:srcCompat="?attr/iconFastForward"/>
             </LinearLayout>
 
             <TextView
@@ -132,7 +132,7 @@
             android:layout_weight="1"
             android:layout_height="match_parent"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconHome"
+            app:srcCompat="?attr/iconHome"
             android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/home"/>
         <ImageButton
@@ -141,7 +141,7 @@
             android:layout_weight="1"
             android:layout_height="match_parent"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconMovies"
+            app:srcCompat="?attr/iconMovies"
             android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/movies"/>
         <ImageButton
@@ -150,7 +150,7 @@
             android:layout_weight="1"
             android:layout_height="match_parent"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconTvShows"
+            app:srcCompat="?attr/iconTvShows"
             android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/tv_shows"/>
         <ImageButton
@@ -159,7 +159,7 @@
             android:layout_weight="1"
             android:layout_height="match_parent"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconMusic"
+            app:srcCompat="?attr/iconMusic"
             android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/music"/>
         <ImageButton
@@ -168,7 +168,7 @@
             android:layout_weight="1"
             android:layout_height="match_parent"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconPVR"
+            app:srcCompat="?attr/iconPVR"
             android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/pvr"/>
         <ImageButton
@@ -177,7 +177,7 @@
             android:layout_weight="1"
             android:layout_height="match_parent"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconPicture"
+            app:srcCompat="?attr/iconPicture"
             android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/pictures"/>
         <ImageButton
@@ -186,7 +186,7 @@
             android:layout_weight="1"
             android:layout_height="match_parent"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconVideo"
+            app:srcCompat="?attr/iconVideo"
             android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/videos"/>
         <!-- <ImageButton
@@ -195,7 +195,7 @@
             android:layout_weight="1"
             android:layout_height="match_parent"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconFavourites"
+            app:srcCompat="?attr/iconFavourites"
             android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/favourites"/> -->
         <ImageButton
@@ -204,7 +204,7 @@
             android:layout_weight="1"
             android:layout_height="match_parent"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconAddons"
+            app:srcCompat="?attr/iconAddons"
             android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/addons"/>
         <ImageButton
@@ -213,7 +213,7 @@
             android:layout_weight="1"
             android:layout_height="match_parent"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconWeather"
+            app:srcCompat="?attr/iconWeather"
             android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/weather"/>
         <ImageButton
@@ -222,7 +222,7 @@
             android:layout_weight="1"
             android:layout_height="match_parent"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconSettings"
+            app:srcCompat="?attr/iconSettings"
             android:tint="?attr/defaultButtonColorFilter"
             android:contentDescription="@string/system"/>
     </LinearLayout>

--- a/app/src/main/res/layout/grid_item_album.xml
+++ b/app/src/main/res/layout/grid_item_album.xml
@@ -17,6 +17,7 @@
 
 <android.support.v7.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -44,7 +45,7 @@
             android:layout_alignParentRight="true"
             android:layout_alignParentEnd="true"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconOverflow"
+            app:srcCompat="?attr/iconOverflow"
             android:contentDescription="@string/action_options"/>
 
         <LinearLayout

--- a/app/src/main/res/layout/grid_item_artist.xml
+++ b/app/src/main/res/layout/grid_item_artist.xml
@@ -17,6 +17,7 @@
 
 <android.support.v7.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -61,7 +62,7 @@
             android:layout_height="@dimen/default_icon_size"
             android:padding="@dimen/default_icon_padding"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconOverflow"
+            app:srcCompat="?attr/iconOverflow"
             android:contentDescription="@string/action_options"/>
     </LinearLayout>
 </android.support.v7.widget.CardView>

--- a/app/src/main/res/layout/grid_item_audio_genre.xml
+++ b/app/src/main/res/layout/grid_item_audio_genre.xml
@@ -17,6 +17,7 @@
 
 <android.support.v7.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -48,7 +49,7 @@
             android:layout_height="@dimen/default_icon_size"
             android:padding="@dimen/default_icon_padding"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconOverflow"
+            app:srcCompat="?attr/iconOverflow"
             android:contentDescription="@string/action_options"/>
     </LinearLayout>
 </android.support.v7.widget.CardView>

--- a/app/src/main/res/layout/grid_item_cast.xml
+++ b/app/src/main/res/layout/grid_item_cast.xml
@@ -16,6 +16,7 @@
 -->
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_gravity="start"
@@ -29,13 +30,13 @@
         android:layout_alignParentStart="true"
         android:layout_alignParentLeft="true"
         android:contentDescription="@string/poster"/>
-        <!--android:src="?attr/iconPerson"/>-->
+        <!--app:srcCompat="?attr/iconPerson"/>-->
 
     <!--&lt;!&ndash; Shade to make text easier to read &ndash;&gt;-->
     <!--<ImageView-->
         <!--android:layout_width="match_parent"-->
         <!--android:layout_height="match_parent"-->
-        <!--android:src="?attr/imageViewShade"/>-->
+        <!--app:srcCompat="?attr/imageViewShade"/>-->
 
     <!--
     Somehow i can't make the TextViews work correctly, one below the other when this RelativeLayout is inside a
@@ -79,7 +80,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
-            android:src="?attr/iconOpenInNew"
+            app:srcCompat="?attr/iconOpenInNew"
             android:contentDescription="@string/poster"/>
         <TextView
             android:id="@+id/remaining_cast_count"

--- a/app/src/main/res/layout/grid_item_channel.xml
+++ b/app/src/main/res/layout/grid_item_channel.xml
@@ -17,6 +17,7 @@
 
 <android.support.v7.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -45,7 +46,7 @@
             android:layout_alignParentRight="true"
             android:layout_alignParentEnd="true"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconOverflow"
+            app:srcCompat="?attr/iconOverflow"
             android:contentDescription="@string/action_options"/>
 
         <TextView

--- a/app/src/main/res/layout/grid_item_file.xml
+++ b/app/src/main/res/layout/grid_item_file.xml
@@ -17,6 +17,7 @@
 
 <android.support.v7.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -54,7 +55,7 @@
             android:layout_alignParentRight="true"
             android:layout_alignParentEnd="true"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconOverflow"
+            app:srcCompat="?attr/iconOverflow"
             android:contentDescription="@string/action_options"/>
 
         <TextView

--- a/app/src/main/res/layout/grid_item_host.xml
+++ b/app/src/main/res/layout/grid_item_host.xml
@@ -17,6 +17,7 @@
 
 <android.support.v7.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -35,7 +36,7 @@
             android:padding="@dimen/default_icon_padding"
             android:layout_alignParentStart="true"
             android:layout_alignParentLeft="true"
-            android:src="?attr/iconHosts"/>
+            app:srcCompat="?attr/iconHosts"/>
 
         <ImageView
             android:id="@+id/list_context_menu"
@@ -46,7 +47,7 @@
             android:layout_alignParentRight="true"
             android:layout_alignParentEnd="true"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconOverflow"
+            app:srcCompat="?attr/iconOverflow"
             android:contentDescription="@string/action_options"/>
 
         <TextView

--- a/app/src/main/res/layout/grid_item_movie.xml
+++ b/app/src/main/res/layout/grid_item_movie.xml
@@ -17,6 +17,7 @@
 
 <android.support.v7.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -25,6 +26,7 @@
 
     <RelativeLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
@@ -74,7 +76,7 @@
             android:layout_alignParentEnd="true"
             style="@style/Widget.Button.Borderless"
             android:padding="@dimen/default_icon_padding"
-            android:src="?attr/iconSeen"
+            app:srcCompat="?attr/iconSeen"
             android:contentDescription="@string/seen"/>
     </RelativeLayout>
 

--- a/app/src/main/res/layout/grid_item_playlist.xml
+++ b/app/src/main/res/layout/grid_item_playlist.xml
@@ -17,6 +17,7 @@
 
 <android.support.v7.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     android:id="@+id/card"
     android:layout_width="match_parent"
@@ -53,7 +54,7 @@
             android:layout_alignParentRight="true"
             android:layout_alignParentEnd="true"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconOverflow"
+            app:srcCompat="?attr/iconOverflow"
             android:contentDescription="@string/action_options"/>
 
         <TextView

--- a/app/src/main/res/layout/grid_item_song.xml
+++ b/app/src/main/res/layout/grid_item_song.xml
@@ -17,6 +17,7 @@
 
 <android.support.v7.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -44,7 +45,7 @@
             android:layout_alignParentRight="true"
             android:layout_alignParentEnd="true"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconOverflow"
+            app:srcCompat="?attr/iconOverflow"
             android:contentDescription="@string/action_options"/>
 
         <LinearLayout

--- a/app/src/main/res/layout/list_item_episode.xml
+++ b/app/src/main/res/layout/list_item_episode.xml
@@ -17,6 +17,7 @@
 
 <android.support.v7.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -25,6 +26,7 @@
 
     <RelativeLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
         android:id="@+id/container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
@@ -58,7 +60,7 @@
             android:layout_alignStart="@id/episode_number"
             android:padding="@dimen/default_icon_padding"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconSeen"
+            app:srcCompat="?attr/iconSeen"
             android:contentDescription="@string/seen"/>
 
         <ImageView
@@ -70,7 +72,7 @@
             android:layout_alignParentEnd="true"
             android:padding="@dimen/default_icon_padding"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconOverflow"
+            app:srcCompat="?attr/iconOverflow"
             android:contentDescription="@string/action_options"/>
 
         <TextView

--- a/app/src/main/res/layout/list_item_navigation_drawer.xml
+++ b/app/src/main/res/layout/list_item_navigation_drawer.xml
@@ -16,6 +16,7 @@
 -->
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
@@ -28,7 +29,7 @@
         android:layout_marginRight="@dimen/default_padding"
         android:layout_centerVertical="true"
         android:tint="?attr/defaultButtonColorFilter"
-        android:src="@mipmap/ic_launcher"/>
+        app:srcCompat="@mipmap/ic_launcher"/>
 
     <TextView
         android:id="@+id/drawer_item_title"

--- a/app/src/main/res/layout/list_item_navigation_drawer_host.xml
+++ b/app/src/main/res/layout/list_item_navigation_drawer_host.xml
@@ -17,6 +17,7 @@
 
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/navigation_drawer_item_hosts_height"
@@ -32,7 +33,7 @@
             android:layout_alignParentBottom="true"
             android:layout_alignParentRight="true"
             android:layout_alignParentEnd="true"
-            android:src="@drawable/drawer_image"/>
+            app:srcCompat="@drawable/drawer_image"/>
 
         <ImageView
             android:id="@+id/drawer_item_icon"
@@ -42,7 +43,7 @@
             android:layout_marginLeft="@dimen/default_padding"
             android:layout_marginRight="@dimen/default_padding"
             android:layout_centerVertical="true"
-            android:src="@mipmap/ic_launcher"/>
+            app:srcCompat="@mipmap/ic_launcher"/>
 
         <TextView
             android:id="@+id/drawer_item_title"

--- a/app/src/main/res/layout/list_item_next_episode.xml
+++ b/app/src/main/res/layout/list_item_next_episode.xml
@@ -17,6 +17,7 @@
 
 <android.support.v7.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -25,6 +26,7 @@
 
     <RelativeLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
         android:id="@+id/container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
@@ -47,7 +49,7 @@
             android:layout_alignParentEnd="true"
             android:padding="@dimen/default_icon_padding"
             style="@style/Widget.Button.Borderless"
-            android:src="?attr/iconOverflow"
+            app:srcCompat="?attr/iconOverflow"
             android:contentDescription="@string/action_options"/>
 
         <TextView

--- a/app/src/main/res/layout/list_item_song.xml
+++ b/app/src/main/res/layout/list_item_song.xml
@@ -16,6 +16,7 @@
 -->
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
                 android:id="@+id/container"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -39,7 +40,7 @@
         android:layout_alignParentEnd="true"
         android:layout_centerVertical="true"
         style="@style/Widget.Button.Borderless"
-        android:src="?attr/iconOverflow"
+        app:srcCompat="?attr/iconOverflow"
         android:contentDescription="@string/action_options"/>
 
     <TextView

--- a/app/src/main/res/layout/now_playing_panel.xml
+++ b/app/src/main/res/layout/now_playing_panel.xml
@@ -14,7 +14,8 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-<merge xmlns:android="http://schemas.android.com/apk/res/android">
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <FrameLayout
         android:id="@+id/fragment_container"
@@ -75,7 +76,7 @@
                 android:layout_height="@dimen/default_icon_size"
                 android:layout_gravity="center_vertical"
                 style="@style/Widget.Button.Borderless"
-                android:src="?attr/iconVolumeMute"
+                app:srcCompat="?attr/iconVolumeMute"
                 android:contentDescription="@string/volume_mute"
                 android:visibility="gone"/>
 
@@ -86,7 +87,7 @@
                 android:layout_gravity="center_vertical"
                 style="@style/Widget.Button.Borderless"
                 android:tint="?attr/buttonColorOverPrimary"
-                android:src="?attr/iconPrevious"
+                app:srcCompat="?attr/iconPrevious"
                 android:contentDescription="@string/previous"/>
 
             <ImageButton
@@ -96,7 +97,7 @@
                 android:layout_gravity="center_vertical"
                 style="@style/Widget.Button.Borderless"
                 android:tint="?attr/buttonColorOverPrimary"
-                android:src="?attr/iconPlay"
+                app:srcCompat="?attr/iconPlay"
                 android:contentDescription="@string/play"/>
 
             <ImageButton
@@ -106,7 +107,7 @@
                 android:layout_gravity="center_vertical"
                 style="@style/Widget.Button.Borderless"
                 android:tint="?attr/buttonColorOverPrimary"
-                android:src="?attr/iconNext"
+                app:srcCompat="?attr/iconNext"
                 android:contentDescription="@string/next"/>
         </LinearLayout>
         <org.xbmc.kore.ui.widgets.MediaProgressIndicator
@@ -131,7 +132,7 @@
                 android:layout_weight="1"
                 android:layout_height="match_parent"
                 style="@style/Widget.Button.Borderless"
-                android:src="?attr/iconVolumeMute"
+                app:srcCompat="?attr/iconVolumeMute"
                 android:contentDescription="@string/volume_mute"/>
             <org.xbmc.kore.ui.widgets.VolumeLevelIndicator
                 android:id="@+id/npp_volume_level_indicator"
@@ -147,7 +148,7 @@
                 android:layout_weight="1"
                 android:layout_height="match_parent"
                 style="@style/Widget.Button.Borderless"
-                android:src="?attr/iconRepeat"
+                app:srcCompat="?attr/iconRepeat"
                 android:contentDescription="@string/repeat"/>
             <org.xbmc.kore.ui.widgets.HighlightButton
                 android:id="@+id/npp_shuffle"
@@ -155,7 +156,7 @@
                 android:layout_weight="1"
                 android:layout_height="match_parent"
                 style="@style/Widget.Button.Borderless"
-                android:src="?attr/iconShuffle"
+                app:srcCompat="?attr/iconShuffle"
                 android:contentDescription="@string/shuffle"/>
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/remote_control_pad.xml
+++ b/app/src/main/res/layout/remote_control_pad.xml
@@ -20,21 +20,21 @@
         android:id="@+id/context"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:src="?attr/iconContext"
+        app:srcCompat="?attr/iconContext"
         app:tint="?attr/remoteButtonColorFilter"
         android:contentDescription="@string/codec_info"/>
     <android.support.v7.widget.AppCompatImageView
         android:id="@+id/up"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:src="?attr/iconUp"
+        app:srcCompat="?attr/iconUp"
         app:tint="?attr/remoteButtonColorFilter"
         android:contentDescription="@string/up"/>
     <android.support.v7.widget.AppCompatImageView
         android:id="@+id/info"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:src="?attr/iconInfo"
+        app:srcCompat="?attr/iconInfo"
         app:tint="?attr/remoteButtonColorFilter"
         android:contentDescription="@string/info"/>
 
@@ -42,21 +42,21 @@
         android:id="@+id/left"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:src="?attr/iconLeft"
+        app:srcCompat="?attr/iconLeft"
         app:tint="?attr/remoteButtonColorFilter"
         android:contentDescription="@string/left"/>
     <android.support.v7.widget.AppCompatImageView
         android:id="@+id/select"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:src="?attr/iconSelect"
+        app:srcCompat="?attr/iconSelect"
         app:tint="?attr/remoteButtonColorFilter"
         android:contentDescription="@string/select"/>
     <android.support.v7.widget.AppCompatImageView
         android:id="@+id/right"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:src="?attr/iconRight"
+        app:srcCompat="?attr/iconRight"
         app:tint="?attr/remoteButtonColorFilter"
         android:contentDescription="@string/right"/>
 
@@ -64,21 +64,21 @@
         android:id="@+id/back"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:src="?attr/iconBack"
+        app:srcCompat="?attr/iconBack"
         app:tint="?attr/remoteButtonColorFilter"
         android:contentDescription="@string/back"/>
     <android.support.v7.widget.AppCompatImageView
         android:id="@+id/down"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:src="?attr/iconDown"
+        app:srcCompat="?attr/iconDown"
         app:tint="?attr/remoteButtonColorFilter"
         android:contentDescription="@string/down"/>
     <android.support.v7.widget.AppCompatImageView
         android:id="@+id/osd"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:src="?attr/iconMenu"
+        app:srcCompat="?attr/iconMenu"
         app:tint="?attr/remoteButtonColorFilter"
         android:contentDescription="@string/osd"/>
 </merge>

--- a/app/src/main/res/layout/volume_controller_dialog.xml
+++ b/app/src/main/res/layout/volume_controller_dialog.xml
@@ -2,6 +2,7 @@
 
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -15,7 +16,7 @@
         android:layout_width="@dimen/default_icon_size"
         android:layout_height="@dimen/default_icon_size"
         android:contentDescription="@string/volume_mute"
-        android:src="?attr/iconVolumeMute"
+        app:srcCompat="?attr/iconVolumeMute"
         tools:src="@drawable/ic_volume_off_white_24dp" />
 
     <org.xbmc.kore.ui.widgets.HighlightButton
@@ -24,7 +25,7 @@
         android:layout_width="@dimen/default_icon_size"
         android:layout_height="@dimen/default_icon_size"
         android:contentDescription="@string/volume_mute"
-        android:src="?attr/iconVolumeMute"
+        app:srcCompat="?attr/iconVolumeMute"
         android:visibility="gone"
         tools:src="@drawable/ic_volume_off_white_24dp" />
 

--- a/app/src/main/res/layout/wizard_button_bar.xml
+++ b/app/src/main/res/layout/wizard_button_bar.xml
@@ -32,12 +32,6 @@
         android:paddingLeft="@dimen/large_padding"
         android:paddingRight="@dimen/large_padding"
         android:text="@string/previous"/>
-    <!--android:drawableLeft="?attr/iconChevronLeft"-->
-
-    <!--<View-->
-        <!--style="@style/DefaultDividerV"-->
-        <!--android:layout_marginTop="8dp"-->
-        <!--android:layout_marginBottom="8dp"/>-->
 
     <Button
         android:id="@+id/next"
@@ -48,7 +42,5 @@
         android:gravity="end|center_vertical"
         android:paddingLeft="@dimen/large_padding"
         android:paddingRight="@dimen/large_padding"
-        android:text="@string/next"
-        android:drawableRight="?attr/iconChevronRight"
-        android:drawableEnd="?attr/iconChevronRight"/>
+        android:text="@string/next"/>
 </LinearLayout>

--- a/app/src/main/res/layout/wizard_title.xml
+++ b/app/src/main/res/layout/wizard_title.xml
@@ -15,7 +15,8 @@
    limitations under the License.
 -->
 
-<merge xmlns:android="http://schemas.android.com/apk/res/android">
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:app="http://schemas.android.com/apk/res-auto">
     <View
         android:layout_width="match_parent"
         android:layout_height="@dimen/wizard_title"
@@ -23,6 +24,6 @@
     <ImageView
         android:layout_width="match_parent"
         android:layout_height="@dimen/wizard_title"
-        android:src="@drawable/drawer_image"
+        app:srcCompat="@drawable/drawer_image"
         android:scaleType="centerCrop"/>
 </merge>


### PR DESCRIPTION
Stumbled upon this when running Kore on a pre-lollipop device. Kore crashed due to the drawableRight attribute that wasn't able to find the vector drawable.
AFAICT the drawableRight wasn't used and could simply be removed. Strange thing that the left button already had the drawableLeft commented out.