### PR TITLE
Add sort by year section thumb text

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/RecyclerViewCursorAdapter.java
+++ b/app/src/main/java/org/xbmc/kore/ui/RecyclerViewCursorAdapter.java
@@ -30,6 +30,11 @@ abstract public class RecyclerViewCursorAdapter
     private int rowIDColumn;
     protected Cursor cursor;
 
+    // Section types
+    public static final int SECTION_TYPE_ALPHANUMERIC = 0,
+            SECTION_TYPE_YEAR_INTEGER = 1,
+            SECTION_TYPE_DATE_STRING = 2;
+
     @Override
     public void onBindViewHolder(CursorViewHolder holder, int position) {
         if (!dataValid) {
@@ -71,7 +76,21 @@ abstract public class RecyclerViewCursorAdapter
             throw new IllegalStateException("Could not move cursor to position " + position);
         }
 
-        return cursor.getString(getSectionColumnIdx()).substring(0, 1).toUpperCase();
+        int sectionType = getSectionType();
+        int sectionColumnIdx = getSectionColumnIdx();
+        String sectionName = "";
+        if (sectionType == SECTION_TYPE_YEAR_INTEGER) {
+            sectionName = String.format("%02d", cursor.getInt(sectionColumnIdx) % 100);
+        } else if (sectionType == SECTION_TYPE_DATE_STRING) {
+            String dateStr = cursor.getString(sectionColumnIdx);
+            if (dateStr.length() >= 4) {
+                sectionName = dateStr.substring(2, 4);
+            }
+        } else {
+            sectionName = cursor.getString(sectionColumnIdx).substring(0, 1).toUpperCase();
+        }
+
+        return sectionName;
     }
 
     /**
@@ -81,6 +100,10 @@ abstract public class RecyclerViewCursorAdapter
      * @return Cursor column index of the field to show in the fastscroller
      */
     abstract protected int getSectionColumnIdx();
+
+    protected int getSectionType() {
+        return SECTION_TYPE_ALPHANUMERIC;
+    }
 
     public void swapCursor(Cursor newCursor) {
         if (newCursor == cursor) {

--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/AlbumListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/AlbumListFragment.java
@@ -333,7 +333,25 @@ public class AlbumListFragment extends AbstractCursorListFragment {
             }
         };
 
-        protected int getSectionColumnIdx() { return AlbumListQuery.TITLE; }
+        protected int getSectionColumnIdx() {
+            int sortOrder = PreferenceManager.getDefaultSharedPreferences(fragment.getContext())
+                    .getInt(Settings.KEY_PREF_ALBUMS_SORT_ORDER, Settings.DEFAULT_PREF_ALBUMS_SORT_ORDER);
+            if (sortOrder == Settings.SORT_BY_YEAR) {
+                return AlbumListQuery.YEAR;
+            } else {
+                return AlbumListQuery.TITLE;
+            }
+        }
+
+        protected int getSectionType() {
+            int sortOrder = PreferenceManager.getDefaultSharedPreferences(fragment.getContext())
+                    .getInt(Settings.KEY_PREF_ALBUMS_SORT_ORDER, Settings.DEFAULT_PREF_ALBUMS_SORT_ORDER);
+            if (sortOrder == Settings.SORT_BY_YEAR) {
+                return RecyclerViewCursorAdapter.SECTION_TYPE_YEAR_INTEGER;
+            } else {
+                return RecyclerViewCursorAdapter.SECTION_TYPE_ALPHANUMERIC;
+            }
+        }
     }
 
     /**

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/MovieListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/MovieListFragment.java
@@ -362,7 +362,25 @@ public class MovieListFragment extends AbstractCursorListFragment {
             return new ViewHolder(view, getContext(), themeAccentColor, dimmedNeutralColor, hostManager, artWidth, artHeight);
         }
 
-        protected int getSectionColumnIdx() { return MovieListQuery.TITLE; }
+        protected int getSectionColumnIdx() {
+            int sortOrder = PreferenceManager.getDefaultSharedPreferences(getContext())
+                    .getInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.DEFAULT_PREF_MOVIES_SORT_ORDER);
+            if (sortOrder == Settings.SORT_BY_YEAR) {
+                return MovieListQuery.YEAR;
+            } else {
+                return MovieListQuery.TITLE;
+            }
+        }
+
+        protected int getSectionType() {
+            int sortOrder = PreferenceManager.getDefaultSharedPreferences(getContext())
+                    .getInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.DEFAULT_PREF_MOVIES_SORT_ORDER);
+            if (sortOrder == Settings.SORT_BY_YEAR) {
+                return RecyclerViewCursorAdapter.SECTION_TYPE_YEAR_INTEGER;
+            } else {
+                return RecyclerViewCursorAdapter.SECTION_TYPE_ALPHANUMERIC;
+            }
+        }
     }
 
     /**

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowListFragment.java
@@ -354,7 +354,25 @@ public class TVShowListFragment extends AbstractCursorListFragment {
             return viewHolder;
         }
 
-        protected int getSectionColumnIdx() { return TVShowListQuery.TITLE; }
+        protected int getSectionColumnIdx() {
+            int sortOrder = PreferenceManager.getDefaultSharedPreferences(getContext())
+                    .getInt(Settings.KEY_PREF_TVSHOWS_SORT_ORDER, Settings.DEFAULT_PREF_TVSHOWS_SORT_ORDER);
+            if (sortOrder == Settings.SORT_BY_YEAR) {
+                return TVShowListQuery.PREMIERED;
+            } else {
+                return TVShowListQuery.TITLE;
+            }
+        }
+
+        protected int getSectionType() {
+            int sortOrder = PreferenceManager.getDefaultSharedPreferences(getContext())
+                    .getInt(Settings.KEY_PREF_TVSHOWS_SORT_ORDER, Settings.DEFAULT_PREF_TVSHOWS_SORT_ORDER);
+            if (sortOrder == Settings.SORT_BY_YEAR) {
+                return RecyclerViewCursorAdapter.SECTION_TYPE_DATE_STRING;
+            } else {
+                return RecyclerViewCursorAdapter.SECTION_TYPE_ALPHANUMERIC;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
When album, movie and tv show lists are sorted by year, use the 2 digit year as the section thumb text rather than the title first letter.