### PR TITLE
Use a ChooserTargetService to direct a shared url to a specific host

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,9 @@
                 <data android:host="player.vimeo.com"/>
                 <data android:host="www.svtplay.se"/>
             </intent-filter>
+
+            <meta-data android:name="android.service.chooser.chooser_target_service"
+                android:value=".service.HostChooserTargetService" />
         </activity>
 
         <activity android:name="org.xbmc.kore.ui.sections.hosts.HostManagerActivity"/>
@@ -78,6 +81,12 @@
             android:exported="false"/>
         <service android:name="org.xbmc.kore.service.IntentActionsService"
             android:exported="false"/>
+        <service android:name="org.xbmc.kore.service.HostChooserTargetService"
+            android:permission="android.permission.BIND_CHOOSER_TARGET_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.chooser.ChooserTargetService" />
+            </intent-filter>
+        </service>
 
         <uses-library android:required="false" android:name="com.sec.android.app.multiwindow"/>
         <meta-data android:name="com.sec.android.support.multiwindow" android:value="true" />

--- a/app/src/main/java/org/xbmc/kore/service/HostChooserTargetService.java
+++ b/app/src/main/java/org/xbmc/kore/service/HostChooserTargetService.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Dan Pasanen. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.xbmc.kore.service;
+
+import android.annotation.TargetApi;
+import android.content.ComponentName;
+import android.content.IntentFilter;
+import android.graphics.drawable.Icon;
+import android.os.Build;
+import android.os.Bundle;
+import android.service.chooser.ChooserTarget;
+import android.service.chooser.ChooserTargetService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.xbmc.kore.host.HostInfo;
+import org.xbmc.kore.host.HostManager;
+import org.xbmc.kore.R;
+
+@TargetApi(Build.VERSION_CODES.M)
+public class HostChooserTargetService extends ChooserTargetService {
+
+    @Override
+    public List<ChooserTarget> onGetChooserTargets(ComponentName targetActivityName, IntentFilter matchedFilter) {
+        final List<ChooserTarget> targets = new ArrayList<>();
+        HostManager hostManager = HostManager.getInstance(this);
+
+        final Icon icon = Icon.createWithResource(this, R.mipmap.ic_launcher);
+        final float score = 0;
+        final ComponentName componentName = new ComponentName(getPackageName(), "org.xbmc.kore.ui.sections.remote.RemoteActivity");
+
+        for (HostInfo host : hostManager.getHosts()) {
+            Bundle intentExtras = new Bundle();
+            intentExtras.putInt("hostId", host.getId());
+            targets.add(new ChooserTarget(host.getName(), icon, score, componentName, intentExtras));
+        }
+
+        return targets;
+    }
+}

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
@@ -39,6 +39,7 @@ import android.widget.Toast;
 import org.xbmc.kore.R;
 import org.xbmc.kore.Settings;
 import org.xbmc.kore.host.HostConnectionObserver;
+import org.xbmc.kore.host.HostInfo;
 import org.xbmc.kore.host.HostManager;
 import org.xbmc.kore.jsonrpc.method.Application;
 import org.xbmc.kore.jsonrpc.method.AudioLibrary;
@@ -384,6 +385,18 @@ public class RemoteActivity extends BaseActivity
         String videoUrl = toPluginUrl(videoUri);
         if (videoUrl == null) {
             videoUrl = videoUri.toString();
+        }
+
+        // If a host was passed from the intent use it
+        int hostId = intent.getIntExtra("hostId", 0);
+        if (hostId > 0) {
+            HostManager hostManager = HostManager.getInstance(this);
+            for (HostInfo host : hostManager.getHosts()) {
+                if (host.getId() == hostId) {
+                    hostManager.switchHost(host);
+                    break;
+                }
+            }
         }
 
         String title = getString(R.string.app_name);


### PR DESCRIPTION
Addresses #430 

NOTES:
- Screenshot of what it looks like: https://imgur.com/a/DFWENEn
- I have not checked if this breaks pre-M devices as I do not have any up and running at the moment. (this functionality was added in M)
- The official YouTube app sucks because it doesn't appear to use the standard android share dialog.
- I put my name on the copyright for the new java file, I am unsure if this is proper, but a quick look at other files appeared to be the convention in this project. Let me know if that is not the case.