### PR TITLE
Share local files - part 2

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,14 @@
                 <category android:name="android.intent.category.MULTIWINDOW_LAUNCHER" />
             </intent-filter>
 
+            <intent-filter android:label="@string/play_on_kodi">
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/*" />
+                <data android:mimeType="video/*" />
+                <data android:mimeType="audio/*" />
+            </intent-filter>
+
             <!-- Intent filter for sharing from youtube player -->
             <intent-filter android:label="@string/play_on_kodi">
                 <action android:name="android.intent.action.SEND" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -66,6 +66,43 @@
                 android:value=".service.HostChooserTargetService" />
         </activity>
 
+        <activity android:name=".ui.sections.remote.QueueActivity">
+
+            <intent-filter android:label="@string/queue_on_kodi">
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/*" />
+                <data android:mimeType="video/*" />
+                <data android:mimeType="audio/*" />
+            </intent-filter>
+
+            <!-- Intent filter for sharing from youtube player -->
+            <intent-filter android:label="@string/queue_on_kodi">
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain"/>
+            </intent-filter>
+
+            <!-- Intent filter for sharing youtube URLs -->
+            <intent-filter android:label="@string/queue_on_kodi">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+                <data android:host="youtube.com"/>
+                <data android:host="m.youtube.com"/>
+                <data android:host="www.youtube.com"/>
+                <data android:host="vimeo.com"/>
+                <data android:host="www.vimeo.com"/>
+                <data android:host="player.vimeo.com"/>
+                <data android:host="www.svtplay.se"/>
+                <data android:host="soundcloud.com"/>
+                <data android:host="m.soundcloud.com"/>
+            </intent-filter>
+
+        </activity>
+
         <activity android:name="org.xbmc.kore.ui.sections.hosts.HostManagerActivity"/>
         <activity android:name="org.xbmc.kore.ui.sections.hosts.AddHostActivity"/>
         <activity android:name="org.xbmc.kore.ui.sections.hosts.EditHostActivity"/>

--- a/app/src/main/java/org/xbmc/kore/ui/sections/localfile/HttpApp.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/localfile/HttpApp.java
@@ -2,7 +2,11 @@ package org.xbmc.kore.ui.sections.localfile;
 
 
 import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
 import android.net.wifi.WifiManager;
+import android.provider.OpenableColumns;
+import android.webkit.MimeTypeMap;
 
 import org.xbmc.kore.utils.LogUtils;
 
@@ -12,6 +16,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.security.SecureRandom;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -27,36 +32,78 @@ public class HttpApp extends NanoHTTPD {
         super(port);
         this.applicationContext = applicationContext;
         this.localFileLocationList = new LinkedList<>();
+        this.localUriList = new LinkedList<>();
+        this.token = generateToken();
         start(NanoHTTPD.SOCKET_READ_TIMEOUT, false);
+    }
+
+    private final int TOKEN_LENGTH = 12;
+
+    private String generateToken() {
+        String token = "";
+
+        SecureRandom sr = new SecureRandom();
+
+        for (int i = 0; i < TOKEN_LENGTH; i++) {
+            int n = sr.nextInt(26*2 + 10);
+            if (n < 26) {
+                n += 'A';
+            } else if (n < 26*2) {
+                n += 'a' - 26;
+            } else {
+                n += '0' - 26*2;
+            }
+            token += Character.toString((char) n);
+        }
+
+        return token;
     }
 
     private Context applicationContext;
     private LinkedList<LocalFileLocation> localFileLocationList = null;
+    private LinkedList<Uri> localUriList = null;
     private int currentIndex;
+    private boolean currentIsFile;
+    private String token;
+
+    private final Response forbidden = newFixedLengthResponse(Response.Status.FORBIDDEN, "", "");
 
     @Override
     public Response serve(IHTTPSession session) {
 
         Map<String, List<String>> params = session.getParameters();
         if (localFileLocationList == null) {
-            return newFixedLengthResponse(Response.Status.FORBIDDEN, "", "");
+            return forbidden;
         }
 
-        if (!params.containsKey("number")) {
-            return null;
+        if (!params.containsKey("token")) {
+            return forbidden;
         }
-
-        int file_number = Integer.parseInt(params.get("number").get(0));
+        if (!params.get("token").get(0).equals(this.token)) {
+            return forbidden;
+        }
 
         FileInputStream fis = null;
-        LocalFileLocation localFileLocation = localFileLocationList.get(file_number);
+        String mimeType = null;
         try {
-            fis = new FileInputStream(localFileLocation.fullPath);
+            if (params.containsKey("number")) {
+                int file_number = Integer.parseInt(params.get("number").get(0));
+
+                LocalFileLocation localFileLocation = localFileLocationList.get(file_number);
+                fis = new FileInputStream(localFileLocation.fullPath);
+                mimeType = localFileLocation.getMimeType();
+            } else if (params.containsKey("uri")) {
+                int uri_number = Integer.parseInt(params.get("uri").get(0));
+
+                fis = (FileInputStream) applicationContext.getContentResolver().openInputStream(localUriList.get(uri_number));
+            } else {
+                return forbidden;
+            }
         } catch (FileNotFoundException e) {
             LogUtils.LOGW(LogUtils.makeLogTag(HttpApp.class), e.toString());
-            return newFixedLengthResponse(Response.Status.FORBIDDEN, "", "");
+            return forbidden;
         }
-        String mimeType = localFileLocation.getMimeType();
+
         return newChunkedResponse(Response.Status.OK, mimeType, fis);
     }
 
@@ -68,6 +115,17 @@ public class HttpApp extends NanoHTTPD {
             this.localFileLocationList.add(localFileLocation);
             currentIndex = localFileLocationList.size() - 1;
         }
+        currentIsFile = true;
+    }
+
+    public void addUri(Uri uri) {
+        if (localUriList.contains(uri)) {
+            currentIndex = localUriList.indexOf(uri);
+        } else {
+            this.localUriList.add(uri);
+            currentIndex = localUriList.size() - 1;
+        }
+        currentIsFile = false;
     }
 
     private String getIpAddress() throws UnknownHostException {
@@ -100,7 +158,44 @@ public class HttpApp extends NanoHTTPD {
         } catch (IOException ioe) {
             LogUtils.LOGE(LogUtils.makeLogTag(HttpApp.class), ioe.getMessage());
         }
-        return "http://" + ip + ":" + getListeningPort() + "/" + localFileLocationList.get(currentIndex).fileName + "?number=" + currentIndex;
+        String path = null;
+        if (currentIsFile) {
+            path = localFileLocationList.get(currentIndex).fileName + "?number=" + currentIndex;
+        } else {
+            Uri uri = localUriList.get(currentIndex);
+            String filename = getFileNameFromUri(uri);
+            path = filename + "?uri=" + currentIndex;
+        }
+        return "http://" + ip + ":" + getListeningPort() + "/" + path + "&token=" + token;
+    }
+
+    private String getFileNameFromUri(Uri contentUri) {
+        String fileName = "";
+        // Let's parse the Uri to detect the filename:
+        if (contentUri.toString().startsWith("content://")) {
+            Cursor cursor = null;
+            try {
+                cursor = applicationContext.getContentResolver().query(contentUri, null, null, null, null);
+                if (cursor != null && cursor.moveToFirst()) {
+                    fileName = cursor.getString(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME));
+                }
+            } finally {
+                cursor.close();
+            }
+        }
+
+        // If the mimeType determined by Andoid is not equal to the one determined by
+        // the filename, add an extra extension to make sure Kodi recognizes the file type:
+        String mimeType = applicationContext.getContentResolver().getType(contentUri);
+        MimeTypeMap mimeTypeMap = MimeTypeMap.getSingleton();
+        String extensionFromFilename = mimeTypeMap.getMimeTypeFromExtension(
+                MimeTypeMap.getFileExtensionFromUrl(fileName));
+        if (
+                (extensionFromFilename == null) || (!extensionFromFilename.equals(mimeType))
+        ) {
+            fileName += "." + MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
+        }
+        return fileName;
     }
 
     private static HttpApp http_app = null;

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/QueueActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/QueueActivity.java
@@ -1,0 +1,12 @@
+package org.xbmc.kore.ui.sections.remote;
+
+import android.content.Intent;
+
+public class QueueActivity extends RemoteActivity {
+
+    @Override
+    protected void handleStartIntent(Intent intent) {
+        handleStartIntent(intent, true);
+    }
+
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -282,6 +282,7 @@
 
     <string name="add_to_playlist">Add to playlist</string>
     <string name="item_added_to_playlist">Added to playlist</string>
+    <string name="item_sent_to_kodi">Sent to Kodi</string>
     <string name="no_suitable_playlist">No suitable playlist found to add media type.</string>
 
     <string name="imdb">IMDb</string>
@@ -389,6 +390,7 @@
     <!--<string name="purchase_thanks">Thanks for your support!</string>-->
 
     <string name="play_on_kodi">Play on Kodi</string>
+    <string name="queue_on_kodi">Queue on Kodi</string>
     <string name="pause_call_incoming_title">Incoming call</string>
     <string name="pause_call_incoming_message">Check your phone, someone is calling you</string>
 


### PR DESCRIPTION
This is the second part to https://github.com/xbmc/Kore/pull/681

Now files can be shared to Kodi through Kore from other apps. This PR extends the _"Play on Kodi"_ intent to use `HttpApp` to add shared files.

List of edits:

1. Media files can now be shared with Kodi (see edits to manifest file).
2. `HttpApp` now generates a _token_ for security reasons. Without _token_ you won't be able to download any file.
3. Added `finish()` in order not to open Kore's screen after a file has been shared (do you really care about seeing Kore? I suppose you are looking at Kodi).

Some remaining doubts:

4. ~~Media files share opens the files in Kodi. The code for YouTube videos is queuing the video instead.  What should the correct behaviour be? I've noticed that Yatse has two ways of sharing: play and queue, maybe Kore should add the same?~~ ___Update:___ this PR now adds a second share option `Queue on Kodi`. Now `Play on Kodi` plays the shared media file directly, disregarding the playlist, while `Queue on Kodi` adds the shared media file to the end of the playlist.
5. Unrelated: the current sharing options always assume that the shared link is a video, and it's queued to the video playlist (even if it's an image or audio file), and Kodi is unable to play it.
6. Local files are shared as `content:// ... ` paths, not as file paths. Apparently Android's API allows to open an input file stream from `content://` paths, but it's a bit hard to locate the file path. I've added a second sharing link to `HttpApp` in order to handle generic `Uri` objects beside file paths.