### PR TITLE
add addon search

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
@@ -338,7 +338,6 @@ public abstract class BaseMediaActivity extends BaseActivity
 
     @Override
     public void inputOnInputRequested(String title, String type, String value) {
-
     }
 
     @Override


### PR DESCRIPTION
This pr adds a generic search function that should work for every addon that has a search function.

The current behavior of the search buttons in the addons view is nothing but a socket timeout and a not responding app during everlasting reconnections when using tcp connection.

The problem with the addon search is that it is actualy a `GetDirectory` request. But to obtain search results a text input have to be done. To do so you have to send the search string to the backend. But because of `Socket.getOutputStream()` blocks a request for sending until the response of the previous request is received the search string is sent via http as workaround (to overcome this nio channels could be used in the future).

There is also a fallback implementation to prevent socket timeouts and possible reconnection difficulties. This fallback sends a dummy string to the backend to force the response of the search request. The ugly thing is that this dummy string shows up in the addon history.

resolves https://github.com/xbmc/Kore/issues/597