### PR TITLE
Support local play when Kodi requires authentication

### DIFF
--- a/app/src/main/java/org/xbmc/kore/utils/FileDownloadHelper.java
+++ b/app/src/main/java/org/xbmc/kore/utils/FileDownloadHelper.java
@@ -108,7 +108,9 @@ public class FileDownloadHelper {
 
         public String getMediaUrl(HostInfo hostInfo) {
             String pathforUrl = fileName.replaceAll(" ", "%20").replaceAll("'","%27");
-            String videoUrl = String.format("http://%s:%d/vfs/%s", hostInfo.getAddress(),
+            String credentials = (hostInfo.getPassword() == null || hostInfo.getPassword().isEmpty()) ? "" :
+                String.format("%s:%s@", hostInfo.getUsername(), hostInfo.getPassword());
+            String videoUrl = String.format("http://%s%s:%d/vfs/%s", credentials, hostInfo.getAddress(),
                     hostInfo.getHttpPort(), pathforUrl);
             return videoUrl;
         }


### PR DESCRIPTION
Added credentials to URL when using local play.
Without it trying to play videos on the local device would fail because the external player couldn't connect to Kodi if it is configured to require a password.