### PR TITLE
Fix issues with connection threads

### DIFF
--- a/app/src/main/java/org/xbmc/kore/host/HostConnectionObserver.java
+++ b/app/src/main/java/org/xbmc/kore/host/HostConnectionObserver.java
@@ -57,17 +57,22 @@ public class HostConnectionObserver
 
     public interface PlaylistEventsObserver {
         /**
+         * Notifies that a playlist has been cleared
          * @param playlistId of playlist that has been cleared
          */
         void playlistOnClear(int playlistId);
 
-        void playlistChanged(int playlistId);
-
         /**
-         * @param playlists the available playlists on the server
+         * Notifies about the available playlists on Kodi
+         * @param playlists Available playlists
          */
         void playlistsAvailable(ArrayList<GetPlaylist.GetPlaylistResult> playlists);
 
+        /**
+         * Notifies that an error occured when fetching playlists
+         * @param errorCode Error code
+         * @param description Error description
+         */
         void playlistOnError(int errorCode, String description);
     }
 
@@ -164,8 +169,11 @@ public class HostConnectionObserver
     private List<ApplicationEventsObserver> applicationEventsObservers = new ArrayList<>();
     private List<PlaylistEventsObserver> playlistEventsObservers = new ArrayList<>();
 
+    // This controls the frequency with wich the playlist is checked.
+    // It's checked everytime it reaches 0, being reset afterwards
+    private int checkPlaylistFrequencyCounter = 0;
+
     // Associate the Handler with the UI thread
-    int checkPlaylistCounter = 0;
     private Handler checkerHandler = new Handler(Looper.getMainLooper());
     private Runnable httpCheckerRunnable = new Runnable() {
         @Override
@@ -183,11 +191,15 @@ public class HostConnectionObserver
             if (!applicationEventsObservers.isEmpty())
                 getApplicationProperties();
 
-            if (!playlistEventsObservers.isEmpty() && checkPlaylistCounter > 1) {
-                checkPlaylist();
-                checkPlaylistCounter = 0;
+            if (!playlistEventsObservers.isEmpty()) {
+                if (checkPlaylistFrequencyCounter <= 0) {
+                    // Check playlist and reset the frequency counter
+                    checkPlaylist();
+                    checkPlaylistFrequencyCounter = 1;
+                } else {
+                    checkPlaylistFrequencyCounter--;
+                }
             }
-            checkPlaylistCounter++;
 
             checkerHandler.postDelayed(this, HTTP_NOTIFICATION_CHECK_INTERVAL);
         }
@@ -234,26 +246,18 @@ public class HostConnectionObserver
         }
     };
 
