### PR TITLE
Fix issue with showing multiple bookmarked addons

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListContainerFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListContainerFragment.java
@@ -65,11 +65,12 @@ public class AddonListContainerFragment extends AbstractTabsFragment {
         long baseFragmentId = 70 + bookmarked.size() * 100;
         tabsAdapter.addTab(AddonListFragment.class, new Bundle(), R.string.addons, baseFragmentId);
         for (String path: bookmarked) {
+            Bundle args = (Bundle) arguments.clone();
             String name = prefs.getString(Settings.getNameBookmarkedAddonsPrefKey(hostId) + path, Settings.DEFAULT_PREF_NAME_BOOKMARKED_ADDON);
-            arguments.putParcelable(MediaFileListFragment.ROOT_PATH,
+            args.putParcelable(MediaFileListFragment.ROOT_PATH,
                                     new MediaFileListFragment.FileLocation(name, "plugin://" + path, true));
-            arguments.putString(MediaFileListFragment.MEDIA_TYPE, Files.Media.FILES);
-            tabsAdapter.addTab(MediaFileListFragment.class, arguments, name, ++baseFragmentId);
+            args.putString(MediaFileListFragment.MEDIA_TYPE, Files.Media.FILES);
+            tabsAdapter.addTab(MediaFileListFragment.class, args, name, ++baseFragmentId);
         }
 
         return tabsAdapter;


### PR DESCRIPTION
When multiple addons are bookmarked, the bookmarked tabs all show the content of the last addon, due to reusing a `Bundle` when setting up the tabs.

<img src="https://user-images.githubusercontent.com/8376/66718609-a008d700-eddd-11e9-83b6-1cf1ae61cee3.gif" width="35%">

This code fixes that by cloning the `Bundle` and passing a copy to each `addTab` call.
<img src="https://user-images.githubusercontent.com/8376/66718619-c3338680-eddd-11e9-98ce-35673bac88c1.gif" width="35%">
