### PR TITLE
Implement scrolling title on now playing and general media info screens

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
@@ -35,6 +35,7 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.widget.NestedScrollView;
 import android.support.v4.widget.SwipeRefreshLayout;
+import android.support.v4.widget.TextViewCompat;
 import android.text.TextUtils;
 import android.util.DisplayMetrics;
 import android.view.LayoutInflater;
@@ -374,6 +375,21 @@ abstract public class AbstractInfoFragment extends AbstractFragment
     @SuppressLint("StringFormatInvalid")
     protected void updateView(DataHolder dataHolder) {
         titleTextView.setText(dataHolder.getTitle());
+        titleTextView.post(new Runnable() {
+            @Override
+            public void run() {
+                int lines = titleTextView.getLineCount();
+                int maxLines = TextViewCompat.getMaxLines(titleTextView);
+                if (lines > maxLines) {
+                    titleTextView.setHorizontallyScrolling(true);
+                    titleTextView.setClickable(true);
+                    titleTextView.setOnClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View v) { v.setSelected(!v.isSelected()); }
+                    });
+                }
+            }
+        });
         underTitleTextView.setText(dataHolder.getUnderTitle());
         detailsRightTextView.setText(dataHolder.getDetails());
 

--- a/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
@@ -381,11 +381,21 @@ abstract public class AbstractInfoFragment extends AbstractFragment
                 int lines = titleTextView.getLineCount();
                 int maxLines = TextViewCompat.getMaxLines(titleTextView);
                 if (lines > maxLines) {
-                    titleTextView.setHorizontallyScrolling(true);
+                    titleTextView.setEllipsize(TextUtils.TruncateAt.END);
                     titleTextView.setClickable(true);
                     titleTextView.setOnClickListener(new View.OnClickListener() {
                         @Override
-                        public void onClick(View v) { v.setSelected(!v.isSelected()); }
+                        public void onClick(View v) {
+                            v.setSelected(!v.isSelected());
+                            TextUtils.TruncateAt ellipsize;
+                            if (v.isSelected()) {
+                                ellipsize = TextUtils.TruncateAt.MARQUEE;
+                            } else {
+                                ellipsize = TextUtils.TruncateAt.END;
+                            }
+                            titleTextView.setEllipsize(ellipsize);
+                            titleTextView.setHorizontallyScrolling(v.isSelected());
+                        }
                     });
                 }
             }

--- a/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
@@ -35,7 +35,6 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.widget.NestedScrollView;
 import android.support.v4.widget.SwipeRefreshLayout;
-import android.support.v4.widget.TextViewCompat;
 import android.text.TextUtils;
 import android.util.DisplayMetrics;
 import android.view.LayoutInflater;
@@ -375,31 +374,7 @@ abstract public class AbstractInfoFragment extends AbstractFragment
     @SuppressLint("StringFormatInvalid")
     protected void updateView(DataHolder dataHolder) {
         titleTextView.setText(dataHolder.getTitle());
-        titleTextView.post(new Runnable() {
-            @Override
-            public void run() {
-                int lines = titleTextView.getLineCount();
-                int maxLines = TextViewCompat.getMaxLines(titleTextView);
-                if (lines > maxLines) {
-                    titleTextView.setEllipsize(TextUtils.TruncateAt.END);
-                    titleTextView.setClickable(true);
-                    titleTextView.setOnClickListener(new View.OnClickListener() {
-                        @Override
-                        public void onClick(View v) {
-                            v.setSelected(!v.isSelected());
-                            TextUtils.TruncateAt ellipsize;
-                            if (v.isSelected()) {
-                                ellipsize = TextUtils.TruncateAt.MARQUEE;
-                            } else {
-                                ellipsize = TextUtils.TruncateAt.END;
-                            }
-                            titleTextView.setEllipsize(ellipsize);
-                            titleTextView.setHorizontallyScrolling(v.isSelected());
-                        }
-                    });
-                }
-            }
-        });
+        titleTextView.post(UIUtils.getMarqueeToggleableAction(titleTextView));
         underTitleTextView.setText(dataHolder.getUnderTitle());
         detailsRightTextView.setText(dataHolder.getDetails());
 

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
@@ -20,7 +20,6 @@ import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.v4.app.Fragment;
-import android.support.v4.widget.TextViewCompat;
 import android.text.TextUtils;
 import android.util.DisplayMetrics;
 import android.view.LayoutInflater;
@@ -753,31 +752,7 @@ public class NowPlayingFragment extends Fragment
         }
 
         mediaTitle.setText(title);
