### PR TITLE
Fixed NPE in the VolumeControllerDialog

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/generic/VolumeControllerDialogFragmentListener.java
+++ b/app/src/main/java/org/xbmc/kore/ui/generic/VolumeControllerDialogFragmentListener.java
@@ -36,9 +36,9 @@ public class VolumeControllerDialogFragmentListener extends AppCompatDialogFragm
     private static final String TAG = LogUtils.makeLogTag(VolumeControllerDialogFragmentListener.class);
     private static final int AUTO_DISMISS_DELAY = 2000;
 
-    @BindView(R.id.npp_volume_mute) HighlightButton volumeMuteButton;
-    @BindView(R.id.npp_volume_muted_indicator) HighlightButton volumeMutedIndicatorButton;
-    @BindView(R.id.npp_volume_level_indicator) VolumeLevelIndicator volumeLevelIndicator;
+    @BindView(R.id.vcd_volume_mute) HighlightButton volumeMuteButton;
+    @BindView(R.id.vcd_volume_muted_indicator) HighlightButton volumeMutedIndicatorButton;
+    @BindView(R.id.vcd_volume_level_indicator) VolumeLevelIndicator volumeLevelIndicator;
 
     private Unbinder unbinder;
     private Handler callbackHandler = new Handler();
@@ -125,6 +125,11 @@ public class VolumeControllerDialogFragmentListener extends AppCompatDialogFragm
     @Override
     public void onDestroyView() {
         super.onDestroyView();
+
+        HostConnectionObserver hostConnectionObserver = hostManager.getHostConnectionObserver();
+        if (hostConnectionObserver != null) {
+            hostConnectionObserver.unregisterApplicationObserver(this);
+        }
         unbinder.unbind();
     }
 

--- a/app/src/main/res/layout/volume_controller_dialog.xml
+++ b/app/src/main/res/layout/volume_controller_dialog.xml
@@ -10,7 +10,7 @@
     tools:background="@color/dark_content_background_dim_70pct">
 
     <org.xbmc.kore.ui.widgets.HighlightButton
-        android:id="@+id/npp_volume_mute"
+        android:id="@+id/vcd_volume_mute"
         style="@style/Widget.Button.Borderless"
         android:layout_width="@dimen/default_icon_size"
         android:layout_height="@dimen/default_icon_size"
@@ -19,7 +19,7 @@
         tools:src="@drawable/ic_volume_off_white_24dp" />
 
     <org.xbmc.kore.ui.widgets.HighlightButton
-        android:id="@+id/npp_volume_muted_indicator"
+        android:id="@+id/vcd_volume_muted_indicator"
         style="@style/Widget.Button.Borderless"
         android:layout_width="@dimen/default_icon_size"
         android:layout_height="@dimen/default_icon_size"
@@ -29,7 +29,7 @@
         tools:src="@drawable/ic_volume_off_white_24dp" />
 
     <org.xbmc.kore.ui.widgets.VolumeLevelIndicator
-        android:id="@+id/npp_volume_level_indicator"
+        android:id="@+id/vcd_volume_level_indicator"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"


### PR DESCRIPTION
The applicationObserver was never unregistered resulting in a memory leak
and even worse, crashes when destroyed dialogs still got called through
the applicationOnVolumeChanged callback.

Also changed the view resource identifiers used by the controller dialog
as it used the same resource identifiers as the now playing panel.