### PR TITLE
Fixes a possible race condition and starting multiple instances

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/generic/VolumeControllerDialogFragmentListener.java
+++ b/app/src/main/java/org/xbmc/kore/ui/generic/VolumeControllerDialogFragmentListener.java
@@ -124,13 +124,12 @@ public class VolumeControllerDialogFragmentListener extends AppCompatDialogFragm
 
     @Override
     public void onDestroyView() {
-        super.onDestroyView();
-
         HostConnectionObserver hostConnectionObserver = hostManager.getHostConnectionObserver();
         if (hostConnectionObserver != null) {
             hostConnectionObserver.unregisterApplicationObserver(this);
         }
         unbinder.unbind();
+        super.onDestroyView();
     }
 
     private void registerObserver() {

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
@@ -290,6 +290,9 @@ public class RemoteActivity extends BaseActivity
      */
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
+        if (event.getAction() != KeyEvent.ACTION_DOWN)
+            return false;
+
         boolean handled = VolumeControllerDialogFragmentListener.handleVolumeKeyEvent(this, event);
 
         // Show volume change dialog if the event was handled and we are not in


### PR DESCRIPTION
The `onDestroyView` method is used to unregister the application observer
from the dialog. However the parent got called first which destroys the
view of the dialog. This could lead to _Null Pointer Exceptions_ when
the listener tries to update the UI of the dialog right after it was
destroyed.

The `VolumeControllerDialogFragmentListener` was created twice as creation
was triggered on both the down and up event of the volume keys. This has
been changed to only trigger on down events.