### PR TITLE
Fix href tag closing

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,14 +79,14 @@
     <string name="wizard_welcome">Welcome</string>
     <string name="wizard_welcome_message"><![CDATA[
     Let\'s start by adding a media center. Make sure your Kodi/XBMC is running, properly configured and on the same network as your device.<br/><br/>
-    You can get help configuring it <a href="http://syncedsynapse.com/kore/kore-faq/>here</a>.<br/><br/>
+    You can get help configuring it <a href="http://syncedsynapse.com/kore/kore-faq/">here</a>.<br/><br/>
     When you\'re ready press <b><i>Next</i></b>.
     ]]></string>
     <string name="wizard_search_message"><![CDATA[
     Searching for media centers on your local network…<br/>
     ]]></string>
     <string name="wizard_search_no_host_found"><![CDATA[
-    I couldn\'t find any media center on your network.<br/>If you need help configuring it, check <a href="http://syncedsynapse.com/kore/kore-faq/>here</a>.<br/><br/>
+    I couldn\'t find any media center on your network.<br/>If you need help configuring it, check <a href="http://syncedsynapse.com/kore/kore-faq/">here</a>.<br/><br/>
     Click <i>Search</i> to search again or <i>Next</i> for manual configuration.
     ]]></string>
     <string name="wizard_search_no_network_connection"><![CDATA[


### PR DESCRIPTION
I found a problem with displaying these two HTML strings during setup of a new host. The missing closing quotes would cause any text from the \<a> tag onward to not be displayable.

Somehow this wasn't a problem on support lib version 26.1.0 and gradle 3.1.2 before #640. On the current versions, adding the closing quotes is enough to get it to parse correctly.

While we are looking at this.. `Html.fromHtml(String source)` is deprecated since N. Would it be worthwhile to add a compatibility method like in [androidx HtmlCompat](https://android.googlesource.com/platform/frameworks/support/+/f7528a970ad7f2f099b4dc1397084cc388c9193c/core/src/main/java/androidx/core/text/HtmlCompat.java#145)? I guess we would just pass the `FROM_HTML_MODE_LEGACY` flag anyway so doesn't make any difference for now.

![image](https://user-images.githubusercontent.com/5179255/60802048-310f5700-a1cc-11e9-8035-9f3367e3b7e4.png)