### PR TITLE
Reinstate the ability to bookmark addons

### DIFF
--- a/app/src/main/java/org/xbmc/kore/Settings.java
+++ b/app/src/main/java/org/xbmc/kore/Settings.java
@@ -187,4 +187,18 @@ public class Settings {
         }
         return result;
     }
+
+    /**
+     * Keys for bookmarked addons stored in preferences
+     */
+    private static final String KEY_PREF_BOOKMARKED_ADDONS = "bookmarked";
+    public static String getBookmarkedAddonsPrefKey(int hostId) {
+        return Settings.KEY_PREF_BOOKMARKED_ADDONS + hostId;
+    }
+    private static final String KEY_PREF_NAME_BOOKMARKED_ADDON = "name_";
+    public static String getNameBookmarkedAddonsPrefKey(int hostId) {
+        return Settings.KEY_PREF_NAME_BOOKMARKED_ADDON + hostId + "_";
+    }
+    public static final String DEFAULT_PREF_NAME_BOOKMARKED_ADDON = "Content";
+
 }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonInfoFragment.java
@@ -15,14 +15,16 @@
  */
 package org.xbmc.kore.ui.sections.addon;
 
-import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Handler;
+import android.preference.PreferenceManager;
 import android.view.View;
 import android.widget.Toast;
 
 import org.xbmc.kore.R;
+import org.xbmc.kore.Settings;
+import org.xbmc.kore.host.HostManager;
 import org.xbmc.kore.jsonrpc.ApiCallback;
 import org.xbmc.kore.jsonrpc.method.Addons;
 import org.xbmc.kore.jsonrpc.type.AddonType;
@@ -167,6 +169,8 @@ public class AddonInfoFragment extends AbstractInfoFragment {
     }
 
     private void setupPinButton() {
+        final int hostId = HostManager.getInstance(getContext()).getHostInfo().getId();
+
         setOnPinClickedListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -175,23 +179,23 @@ public class AddonInfoFragment extends AbstractInfoFragment {
                 String name = getDataHolder().getTitle();
                 String path = addonId;
 
-                SharedPreferences prefs = getActivity().getSharedPreferences("addons", Context.MODE_PRIVATE);
-                Set<String> bookmarks = new HashSet<>(prefs.getStringSet("bookmarked", Collections.<String>emptySet()));
+                SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
+                Set<String> bookmarks = new HashSet<>(prefs.getStringSet(Settings.getBookmarkedAddonsPrefKey(hostId), Collections.<String>emptySet()));
                 if (isBookmarked)
                     bookmarks.add(path);
                 else
                     bookmarks.remove(path);
                 prefs.edit()
-                     .putStringSet("bookmarked", bookmarks)
-                     .putString("name_" + path, name)
+                     .putStringSet(Settings.getBookmarkedAddonsPrefKey(hostId), bookmarks)
+                     .putString(Settings.getNameBookmarkedAddonsPrefKey(hostId) + path, name)
                      .apply();
                 Toast.makeText(getActivity(), isBookmarked ? R.string.addon_pinned : R.string.addon_unpinned, Toast.LENGTH_SHORT).show();
                 setPinButtonState(!isBookmarked);
             }
         });
 
-        SharedPreferences prefs = getActivity().getSharedPreferences("addons", Context.MODE_PRIVATE);
-        Set<String> bookmarked = prefs.getStringSet("bookmarked", Collections.<String>emptySet());
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
+        Set<String> bookmarked = prefs.getStringSet(Settings.getBookmarkedAddonsPrefKey(hostId), Collections.<String>emptySet());
         setPinButtonState(bookmarked.contains(addonId));
     }
 }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListContainerFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListContainerFragment.java
@@ -15,13 +15,15 @@
  */
 package org.xbmc.kore.ui.sections.addon;
 
-import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 
 import org.xbmc.kore.R;
-import org.xbmc.kore.ui.AbstractTabsFragment;
+import org.xbmc.kore.Settings;
+import org.xbmc.kore.host.HostManager;
 import org.xbmc.kore.ui.AbstractInfoFragment;
+import org.xbmc.kore.ui.AbstractTabsFragment;
 import org.xbmc.kore.ui.sections.file.MediaFileListFragment;
 import org.xbmc.kore.utils.LogUtils;
 import org.xbmc.kore.utils.TabsAdapter;
@@ -44,13 +46,15 @@ public class AddonListContainerFragment extends AbstractTabsFragment {
         if (arguments == null)
             arguments = new Bundle();
 
+        int hostId = HostManager.getInstance(getContext()).getHostInfo().getId();
+
         TabsAdapter tabsAdapter = new TabsAdapter(getActivity(), getChildFragmentManager());
-        SharedPreferences prefs = getActivity().getSharedPreferences("addons", Context.MODE_PRIVATE);
-        Set<String> bookmarked = prefs.getStringSet("bookmarked", Collections.<String>emptySet());
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
+        Set<String> bookmarked = prefs.getStringSet(Settings.getBookmarkedAddonsPrefKey(hostId), Collections.<String>emptySet());
         long baseFragmentId = 70 + bookmarked.size() * 100;
         tabsAdapter.addTab(AddonListFragment.class, new Bundle(), R.string.addons, baseFragmentId);
         for (String path: bookmarked) {
-            String name = prefs.getString("name_" + path, "Content");
+            String name = prefs.getString(Settings.getNameBookmarkedAddonsPrefKey(hostId) + path, Settings.DEFAULT_PREF_NAME_BOOKMARKED_ADDON);
             arguments.putParcelable(MediaFileListFragment.ROOT_PATH,
                                     new MediaFileListFragment.FileLocation(name, "plugin://" + path, true));
             tabsAdapter.addTab(MediaFileListFragment.class, arguments, name, ++baseFragmentId);

--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonsActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonsActivity.java
@@ -45,7 +45,7 @@ public class AddonsActivity extends BaseMediaActivity
 
     @Override
     protected Fragment createFragment() {
-        return new AddonListFragment();
+        return new AddonListContainerFragment();
     }
 
     @Override


### PR DESCRIPTION
Somewhere along the line, the edits made in/around b0f2adb876d6650b002bb97042491c227abfe53f where lost because the `AddonsActivity` was instantiating `AddonListFragment` instead of `AddonListContainerFragment`.
This PR reinstates the ability to bookmark and access addons, and refactors the way those settings were being stored in the Shared Preferences to use the default Shared Preferences and take into account the specific host we're connected to.