### PR TITLE
Add support for OnAVStart event and tweak HostConnectionOberver

### DIFF
--- a/app/src/main/java/org/xbmc/kore/host/HostInfo.java
+++ b/app/src/main/java/org/xbmc/kore/host/HostInfo.java
@@ -307,7 +307,11 @@ public class HostInfo {
         return kodiVersionMajor >= KODI_V17_KRYPTON;
     }
 
-    /**
+	public boolean isLeiaOrLater() {
+		return kodiVersionMajor >= KODI_V18_LEIA;
+	}
+
+	/**
 	 * Returns the URL of the host
 	 * @return HTTP URL eg. http://192.168.1.1:8080
 	 */

--- a/app/src/main/java/org/xbmc/kore/jsonrpc/notification/Player.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/notification/Player.java
@@ -159,6 +159,42 @@ public class Player {
     }
 
     /**
+     * Player.OnAVStart notification
+     * Will be triggered on playback start if the first frame was drawn.
+     * If there is no ID available extra information will be provided
+     */
+    public static class OnAVStart extends ApiNotification {
+        public static final String  NOTIFICATION_NAME = "Player.OnAVStart";
+
+        public final NotificationsData data;
+
+        public OnAVStart(ObjectNode node) {
+            super(node);
+            data = new NotificationsData(node.get(NotificationsData.DATA_NODE));
+        }
+
+        public String getNotificationName() { return NOTIFICATION_NAME; }
+    }
+
+    /**
+     * Player.OnAVChange notification
+     * Audio- or videostream has changed.
+     * If there is no ID available extra information will be provided
+     */
+    public static class OnAVChange extends ApiNotification {
+        public static final String  NOTIFICATION_NAME = "Player.OnAVChange";
+
+        public final NotificationsData data;
+
+        public OnAVChange(ObjectNode node) {
+            super(node);
+            data = new NotificationsData(node.get(NotificationsData.DATA_NODE));
+        }
+
+        public String getNotificationName() { return NOTIFICATION_NAME; }
+    }
+
+    /**
      * Notification data for Player
      */
     public static class NotificationsPlayer {

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
@@ -151,7 +151,7 @@ public class RemoteActivity extends BaseActivity
         setupActionBar();
 
         // Periodic Check of Kodi version
-        hostManager.checkAndUpdateKodiVersion(hostManager.getHostInfo());
+        hostManager.checkAndUpdateKodiVersion();
 
         // If we should start playing something
 


### PR DESCRIPTION
This fixes https://github.com/xbmc/Kore/issues/602 by supporting the OnAVStart event, which supersedes OnPlay in Kodi Leia (introduced in this Kodi PR: https://github.com/xbmc/xbmc/pull/13726).

Some notes regarding this PR:
1. If Kodi is Leia or higher ignore the OnPlay event in favour of OnAVStart, so that we don't twice process the same thing;
2. Ignore the OnAVChange event in the `HostConnectionObserver`, as this event is fired very often by Kodi (about 3 times in quick succession when playing starts), and we are really interested is in the OnAVStart event;
3. This PR also introduces a mechanism to prevent simultaneous calls to `checkWhatsPlaying`. With Kodi Leia we're getting more events and processing them results in more calls to `checkWhatsPlaying`. This PR introduces a flag that tries to guarantee that there's only one call going on. It's not thread-safe, as i think it's not worth the trouble (if we get a race condition in this call there's no harm done, we're just calling Kodi one more time than needed). I'm not happy about the solution because every exit point of `checkWhatsPlaying` needs to unset the flag and that can introduce bugs in the future. I plan to revisit this to maybe use `Futures` so localizing the change to the flag in the same function.