### PR TITLE
Fix invisible media details in info fragment

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
@@ -454,6 +454,8 @@ abstract public class AbstractInfoFragment extends AbstractFragment
             ratingContainer.setVisibility(View.VISIBLE);
         } else if (TextUtils.isEmpty(dataHolder.getDetails())) {
             mediaDetailsContainer.setVisibility(View.GONE);
+        } else {
+            mediaDetailsContainer.setVisibility(View.VISIBLE);
         }
     }
 


### PR DESCRIPTION
Fixes an issue where the media details are invisible if there is no rating information.

The media details would only be shown if there was a redraw forced e.g. by rotation. This change ensures that the visibility is set correctly in the case that media details are available but rating info is not.