### PR TITLE
Implemented scrolling title on remote screen

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteFragment.java
@@ -206,6 +206,12 @@ public class RemoteFragment extends Fragment
                 buttons[i].setVisibility(shownItems.contains(String.valueOf(i)) ? View.VISIBLE : View.GONE);
         }
 
+        nowPlayingTitle.setClickable(true);
+        nowPlayingTitle.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) { v.setSelected(!v.isSelected()); }
+        });
+
         return root;
     }
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -159,6 +159,11 @@
         <item name="android:paddingTop">@dimen/default_padding</item>
         <item name="android:paddingBottom">@dimen/small_padding</item>
         <item name="android:singleLine">true</item>
+        <item name="android:ellipsize">marquee</item>
+        <item name="android:marqueeRepeatLimit">marquee_forever</item>
+        <item name="android:focusable">true</item>
+        <item name="android:focusableInTouchMode">true</item>
+        <item name="android:scrollHorizontally">true</item>
     </style>
 
     <style name="TextAppearance.Media.Remote.Details">


### PR DESCRIPTION
When the title is longer than fits on screen, it wil first be ellipsized
and when user clicks on the title it will start scrolling to make it
fully readable.

This should fix request #599 

Currently I only implemented scrolling the title text on the main remote screen. We probably also want to implement this on the general media info screens as well.