### PR TITLE
Fix back button not exiting the app when on the remote activity

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
@@ -290,16 +290,16 @@ public class RemoteActivity extends BaseActivity
      */
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
-        if (event.getAction() != KeyEvent.ACTION_DOWN)
-            return false;
+        boolean handled = false;
+        if (event.getAction() == KeyEvent.ACTION_DOWN) {
+            handled = VolumeControllerDialogFragmentListener.handleVolumeKeyEvent(this, event);
 
-        boolean handled = VolumeControllerDialogFragmentListener.handleVolumeKeyEvent(this, event);
-
-        // Show volume change dialog if the event was handled and we are not in
-        // first page, which already contains a volume control
-        if (handled && (viewPager.getCurrentItem() != 0)) {
-            new VolumeControllerDialogFragmentListener()
-                    .show(getSupportFragmentManager(), VolumeControllerDialogFragmentListener.class.getName());
+            // Show volume change dialog if the event was handled and we are not in
+            // first page, which already contains a volume control
+            if (handled && (viewPager.getCurrentItem() != 0)) {
+                new VolumeControllerDialogFragmentListener()
+                        .show(getSupportFragmentManager(), VolumeControllerDialogFragmentListener.class.getName());
+            }
         }
         return handled || super.dispatchKeyEvent(event);
     }


### PR DESCRIPTION
Hitting the back button in the remote activity was being ignored, thus preventing exiting the app. This issue was inadvertidely introduced in d11dbe68531f8e9f17cbbead11fa4a879eb89ee4