### PR TITLE
Implemented changing language in-app

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,12 @@ android {
         versionCode 25
         versionName = getVersionName()
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+
+        def supportedLocales = ["en", "ast", "ru", "it", "ca", "cs", "zh-CN", "ja", "pt", "pt-BR",
+                                "pl", "sl", "sk", "lt", "eu", "iw", "fr", "es", "hr", "hu", "nl",
+                                "bg", "de", "ko", "uk"]
+        buildConfigField "String[]", "SUPPORTED_LOCALES", "new String[]{\""+
+                supportedLocales.join("\",\"")+"\"}"
     }
 
     File keystoreFile = file('keystore.properties')

--- a/app/src/main/java/org/xbmc/kore/Settings.java
+++ b/app/src/main/java/org/xbmc/kore/Settings.java
@@ -171,6 +171,9 @@ public class Settings {
     public static final String KEY_PREF_DISABLE_LOCAL_PLAY = "pref_disable_local_play";
     public static final boolean DEFAULT_PREF_DISABLE_LOCAL_PLAY = false;
 
+    public static final String KEY_PREF_LANGUAGE = "pref_language";
+    public static final String KEY_PREF_SELECTED_LANGUAGE = "pref_selected_language";
+
     /**
      * Determines the bit flags used by {@link DownloadManager.Request} to correspond to the enabled network connections
      * from the settings screen.

--- a/app/src/main/java/org/xbmc/kore/ui/BaseActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/BaseActivity.java
@@ -22,6 +22,7 @@ import android.support.v7.app.AppCompatActivity;
 
 import org.xbmc.kore.Settings;
 import org.xbmc.kore.utils.UIUtils;
+import org.xbmc.kore.utils.Utils;
 
 /**
  * Base activity, where common behaviour is implemented
@@ -33,7 +34,17 @@ public abstract class BaseActivity extends AppCompatActivity {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
         setTheme(UIUtils.getThemeResourceId(
                 prefs.getString(Settings.KEY_PREF_THEME, Settings.DEFAULT_PREF_THEME)));
+
+        setPreferredLocale();
         super.onCreate(savedInstanceState);
+    }
+
+    private void setPreferredLocale() {
+        String preferredLocale = android.preference.PreferenceManager.getDefaultSharedPreferences(this)
+                                                                     .getString(Settings.KEY_PREF_SELECTED_LANGUAGE, "");
+        if (! preferredLocale.isEmpty()) {
+            Utils.setLocale(this, preferredLocale);
+        }
     }
 
     //    @Override

--- a/app/src/main/java/org/xbmc/kore/utils/Utils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/Utils.java
@@ -17,6 +17,8 @@ package org.xbmc.kore.utils;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.drawable.BitmapDrawable;
@@ -37,6 +39,7 @@ import org.xbmc.kore.jsonrpc.type.PlaylistType;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Because every project needs one of these
@@ -249,5 +252,29 @@ public class Utils {
                      .show();
             }
         }, callbackHandler);
+    }
+
+    public static void setLocale(Context context, String localeName) {
+        Locale locale = getLocale(localeName);
+
+        Locale.setDefault(locale);
+
+        Resources resources = context.getResources();
+
+        Configuration configuration = resources.getConfiguration();
+        configuration.locale = locale;
+
+        resources.updateConfiguration(configuration, resources.getDisplayMetrics());
+    }
+
+    public static Locale getLocale(String localeName) {
+        Locale locale;
+        String[] languageAndRegion = localeName.split("-", 2);
+        if (languageAndRegion.length > 1) {
+            locale = new Locale(languageAndRegion[0], languageAndRegion[1]);
+        } else {
+            locale = new Locale(localeName);
+        }
+        return locale;
     }
 }

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -362,4 +362,5 @@
   <string name="show_now_playing_panel_summary">Toont een uitvouwbare balk onderaan het scherm wanneer media wordt afgespeeld</string>
   <string name="notification_seek_jump_speed">De weergavesnelheid wijzigen met de afspeelmelding</string>
   <string name="notification_seek_jump_step">In grote stappen vooruit of terug springen met de afspeelmelding</string>
+    <string name="language">Taal</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -431,4 +431,5 @@
 
     <string name="disable_local_playback_support">Disable local playback support</string>
     <string name="disable_local_playback_support_summary">Disables support for playing media locally on the device running Kore.</string>
+    <string name="language">Language</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -54,6 +54,10 @@
             android:entryValues="@array/themes_values_array"
             android:defaultValue="0"/>
 
+        <ListPreference
+            android:key="pref_language"
+            android:title="@string/language"/>
+        
         <SwitchPreferenceCompat
             android:key="pref_keep_screen_on"
             android:title="@string/pref_keep_screen_on"


### PR DESCRIPTION
This allows users to use a different supported locale than the one that
matches the device's locale.

Implements feature request #585 