### PR TITLE
Fix addons content sort

### DIFF
--- a/app/src/main/java/org/xbmc/kore/jsonrpc/method/Files.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/method/Files.java
@@ -60,12 +60,12 @@ public class Files {
      * Enums for File.Media
      */
     public interface Media {
-        public final static String VIDEO = "video";
-        public final static String MUSIC = "music";
-        public final static String PICTURES = "pictures";
-        public final static String FILES =  "files";
-        public final static String PROGRAMS =  "programs";
-        public final static String[] allValues = new String[] {
+        String VIDEO = "video";
+        String MUSIC = "music";
+        String PICTURES = "pictures";
+        String FILES =  "files";
+        String PROGRAMS =  "programs";
+        String[] allValues = new String[] {
                 VIDEO, MUSIC, PICTURES, FILES, PROGRAMS
         };
     }
@@ -96,7 +96,7 @@ public class Files {
             ArrayNode items = resultNode.has(SOURCE_NODE) ?
                     (ArrayNode) resultNode.get(SOURCE_NODE) : null;
             if (items == null) {
-                return new ArrayList<ItemType.Source>(0);
+                return new ArrayList<>(0);
             }
             ArrayList<ItemType.Source> result = new ArrayList<ItemType.Source>(items.size());
 
@@ -117,17 +117,6 @@ public class Files {
 
         /**
          * Get the directories and files in the given directory
-         * @param directory          full path name
-         * @param sort_params   sorting criteria
-         */
-        public GetDirectory(String directory, ListType.Sort sort_params) {
-            super();
-            addParameterToRequest("directory", directory);
-            addParameterToRequest(SORT_NODE, sort_params.toJsonNode());
-        }
-
-        /**
-         * Get the directories and files in the given directory
          * @param directory Full path name
          * @param media Type of media to retrieve.
          *              See {@link Files.Media} for a list of accepted values
@@ -141,7 +130,9 @@ public class Files {
             addParameterToRequest("directory", directory);
             addParameterToRequest("media", media);
             addParameterToRequest("properties", properties);
-            addParameterToRequest(SORT_NODE, sort_params.toJsonNode());
+            if (sort_params != null) {
+                addParameterToRequest(SORT_NODE, sort_params.toJsonNode());
+            }
         }
 
         @Override
@@ -152,10 +143,10 @@ public class Files {
             JsonNode fileNode = jsonObject.get(RESULT_NODE)
                     .get(FILE_NODE);
             if (fileNode == null || fileNode.isNull()) {
-                return new ArrayList<ListType.ItemFile>(0);
+                return new ArrayList<>(0);
             }
             ArrayNode items = (ArrayNode) fileNode;
-            ArrayList<ListType.ItemFile> result = new ArrayList<ListType.ItemFile>(items.size());
+            ArrayList<ListType.ItemFile> result = new ArrayList<>(items.size());
             for (JsonNode item : items) {
                 String regex = "\\[.*?\\]";
                 JsonNode label = item.get("label");

--- a/app/src/main/java/org/xbmc/kore/jsonrpc/type/ListType.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/type/ListType.java
@@ -15,6 +15,9 @@
  */
 package org.xbmc.kore.jsonrpc.type;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -580,7 +583,7 @@ public class ListType {
     /**
      * List.Sort
      */
-    public static class Sort implements ApiParameter {
+    public static class Sort implements ApiParameter, Parcelable {
         public static final String SORT_METHOD_NONE = "none";
         public static final String SORT_METHOD_LABEL = "label";
         public static final String SORT_METHOD_DATE = "date";
@@ -588,7 +591,7 @@ public class ListType {
         public static final String SORT_METHOD_FILE = "file";
         public static final String SORT_METHOD_PATH = "path";
         public static final String SORT_METHOD_DRIVETYPE = "drivetype";
-        public static final String SORT_METHOD_TYPE = "title";
+        public static final String SORT_METHOD_TITLE = "title";
         public static final String SORT_METHOD_TRACK = "track";
         public static final String SORT_METHOD_TIME = "time";
         public static final String SORT_METHOD_ARTIST = "artist";
@@ -643,5 +646,31 @@ public class ListType {
             node.put(METHOD, sort_method);
             return node;
         }
+
+        private Sort(Parcel in) {
+            this.sort_method = in.readString();
+            this.ascending_order = (in.readInt() != 0);
+            this.ignore_article = (in.readInt() != 0);
+        }
+
+        public int describeContents() {
+            return 0;
+        }
+
+        public void writeToParcel(Parcel out, int flags) {
+            out.writeString(sort_method);
+            out.writeInt(ascending_order ? 1 : 0);
+            out.writeInt(ignore_article ? 1 : 0);
+        }
+
+        public static final Parcelable.Creator<Sort> CREATOR = new Parcelable.Creator<Sort>() {
+            public Sort createFromParcel(Parcel in) {
+                return new Sort(in);
+            }
+
+            public Sort[] newArray(int size) {
+                return new Sort[size];
+            }
+        };
     }
 }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListContainerFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListContainerFragment.java
@@ -22,6 +22,8 @@ import android.preference.PreferenceManager;
 import org.xbmc.kore.R;
 import org.xbmc.kore.Settings;
 import org.xbmc.kore.host.HostManager;
+import org.xbmc.kore.jsonrpc.method.Files;
+import org.xbmc.kore.jsonrpc.type.ListType;
 import org.xbmc.kore.ui.AbstractInfoFragment;
 import org.xbmc.kore.ui.AbstractTabsFragment;
 import org.xbmc.kore.ui.sections.file.MediaFileListFragment;
@@ -46,7 +48,7 @@ public class AddonListContainerFragment extends AbstractTabsFragment {
         if (arguments == null)
             arguments = new Bundle();
 
-        /**
+        /*
          * Following check required to support testing AddonsActivity.
          * The database with host info is setup after initializing AddonsActivity using
          * ActivityTestRule from the test support library. This means getHostInfo() will
@@ -66,6 +68,7 @@ public class AddonListContainerFragment extends AbstractTabsFragment {
             String name = prefs.getString(Settings.getNameBookmarkedAddonsPrefKey(hostId) + path, Settings.DEFAULT_PREF_NAME_BOOKMARKED_ADDON);
             arguments.putParcelable(MediaFileListFragment.ROOT_PATH,
                                     new MediaFileListFragment.FileLocation(name, "plugin://" + path, true));
+            arguments.putString(MediaFileListFragment.MEDIA_TYPE, Files.Media.FILES);
             tabsAdapter.addTab(MediaFileListFragment.class, arguments, name, ++baseFragmentId);
         }
 

--- a/app/src/main/java/org/xbmc/kore/ui/sections/file/FileListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/file/FileListFragment.java
@@ -20,6 +20,7 @@ import android.os.Bundle;
 
 import org.xbmc.kore.R;
 import org.xbmc.kore.jsonrpc.method.Files;
+import org.xbmc.kore.jsonrpc.type.ListType;
 import org.xbmc.kore.ui.AbstractTabsFragment;
 import org.xbmc.kore.ui.OnBackPressedListener;
 import org.xbmc.kore.utils.TabsAdapter;
@@ -32,12 +33,20 @@ public class FileListFragment extends AbstractTabsFragment
 
     @Override
     protected TabsAdapter createTabsAdapter(DataHolder dataHolder) {
+        ListType.Sort sortMethod = new ListType.Sort(ListType.Sort.SORT_METHOD_PATH, true, true);
+
         Bundle videoFileListArgs = new Bundle();
         videoFileListArgs.putString(MediaFileListFragment.MEDIA_TYPE, Files.Media.VIDEO);
+        videoFileListArgs.putParcelable(MediaFileListFragment.SORT_METHOD, sortMethod);
+
         Bundle musicFileListArgs = new Bundle();
         musicFileListArgs.putString(MediaFileListFragment.MEDIA_TYPE, Files.Media.MUSIC);
+        musicFileListArgs.putParcelable(MediaFileListFragment.SORT_METHOD, sortMethod);
+
         Bundle pictureFileListArgs = new Bundle();
         pictureFileListArgs.putString(MediaFileListFragment.MEDIA_TYPE, Files.Media.PICTURES);
+        pictureFileListArgs.putParcelable(MediaFileListFragment.SORT_METHOD, sortMethod);
+
         return new TabsAdapter(getActivity(), getChildFragmentManager())
                 .addTab(MediaFileListFragment.class, videoFileListArgs, R.string.video, 1)
                 .addTab(MediaFileListFragment.class, musicFileListArgs, R.string.music, 2)


### PR DESCRIPTION
Don't specify a sort method in the listing of addon contents, so that the addon can sort its contents as it sees fit.