### PR TITLE
Fixed issue setting preferred locale in Settings

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/BaseActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/BaseActivity.java
@@ -35,16 +35,8 @@ public abstract class BaseActivity extends AppCompatActivity {
         setTheme(UIUtils.getThemeResourceId(
                 prefs.getString(Settings.KEY_PREF_THEME, Settings.DEFAULT_PREF_THEME)));
 
-        setPreferredLocale();
+        Utils.setPreferredLocale(this);
         super.onCreate(savedInstanceState);
-    }
-
-    private void setPreferredLocale() {
-        String preferredLocale = android.preference.PreferenceManager.getDefaultSharedPreferences(this)
-                                                                     .getString(Settings.KEY_PREF_SELECTED_LANGUAGE, "");
-        if (! preferredLocale.isEmpty()) {
-            Utils.setLocale(this, preferredLocale);
-        }
     }
 
     //    @Override

--- a/app/src/main/java/org/xbmc/kore/ui/sections/settings/SettingsActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/settings/SettingsActivity.java
@@ -28,6 +28,7 @@ import org.xbmc.kore.R;
 import org.xbmc.kore.Settings;
 import org.xbmc.kore.utils.LogUtils;
 import org.xbmc.kore.utils.UIUtils;
+import org.xbmc.kore.utils.Utils;
 
 /**
  * Presents the Preferences fragment
@@ -41,6 +42,8 @@ public class SettingsActivity extends AppCompatActivity {
         setTheme(UIUtils.getThemeResourceId(
                 prefs.getString(Settings.KEY_PREF_THEME,
                         Settings.DEFAULT_PREF_THEME)));
+        Utils.setPreferredLocale(this);
+
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.activity_settings);

--- a/app/src/main/java/org/xbmc/kore/utils/Utils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/Utils.java
@@ -31,6 +31,7 @@ import android.text.TextUtils;
 import android.widget.Toast;
 
 import org.xbmc.kore.R;
+import org.xbmc.kore.Settings;
 import org.xbmc.kore.host.HostManager;
 import org.xbmc.kore.jsonrpc.ApiCallback;
 import org.xbmc.kore.jsonrpc.HostConnection;
@@ -254,7 +255,15 @@ public class Utils {
         }, callbackHandler);
     }
 
-    public static void setLocale(Context context, String localeName) {
+    public static void setPreferredLocale(Context context) {
+        String preferredLocale = android.preference.PreferenceManager.getDefaultSharedPreferences(context)
+                                                                     .getString(Settings.KEY_PREF_SELECTED_LANGUAGE, "");
+        if (! preferredLocale.isEmpty()) {
+            Utils.setLocale(context, preferredLocale);
+        }
+    }
+
+    private static void setLocale(Context context, String localeName) {
         Locale locale = getLocale(localeName);
 
         Locale.setDefault(locale);


### PR DESCRIPTION
SettingsActivity does not inherit from BaseActivity which caused
the preferred locale not to be set. This was not apparent when
switching to the Settings screen as the preferred locale would
already have been set by a previous activity which does inherit
from BaseActivity (e.g. RemoteActivity). Therefore we needed
to explicitly set the preferred locale as well in SettingsActivity.