### PR TITLE
Progressbar synchronisation

### DIFF
--- a/app/src/main/java/org/xbmc/kore/host/HostConnectionObserver.java
+++ b/app/src/main/java/org/xbmc/kore/host/HostConnectionObserver.java
@@ -27,6 +27,7 @@ import org.xbmc.kore.jsonrpc.notification.Player.NotificationsData;
 import org.xbmc.kore.jsonrpc.notification.Input;
 import org.xbmc.kore.jsonrpc.notification.System;
 import org.xbmc.kore.jsonrpc.type.ApplicationType;
+import org.xbmc.kore.jsonrpc.type.GlobalType;
 import org.xbmc.kore.jsonrpc.type.ListType;
 import org.xbmc.kore.jsonrpc.type.PlayerType;
 import org.xbmc.kore.utils.LogUtils;
@@ -101,6 +102,13 @@ public class HostConnectionObserver
          * Notifies that media is stopped/nothing is playing
          */
         public void playerOnStop();
+
+        /**
+         * Notifies player seeking
+         * @param time New time
+         * @param seekOffset Offset relative to the previous time
+         */
+        public void playerOnSeek(GlobalType.Time time, GlobalType.Time seekOffset);
 
         /**
          * Called when we get a connection error
@@ -403,7 +411,12 @@ public class HostConnectionObserver
 
     public void onSeek(org.xbmc.kore.jsonrpc.notification.Player.OnSeek notification) {
         // Just start our chain calls
-        chainCallGetActivePlayers();
+        // chainCallGetActivePlayers();
+
+        List<PlayerEventsObserver> allObservers = new ArrayList<>(playerEventsObservers);
+        for (final PlayerEventsObserver observer : allObservers) {
+            observer.playerOnSeek(notification.time, notification.seekoffset);
+        }
     }
 
     public void onStop(org.xbmc.kore.jsonrpc.notification.Player.OnStop notification) {

--- a/app/src/main/java/org/xbmc/kore/service/ConnectionObserversManagerService.java
+++ b/app/src/main/java/org/xbmc/kore/service/ConnectionObserversManagerService.java
@@ -28,6 +28,7 @@ import org.xbmc.kore.Settings;
 import org.xbmc.kore.host.HostConnectionObserver;
 import org.xbmc.kore.host.HostManager;
 import org.xbmc.kore.jsonrpc.notification.Player;
+import org.xbmc.kore.jsonrpc.type.GlobalType;
 import org.xbmc.kore.jsonrpc.type.ListType;
 import org.xbmc.kore.jsonrpc.type.PlayerType;
 import org.xbmc.kore.utils.LogUtils;
@@ -214,6 +215,11 @@ public class ConnectionObserversManagerService extends Service
                 }
             }
         }, 5000);
+    }
+
+    @Override
+    public void playerOnSeek(GlobalType.Time time, GlobalType.Time seekOffset) {
+
     }
 
     public void playerNoResultsYet() {

--- a/app/src/main/java/org/xbmc/kore/service/NotificationObserver.java
+++ b/app/src/main/java/org/xbmc/kore/service/NotificationObserver.java
@@ -40,6 +40,7 @@ import org.xbmc.kore.Settings;
 import org.xbmc.kore.host.HostConnectionObserver;
 import org.xbmc.kore.host.HostManager;
 import org.xbmc.kore.jsonrpc.notification.Player;
+import org.xbmc.kore.jsonrpc.type.GlobalType;
 import org.xbmc.kore.jsonrpc.type.ListType;
 import org.xbmc.kore.jsonrpc.type.PlayerType;
 import org.xbmc.kore.ui.sections.remote.RemoteActivity;
@@ -104,6 +105,11 @@ public class NotificationObserver
 
     public void playerOnStop() {
         notifyNothingPlaying();
+    }
+
+    @Override
+    public void playerOnSeek(GlobalType.Time time, GlobalType.Time seekOffset) {
+
     }
 
     public void playerNoResultsYet() {

--- a/app/src/main/java/org/xbmc/kore/service/PauseCallObserver.java
+++ b/app/src/main/java/org/xbmc/kore/service/PauseCallObserver.java
@@ -23,6 +23,7 @@ import org.xbmc.kore.R;
 import org.xbmc.kore.host.HostConnectionObserver;
 import org.xbmc.kore.host.HostManager;
 import org.xbmc.kore.jsonrpc.method.Player;
+import org.xbmc.kore.jsonrpc.type.GlobalType;
 import org.xbmc.kore.jsonrpc.type.ListType;
 import org.xbmc.kore.jsonrpc.type.PlayerType;
 import org.xbmc.kore.utils.LogUtils;
@@ -110,6 +111,11 @@ public class PauseCallObserver extends PhoneStateListener
         isPlaying = false;
         shouldResume = false;
         stopListener();
+    }
+
+    @Override
+    public void playerOnSeek(GlobalType.Time time, GlobalType.Time seekOffset) {
+
     }
 
     @Override

--- a/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
@@ -45,6 +45,7 @@ import org.xbmc.kore.jsonrpc.ApiCallback;
 import org.xbmc.kore.jsonrpc.ApiMethod;
 import org.xbmc.kore.jsonrpc.method.Application;
 import org.xbmc.kore.jsonrpc.method.Player;
+import org.xbmc.kore.jsonrpc.type.GlobalType;
 import org.xbmc.kore.jsonrpc.type.ListType;
 import org.xbmc.kore.jsonrpc.type.PlayerType;
 import org.xbmc.kore.ui.generic.NavigationDrawerFragment;
@@ -315,6 +316,11 @@ public abstract class BaseMediaActivity extends BaseActivity
         // the next item in a playlist
         callbackHandler.removeCallbacks(hidePanelRunnable);
         callbackHandler.postDelayed(hidePanelRunnable, 1000);
+    }
+
+    @Override
+    public void playerOnSeek(GlobalType.Time time, GlobalType.Time seekOffset) {
+        nowPlayingPanel.setMediaProgress(time);
     }
 
     @Override

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
@@ -585,6 +585,11 @@ public class NowPlayingFragment extends Fragment
         infoMessage.setText(String.format(getString(R.string.connected_to), hostInfo.getName()));
     }
 
+    @Override
+    public void playerOnSeek(GlobalType.Time time, GlobalType.Time seekOffset) {
+        mediaProgressIndicator.setProgress(time.ToSeconds());
+    }
+
     public void playerOnConnectionError(int errorCode, String description) {
         HostInfo hostInfo = hostManager.getHostInfo();
 

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/PlaylistFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/PlaylistFragment.java
@@ -46,6 +46,7 @@ import org.xbmc.kore.jsonrpc.ApiMethod;
 import org.xbmc.kore.jsonrpc.HostConnection;
 import org.xbmc.kore.jsonrpc.method.Player;
 import org.xbmc.kore.jsonrpc.method.Playlist;
+import org.xbmc.kore.jsonrpc.type.GlobalType;
 import org.xbmc.kore.jsonrpc.type.ListType;
 import org.xbmc.kore.jsonrpc.type.PlayerType;
 import org.xbmc.kore.jsonrpc.type.PlaylistType;
@@ -261,6 +262,11 @@ public class PlaylistFragment extends Fragment
         infoMessage.setText(String.format(getString(R.string.connected_to), hostInfo.getName()));
 
         lastCallResult = PLAYER_IS_STOPPED;
+    }
+
+    @Override
+    public void playerOnSeek(GlobalType.Time time, GlobalType.Time seekOffset) {
+
     }
 
     public void playerOnConnectionError(int errorCode, String description) {

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
@@ -47,6 +47,7 @@ import org.xbmc.kore.jsonrpc.method.GUI;
 import org.xbmc.kore.jsonrpc.method.Input;
 import org.xbmc.kore.jsonrpc.method.System;
 import org.xbmc.kore.jsonrpc.method.VideoLibrary;
+import org.xbmc.kore.jsonrpc.type.GlobalType;
 import org.xbmc.kore.jsonrpc.type.ListType;
 import org.xbmc.kore.jsonrpc.type.PlayerType;
 import org.xbmc.kore.service.ConnectionObserversManagerService;
@@ -641,6 +642,11 @@ public class RemoteActivity extends BaseActivity
             setImageViewBackground(null);
         }
         lastImageUrl = null;
+    }
+
+    @Override
+    public void playerOnSeek(GlobalType.Time time, GlobalType.Time seekOffset) {
+
     }
 
     public void playerNoResultsYet() {

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteFragment.java
@@ -434,6 +434,11 @@ public class RemoteFragment extends Fragment
         infoMessage.setText(String.format(getString(R.string.connected_to), hostInfo.getName()));
     }
 
+    @Override
+    public void playerOnSeek(GlobalType.Time time, GlobalType.Time seekOffset) {
+
+    }
+
     public void playerOnConnectionError(int errorCode, String description) {
         HostInfo hostInfo = hostManager.getHostInfo();
 

--- a/app/src/main/java/org/xbmc/kore/ui/widgets/NowPlayingPanel.java
+++ b/app/src/main/java/org/xbmc/kore/ui/widgets/NowPlayingPanel.java
@@ -144,6 +144,10 @@ public class NowPlayingPanel extends SlidingUpPanelLayout {
         mediaProgressIndicator.setProgress(time.ToSeconds());
     }
 
+    public void setMediaProgress(GlobalType.Time time) {
+        mediaProgressIndicator.setProgress(time.ToSeconds());
+    }
+
     /**
      * Returns the progression indicator used for media progression
      * @return


### PR DESCRIPTION
When seeking in Kodi, the progressbars in Kore are not synchronised. Although the Player.OnSeek notifications are captured in kore, they are not passed to the HostConnectionObserver.PlayerEventsObserver.

1. I extended the PlayerEventObserver interface with the method:
https://github.com/xbmc/Kore/blob/65ae63966e8e9b0ecb2d242feaf966ef942f1eb2/app/src/main/java/org/xbmc/kore/host/HostConnectionObserver.java#L106-L111
2. I passed the OnSeek notification in the HostConnectionObserver class:
https://github.com/xbmc/Kore/blob/65ae63966e8e9b0ecb2d242feaf966ef942f1eb2/app/src/main/java/org/xbmc/kore/host/HostConnectionObserver.java#L412-L420

This enables the classes BaseMediaActivity and NowPlayingFragment to update the progressbars.


Not sure why this was not implemented though, probably a good reason I'm not aware of.
