### PR TITLE
Fix adaptive icon foreground dimensions

### DIFF
--- a/app/src/main/res/drawable-v21/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable-v21/ic_launcher_foreground.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
+    android:width="72dp"
+    android:height="72dp"
     android:viewportHeight="135.46667"
     android:viewportWidth="135.46666">
     <path


### PR DESCRIPTION
Hello, I found the foreground layer drawable is incorrectly sized which causes display issues in certain parts of the system settings. The correct size should be 72dp as per the [adaptive icon documentation](https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive).

Here are some screenshots to show the effects of the change.

24dp vs 72dp on a Samsung Note 8
![image](https://user-images.githubusercontent.com/5179255/52898188-b6a36200-323f-11e9-869e-6344a7df5855.png)

24dp vs 72dp inside Samsung Secure Folder
![image](https://user-images.githubusercontent.com/5179255/52898277-a93aa780-3240-11e9-8208-afcf1ec51635.png)

24dp on API 27 emulator
![image](https://user-images.githubusercontent.com/5179255/52898235-447f4d00-3240-11e9-90f6-ff32a4d96418.png)

72dp on API 27 emulator
![image](https://user-images.githubusercontent.com/5179255/52898250-7395be80-3240-11e9-8ea3-b626e9a10bd8.png)
