### PR TITLE
Fixed reported NPE when calling notifySomethingIsPlaying

### DIFF
--- a/app/src/main/java/org/xbmc/kore/host/HostConnectionObserver.java
+++ b/app/src/main/java/org/xbmc/kore/host/HostConnectionObserver.java
@@ -684,6 +684,19 @@ public class HostConnectionObserver
         observer.playerOnStop();
     }
 
+    private boolean getPropertiesResultChanged(PlayerType.PropertyValue getPropertiesResult) {
+        return (hostState.lastGetPropertiesResult == null) ||
+                (hostState.lastGetPropertiesResult.speed != getPropertiesResult.speed) ||
+                (hostState.lastGetPropertiesResult.shuffled != getPropertiesResult.shuffled) ||
+                (!hostState.lastGetPropertiesResult.repeat.equals(getPropertiesResult.repeat));
+    }
+
+    private boolean getItemResultChanged(ListType.ItemsAll getItemResult) {
+        return (hostState.lastGetItemResult == null) ||
+                (hostState.lastGetItemResult.id != getItemResult.id) ||
+                (!hostState.lastGetItemResult.label.equals(getItemResult.label));
+    }
+
     /**
      * Something is playing or paused, notify observers
      * Only notifies them if the result is different from the last one
@@ -700,11 +713,8 @@ public class HostConnectionObserver
                 PlayerEventsObserver.PLAYER_IS_PAUSED : PlayerEventsObserver.PLAYER_IS_PLAYING;
         if (forceReply ||
                 (hostState.lastCallResult != currentCallResult) ||
-                (hostState.lastGetPropertiesResult.speed != getPropertiesResult.speed) ||
-                (hostState.lastGetPropertiesResult.shuffled != getPropertiesResult.shuffled) ||
-                (!hostState.lastGetPropertiesResult.repeat.equals(getPropertiesResult.repeat)) ||
-                (hostState.lastGetItemResult.id != getItemResult.id) ||
-                (!hostState.lastGetItemResult.label.equals(getItemResult.label))) {
+                getPropertiesResultChanged(getPropertiesResult) ||
+                getItemResultChanged(getItemResult)) {
             hostState.lastCallResult = currentCallResult;
             hostState.lastGetActivePlayerResult = getActivePlayersResult;
             hostState.lastGetPropertiesResult = getPropertiesResult;


### PR DESCRIPTION
We have a couple of NPE reports in de play dev console, regarding the HostState.lastGetPropertiesResult so I've added a check.
Not really sure why this can happen as https://github.com/xbmc/Kore/compare/master...poisdeux:bug/NPE_hostconnectionobserver?expand=1#diff-922ad3ff344c49bd6e152e32d02a1078R715 should catch the situation where there is no last state saved yet.