-        mediaTitle.post(new Runnable() {
-            @Override
-            public void run() {
-                int lines = mediaTitle.getLineCount();
-                int maxLines = TextViewCompat.getMaxLines(mediaTitle);
-                if (lines > maxLines) {
-                    mediaTitle.setEllipsize(TextUtils.TruncateAt.END);
-                    mediaTitle.setClickable(true);
-                    mediaTitle.setOnClickListener(new View.OnClickListener() {
-                        @Override
-                        public void onClick(View v) {
-                            v.setSelected(!v.isSelected());
-                            TextUtils.TruncateAt ellipsize;
-                            if (v.isSelected()) {
-                                ellipsize = TextUtils.TruncateAt.MARQUEE;
-                            } else {
-                                ellipsize = TextUtils.TruncateAt.END;
-                            }
-                            mediaTitle.setEllipsize(ellipsize);
-                            mediaTitle.setHorizontallyScrolling(v.isSelected());
-                        }
-                    });
-                }
-            }
-        });
+        mediaTitle.post(UIUtils.getMarqueeToggleableAction(mediaTitle));
         mediaUndertitle.setText(underTitle);
 
         mediaProgressIndicator.setOnProgressChangeListener(this);

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
@@ -759,11 +759,21 @@ public class NowPlayingFragment extends Fragment
                 int lines = mediaTitle.getLineCount();
                 int maxLines = TextViewCompat.getMaxLines(mediaTitle);
                 if (lines > maxLines) {
-                    mediaTitle.setHorizontallyScrolling(true);
+                    mediaTitle.setEllipsize(TextUtils.TruncateAt.END);
                     mediaTitle.setClickable(true);
                     mediaTitle.setOnClickListener(new View.OnClickListener() {
                         @Override
-                        public void onClick(View v) { v.setSelected(!v.isSelected()); }
+                        public void onClick(View v) {
+                            v.setSelected(!v.isSelected());
+                            TextUtils.TruncateAt ellipsize;
+                            if (v.isSelected()) {
+                                ellipsize = TextUtils.TruncateAt.MARQUEE;
+                            } else {
+                                ellipsize = TextUtils.TruncateAt.END;
+                            }
+                            mediaTitle.setEllipsize(ellipsize);
+                            mediaTitle.setHorizontallyScrolling(v.isSelected());
+                        }
                     });
                 }
             }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
@@ -20,6 +20,7 @@ import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.v4.app.Fragment;
+import android.support.v4.widget.TextViewCompat;
 import android.text.TextUtils;
 import android.util.DisplayMetrics;
 import android.view.LayoutInflater;
@@ -752,6 +753,21 @@ public class NowPlayingFragment extends Fragment
         }
 
         mediaTitle.setText(title);
+        mediaTitle.post(new Runnable() {
+            @Override
+            public void run() {
+                int lines = mediaTitle.getLineCount();
+                int maxLines = TextViewCompat.getMaxLines(mediaTitle);
+                if (lines > maxLines) {
+                    mediaTitle.setHorizontallyScrolling(true);
+                    mediaTitle.setClickable(true);
+                    mediaTitle.setOnClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View v) { v.setSelected(!v.isSelected()); }
+                    });
+                }
+            }
+        });
         mediaUndertitle.setText(underTitle);
 
         mediaProgressIndicator.setOnProgressChangeListener(this);

--- a/app/src/main/java/org/xbmc/kore/utils/UIUtils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/UIUtils.java
@@ -29,6 +29,7 @@ import android.os.Vibrator;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.v4.widget.SwipeRefreshLayout;
+import android.support.v4.widget.TextViewCompat;
 import android.support.v7.app.AlertDialog;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
@@ -610,6 +611,42 @@ public class UIUtils {
         } else {
             button.setMode(RepeatModeButton.MODE.ALL);
         }
+    }
+
+    /**
+     * Returns a {@link Runnable} that sets up toggleable scrolling behavior on a {@link TextView}
+     * if the number of lines to be displayed exceeds the maximum lines limit supported by the TextView.
+     * Can be applied by using {@link View#post(Runnable)}.
+     *
+     * @param textView TextView that the Runnable should apply against
+     * @return Runnable
+     */
+    public static Runnable getMarqueeToggleableAction(final TextView textView) {
+        return new Runnable() {
+            @Override
+            public void run() {
+                int lines = textView.getLineCount();
+                int maxLines = TextViewCompat.getMaxLines(textView);
+                if (lines > maxLines) {
+                    textView.setEllipsize(TextUtils.TruncateAt.END);
+                    textView.setClickable(true);
+                    textView.setOnClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View v) {
+                            v.setSelected(!v.isSelected());
+                            TextUtils.TruncateAt ellipsize;
+                            if (v.isSelected()) {
+                                ellipsize = TextUtils.TruncateAt.MARQUEE;
+                            } else {
+                                ellipsize = TextUtils.TruncateAt.END;
+                            }
+                            textView.setEllipsize(ellipsize);
+                            textView.setHorizontallyScrolling(v.isSelected());
+                        }
+                    });
+                }
+            }
+        };
     }
 
     /**

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -178,6 +178,10 @@
         <item name="android:paddingTop">@dimen/small_padding</item>
         <item name="android:paddingBottom">@dimen/small_padding</item>
         <item name="android:maxLines">2</item>
+        <item name="android:ellipsize">marquee</item>
+        <item name="android:marqueeRepeatLimit">marquee_forever</item>
+        <item name="android:focusable">true</item>
+        <item name="android:focusableInTouchMode">true</item>
     </style>
 
     <style name="TextAppearance.Media.Subtitle">


### PR DESCRIPTION
Hello 😃 following on from #612 for issue #599

When the title length would exceed maxLines, convert it instead to a single line ellipsized title which scrolls horizontally when focused. Titles that would fit normally on <= 2 lines are unaffected.

Found the marquee doesn't take effect unless `setHorizontallyScrolling()` is directly called which is why it is there instead of in styles.