### PR TITLE
Fix force close caused by migration to Android 9

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.VIBRATE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <!-- Dangerous permissions -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>


### PR DESCRIPTION
Android 9 requires that apps that launch foreground services declare that they need permission, as detailed in https://developer.android.com/about/versions/pie/android-9.0-migration

Failure to do so was causing a FC when launching the notification service.