-    public class HostState {
-        private int lastCallResult = PlayerEventsObserver.PLAYER_NO_RESULT;
-        private PlayerType.GetActivePlayersReturnType lastGetActivePlayerResult = null;
-        private PlayerType.PropertyValue lastGetPropertiesResult = null;
-        private ListType.ItemsAll lastGetItemResult = null;
-        private boolean volumeMuted = false;
-        private int volumeLevel = -1;  // -1 indicates no volumeLevel known
-        private int lastErrorCode;
-        private String lastErrorDescription;
-
-        public int getVolumeLevel() {
-            return volumeLevel;
-        }
-
-        public boolean isVolumeMuted() {
-            return volumeMuted;
-        }
+    private static class HostState {
+        int lastCallResult = PlayerEventsObserver.PLAYER_NO_RESULT;
+        PlayerType.GetActivePlayersReturnType lastGetActivePlayerResult = null;
+        PlayerType.PropertyValue lastGetPropertiesResult = null;
+        ListType.ItemsAll lastGetItemResult = null;
+        boolean volumeMuted = false;
+        int volumeLevel = -1;  // -1 indicates no volumeLevel known
+        int lastErrorCode;
+        String lastErrorDescription;
+        ArrayList<GetPlaylist.GetPlaylistResult> lastGetPlaylistResults = null;
     }
-
-    public HostState hostState;
+    private HostState hostState;
 
     public HostConnectionObserver(HostConnection connection) {
         this.hostState = new HostState();
@@ -264,14 +268,15 @@ public class HostConnectionObserver
      * Registers a new observer that will be notified about player events
      * @param observer Observer
      */
-    public void registerPlayerObserver(PlayerEventsObserver observer, boolean replyImmediately) {
+    public void registerPlayerObserver(PlayerEventsObserver observer) {
         if (this.connection == null)
             return;
 
         if (!playerEventsObservers.contains(observer))
             playerEventsObservers.add(observer);
 
-        if (replyImmediately) replyWithLastResult(observer);
+        // Reply immediatelly
+        replyWithLastResult(observer);
 
         if (playerEventsObservers.size() == 1) {
             // If this is the first observer, start checking through HTTP or register us
@@ -297,8 +302,7 @@ public class HostConnectionObserver
                            " observers.");
 
         if (playerEventsObservers.isEmpty()) {
-            // No more observers, so unregister us from the host connection, or stop
-            // the http checker thread
+            // No more observers. If through TCP unregister us from the host connection
             if (connection.getProtocol() == HostConnection.PROTOCOL_TCP) {
                 connection.unregisterPlayerNotificationsObserver(this);
                 connection.unregisterSystemNotificationsObserver(this);
@@ -311,22 +315,16 @@ public class HostConnectionObserver
     /**
      * Registers a new observer that will be notified about application events
      * @param observer Observer
-     * @param replyImmediately Wether to immediatlely issue a reply with the current status
      */
-    public void registerApplicationObserver(ApplicationEventsObserver observer, boolean replyImmediately) {
+    public void registerApplicationObserver(ApplicationEventsObserver observer) {
         if (this.connection == null)
             return;
 
         if (!applicationEventsObservers.contains(observer))
             applicationEventsObservers.add(observer);
 
-        if (replyImmediately) {
-            if( hostState.volumeLevel == -1 ) {
-                getApplicationProperties();
-            } else {
-                observer.applicationOnVolumeChanged(hostState.volumeLevel, hostState.volumeMuted);
-            }
-        }
+        // Reply immediatelly
+        replyWithLastResult(observer);
 
         if (applicationEventsObservers.size() == 1) {
             // If this is the first observer, start checking through HTTP or register us
@@ -350,8 +348,7 @@ public class HostConnectionObserver
                            " observers.");
 
         if (applicationEventsObservers.isEmpty()) {
-            // No more observers, so unregister us from the host connection, or stop
-            // the http checker thread
+            // No more observers. If through TCP unregister us from the host connection
             if (connection.getProtocol() == HostConnection.PROTOCOL_TCP) {
                 connection.unregisterApplicationNotificationsObserver(this);
             }
@@ -361,29 +358,27 @@ public class HostConnectionObserver
     /**
      * Registers a new observer that will be notified about playlist events
      * @param observer Observer
-     * @param replyImmediately Whether to immediately issue a request if there are playlists available
      */
-    public void registerPlaylistObserver(PlaylistEventsObserver observer, boolean replyImmediately) {
+    public void registerPlaylistObserver(PlaylistEventsObserver observer) {
         if (this.connection == null)
             return;
 
-        if ( ! playlistEventsObservers.contains(observer) ) {
+        if (!playlistEventsObservers.contains(observer) ) {
             playlistEventsObservers.add(observer);
         }
+
+        // Reply immediatelly
+        replyWithLastResult(observer);
 
         if (playlistEventsObservers.size() == 1) {
             if (connection.getProtocol() == HostConnection.PROTOCOL_TCP) {
                 connection.registerPlaylistNotificationsObserver(this, checkerHandler);
             }
-
             startCheckerHandler();
         }
-
-        if (replyImmediately)
-            checkPlaylist();
     }
 
-    public void unregisterPlaylistObserver(PlayerEventsObserver observer) {
+    public void unregisterPlaylistObserver(PlaylistEventsObserver observer) {
         playlistEventsObservers.remove(observer);
 
         LogUtils.LOGD(TAG, "Unregistering playlist observer " + observer.getClass().getSimpleName() +
@@ -391,11 +386,11 @@ public class HostConnectionObserver
                            " observers.");
 
         if (playlistEventsObservers.isEmpty()) {
-            // No more observers, so unregister us from the host connection, or stop
-            // the http checker thread
+            // No more observers. If through TCP unregister us from the host connection
             if (connection.getProtocol() == HostConnection.PROTOCOL_TCP) {
                 connection.unregisterPlaylistNotificationsObserver(this);
             }
+            hostState.lastGetPlaylistResults = null;
         }
     }
 
@@ -407,6 +402,8 @@ public class HostConnectionObserver
             observer.observerOnStopObserving();
 
         playerEventsObservers.clear();
+        playlistEventsObservers.clear();
+        applicationEventsObservers.clear();
 
         if (connection.getProtocol() == HostConnection.PROTOCOL_TCP) {
             connection.unregisterPlayerNotificationsObserver(this);
@@ -416,7 +413,7 @@ public class HostConnectionObserver
             connection.unregisterPlaylistNotificationsObserver(this);
             checkerHandler.removeCallbacks(tcpCheckerRunnable);
         }
-        hostState.lastCallResult = PlayerEventsObserver.PLAYER_NO_RESULT;
+        hostState = new HostState();
     }
 
     @Override
@@ -522,6 +519,11 @@ public class HostConnectionObserver
 
     @Override
     public void onPlaylistCleared(Playlist.OnClear notification) {
+        if (hostState.lastGetPlaylistResults != null)
+            hostState.lastGetPlaylistResults.clear();
+        else
+            hostState.lastGetPlaylistResults = new ArrayList<>();
+
         for (PlaylistEventsObserver observer : playlistEventsObservers) {
             observer.playlistOnClear(notification.playlistId);
         }
@@ -529,16 +531,12 @@ public class HostConnectionObserver
 
     @Override
     public void onPlaylistItemAdded(Playlist.OnAdd notification) {
-        for (PlaylistEventsObserver observer : playlistEventsObservers) {
-            observer.playlistChanged(notification.playlistId);
-        }
+        checkPlaylist();
     }
 
     @Override
     public void onPlaylistItemRemoved(Playlist.OnRemove notification) {
-        for (PlaylistEventsObserver observer : playlistEventsObservers) {
-            observer.playlistChanged(notification.playlistId);
-        }
+        checkPlaylist();
     }
 
     private void startCheckerHandler() {
@@ -577,7 +575,6 @@ public class HostConnectionObserver
         }, checkerHandler);
     }
 
-    private ArrayList<GetPlaylist.GetPlaylistResult> prevGetPlaylistResults = new ArrayList<>();
     private boolean isCheckingPlaylist = false;
     private void checkPlaylist() {
         if (isCheckingPlaylist)
@@ -588,10 +585,12 @@ public class HostConnectionObserver
         connection.execute(new GetPlaylist(connection), new ApiCallback<ArrayList<GetPlaylist.GetPlaylistResult>>() {
             @Override
             public void onSuccess(ArrayList<GetPlaylist.GetPlaylistResult> result) {
+                LogUtils.LOGD(TAG, "Checked playlist, got results: " + result.size());
                 isCheckingPlaylist = false;
 
                 if (result.isEmpty()) {
-                    callPlaylistsOnClear(prevGetPlaylistResults);
+                    callPlaylistsOnClear(hostState.lastGetPlaylistResults);
+                    hostState.lastGetPlaylistResults = result;
                     return;
                 }
 
@@ -599,19 +598,19 @@ public class HostConnectionObserver
                     observer.playlistsAvailable(result);
                 }
 
-                // Handle onClear for HTTP only connections
-                for (GetPlaylist.GetPlaylistResult getPlaylistResult : result) {
-                    for (int i = 0; i < prevGetPlaylistResults.size(); i++) {
-                        if (getPlaylistResult.id == prevGetPlaylistResults.get(i).id) {
-                            prevGetPlaylistResults.remove(i);
-                            break;
+                // Handle cleared playlists
+                if (hostState.lastGetPlaylistResults != null) {
+                    for (GetPlaylist.GetPlaylistResult getPlaylistResult : result) {
+                        for (int i = 0; i < hostState.lastGetPlaylistResults.size(); i++) {
+                            if (getPlaylistResult.id == hostState.lastGetPlaylistResults.get(i).id) {
+                                hostState.lastGetPlaylistResults.remove(i);
+                                break;
+                            }
                         }
                     }
+                    callPlaylistsOnClear(hostState.lastGetPlaylistResults);
                 }
-
-                callPlaylistsOnClear(prevGetPlaylistResults);
-
-                prevGetPlaylistResults = result;
+                hostState.lastGetPlaylistResults = result;
             }
 
             @Override
@@ -622,10 +621,11 @@ public class HostConnectionObserver
                     observer.playlistOnError(errorCode, description);
                 }
             }
-        }, new Handler());
+        }, checkerHandler);
     }
 
     private void callPlaylistsOnClear(ArrayList<GetPlaylist.GetPlaylistResult> clearedPlaylists) {
+        if (clearedPlaylists == null) return;
         for (GetPlaylist.GetPlaylistResult getPlaylistResult : clearedPlaylists) {
             for (PlaylistEventsObserver observer : playlistEventsObservers) {
                 observer.playlistOnClear(getPlaylistResult.id);
@@ -933,11 +933,11 @@ public class HostConnectionObserver
     }
 
     /**
-     * Replies to the observer with the last result we got.
+     * Replies to the player observer with the last result we got.
      * If we have no result, nothing will be called on the observer interface.
-     * @param observer Observer to call with last result
+     * @param observer Player observer to call with last result
      */
-    public void replyWithLastResult(PlayerEventsObserver observer) {
+    private void replyWithLastResult(PlayerEventsObserver observer) {
         switch (hostState.lastCallResult) {
             case PlayerEventsObserver.PLAYER_CONNECTION_ERROR:
                 notifyConnectionError(hostState.lastErrorCode, hostState.lastErrorDescription, observer);
@@ -956,15 +956,40 @@ public class HostConnectionObserver
     }
 
     /**
+     * Replies to the application observer with the last result we got.
+     * If we have no result, nothing will be called on the observer interface.
+     * @param observer Application observer to call with last result
+     */
+    private void replyWithLastResult(ApplicationEventsObserver observer) {
+        if (hostState.volumeLevel == -1) {
+            getApplicationProperties();
+        } else {
+            observer.applicationOnVolumeChanged(hostState.volumeLevel, hostState.volumeMuted);
+        }
+    }
+    /**
+     * Replies to the playlist observer with the last result we got.
+     * If we have no result, nothing will be called on the observer interface.
+     * @param observer Playlist observer to call with last result
+     */
+    private void replyWithLastResult(PlaylistEventsObserver observer) {
+        if (hostState.lastGetPlaylistResults != null)
+            observer.playlistsAvailable(hostState.lastGetPlaylistResults);
+        else
+            checkPlaylist();
+    }
+
+    /**
      * Forces a refresh of the current cached results
      */
-    public void forceRefreshResults() {
-        LogUtils.LOGD(TAG, "Forcing a refresh");
+    public void refreshWhatsPlaying() {
+        LogUtils.LOGD(TAG, "Forcing a refresh of what's playing");
         forceReply = true;
         checkWhatsPlaying();
     }
 
-    public HostState getHostState() {
-        return hostState;
+    public void refreshPlaylists() {
+        LogUtils.LOGD(TAG, "Forcing a refresh of playlists");
+        checkPlaylist();
     }
 }

--- a/app/src/main/java/org/xbmc/kore/host/HostManager.java
+++ b/app/src/main/java/org/xbmc/kore/host/HostManager.java
@@ -198,10 +198,14 @@ public class HostManager {
 	 */
 	public HostConnection getConnection() {
         if (currentHostConnection == null) {
-            currentHostInfo = getHostInfo();
+            synchronized (this) {
+                if (currentHostConnection == null) {
+                    currentHostInfo = getHostInfo();
 
-            if (currentHostInfo != null) {
-                currentHostConnection = new HostConnection(currentHostInfo);
+                    if (currentHostInfo != null) {
+                        currentHostConnection = new HostConnection(currentHostInfo);
+                    }
+                }
             }
         }
 		return currentHostConnection;

--- a/app/src/main/java/org/xbmc/kore/host/actions/GetPlaylist.java
+++ b/app/src/main/java/org/xbmc/kore/host/actions/GetPlaylist.java
@@ -22,6 +22,7 @@ import org.xbmc.kore.jsonrpc.HostConnection;
 import org.xbmc.kore.jsonrpc.method.Playlist;
 import org.xbmc.kore.jsonrpc.type.ListType;
 import org.xbmc.kore.jsonrpc.type.PlaylistType;
+import org.xbmc.kore.utils.LogUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -34,6 +35,7 @@ import java.util.concurrent.ExecutionException;
  * available.
  */
 public class GetPlaylist implements Callable<ArrayList<GetPlaylist.GetPlaylistResult>> {
+    private static final String TAG = LogUtils.makeLogTag(GetPlaylist.class);
 
     private final static String[] propertiesToGet = new String[] {
             ListType.FieldsAll.ART,
@@ -62,7 +64,7 @@ public class GetPlaylist implements Callable<ArrayList<GetPlaylist.GetPlaylistRe
 
     /**
      * Use this to get the first non-empty playlist
-     * @param hostConnection
+     * @param hostConnection {@link HostConnection} to use
      */
     public GetPlaylist(HostConnection hostConnection) {
         this.hostConnection = hostConnection;
@@ -70,7 +72,7 @@ public class GetPlaylist implements Callable<ArrayList<GetPlaylist.GetPlaylistRe
 
     /**
      * Use this to get a playlist for a specific playlist type
-     * @param hostConnection
+     * @param hostConnection {@link HostConnection} to use
      * @param playlistType should be one of the types from {@link org.xbmc.kore.jsonrpc.type.PlaylistType.GetPlaylistsReturnType}.
      *                     If null the first non-empty playlist is returned.
      */
@@ -81,8 +83,8 @@ public class GetPlaylist implements Callable<ArrayList<GetPlaylist.GetPlaylistRe
 
     /**
      * Use this to get a playlist for a specific playlist id
-     * @param hostConnection
-     * @param playlistId
+     * @param hostConnection {@link HostConnection} to use
+     * @param playlistId Kodi's playlist id
      */
     public GetPlaylist(HostConnection hostConnection, int playlistId) {
         this.hostConnection = hostConnection;

--- a/app/src/main/java/org/xbmc/kore/service/ConnectionObserversManagerService.java
+++ b/app/src/main/java/org/xbmc/kore/service/ConnectionObserversManagerService.java
@@ -81,13 +81,13 @@ public class ConnectionObserversManagerService extends Service
 
         if (hostConnectionObserver == null) {
             hostConnectionObserver = connectionObserver;
-            hostConnectionObserver.registerPlayerObserver(this, true);
+            hostConnectionObserver.registerPlayerObserver(this);
         } else if (hostConnectionObserver != connectionObserver) {
             // There has been a change in hosts.
             // Unregister the previous one and register the current one
             hostConnectionObserver.unregisterPlayerObserver(this);
             hostConnectionObserver = connectionObserver;
-            hostConnectionObserver.registerPlayerObserver(this, true);
+            hostConnectionObserver.registerPlayerObserver(this);
         }
 
         // If we get killed after returning from here, restart

--- a/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
@@ -447,10 +447,10 @@ public abstract class BaseMediaActivity extends BaseActivity
         if (hostConnectionObserver == null)
             return;
 
-        hostConnectionObserver.registerApplicationObserver(this, true);
-        hostConnectionObserver.registerPlayerObserver(this, true);
+        hostConnectionObserver.registerApplicationObserver(this);
+        hostConnectionObserver.registerPlayerObserver(this);
 
-        hostConnectionObserver.forceRefreshResults();
+        hostConnectionObserver.refreshWhatsPlaying();
     }
 
     private void updateNowPlayingPanel(PlayerType.PropertyValue getPropertiesResult,

--- a/app/src/main/java/org/xbmc/kore/ui/generic/VolumeControllerDialogFragmentListener.java
+++ b/app/src/main/java/org/xbmc/kore/ui/generic/VolumeControllerDialogFragmentListener.java
@@ -138,8 +138,8 @@ public class VolumeControllerDialogFragmentListener extends AppCompatDialogFragm
             return;
         }
 
-        hostConnectionObserver.registerApplicationObserver(this, true);
-        hostConnectionObserver.forceRefreshResults();
+        hostConnectionObserver.registerApplicationObserver(this);
+        hostConnectionObserver.refreshWhatsPlaying();
     }
 
     private void setListeners() {

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
@@ -232,8 +232,8 @@ public class NowPlayingFragment extends Fragment
     @Override
     public void onResume() {
         super.onResume();
-        hostConnectionObserver.registerPlayerObserver(this, true);
-        hostConnectionObserver.registerApplicationObserver(this, true);
+        hostConnectionObserver.registerPlayerObserver(this);
+        hostConnectionObserver.registerApplicationObserver(this);
     }
 
     @Override
@@ -331,7 +331,7 @@ public class NowPlayingFragment extends Fragment
             public void onSuccess(String result) {
                 if (!isAdded()) return;
                 // Force a refresh
-                hostConnectionObserver.forceRefreshResults();
+                hostConnectionObserver.refreshWhatsPlaying();
             }
 
             @Override
@@ -346,7 +346,7 @@ public class NowPlayingFragment extends Fragment
             @Override
             public void onSuccess(String result) {
                 if (!isAdded()) return;
-                hostConnectionObserver.forceRefreshResults();
+                hostConnectionObserver.refreshWhatsPlaying();
             }
 
             @Override

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
@@ -176,9 +176,10 @@ public class RemoteActivity extends BaseActivity
     public void onResume() {
         super.onResume();
         hostConnectionObserver = hostManager.getHostConnectionObserver();
-        hostConnectionObserver.registerPlayerObserver(this, true);
-        // Force a refresh, mainly to update the time elapsed on the fragments
-        hostConnectionObserver.forceRefreshResults();
+        hostConnectionObserver.registerPlayerObserver(this);
+        // Force a refresh, specifically to update the time elapsed on the fragments
+        hostConnectionObserver.refreshWhatsPlaying();
+        hostConnectionObserver.refreshPlaylists();
 
         // Check whether we should keep the remote activity above the lockscreen
         boolean keepAboveLockscreen = PreferenceManager

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteFragment.java
@@ -224,7 +224,7 @@ public class RemoteFragment extends Fragment
     @Override
     public void onResume() {
         super.onResume();
-        hostConnectionObserver.registerPlayerObserver(this, true);
+        hostConnectionObserver.registerPlayerObserver(this);
         if (eventServerConnection == null)
             eventServerConnection = createEventServerConnection();
     }
@@ -265,7 +265,7 @@ public class RemoteFragment extends Fragment
                             eventServerConnection = null;
                         }
                     }
-                });
+                }, callbackHandler);
     }
 
     /**


### PR DESCRIPTION
This PR fixes some issues with connections and threading. Specifically, the  changes in #618 which introduced threading in `HostConnection`, also introduced some issues. To fix them, the following changes were made:
- A specific TCP listener thread is used and manually started, instead of using one of the threads in the pool. The TCP listener thread is a long lived thread that should always be running (as long as the connection is through TCP) and be blocked listening on the TCP socket, so it shouldn't be managed in a pool, where, theoretically, it can be paused and reused;
- Changed the number of threads to 5. We need 2 threads to run correctly, so we shouldn't create much more than this, otherwise we can overwhelm some Kodi hardware;
- Had to sprinkle some `synchronized`'s to avoid race conditions. For instance, through a TCP connection, as soon as Kore is opened (from a clean state) it will call at least `GetActivePlayers`, `GetProperties`, `Ping`. Given that the TCP socket isn't set up yet, each of these calls has the potential to create a socket (and a TCP listener thread), so we would open 3 or more sockets, 2 of which would be leaked because we would use only 1 from then on. A `synchronized` in `executeThroughTcp` prevents this. The others prevent similar issues.

Additionally:
- Tweaked the playlist fetching code, so that most of it happens in `HostConnectionObserver` and when PlaylistFragment is notified of changes, it already gets the playlist data. This somewhat simplifies the code, and makes it more consistent with the Player Observer code;
- Change `EventServerConnection` to accept a Handler on which to post the result of the connection, so that the caller can control on which thread the result is called;
- Calls to the various `RegisterObserver` loose the reply immediately parameter, as it was always true.