### PR TITLE
Allow sorting of PVR Recordings and optionally hide watched items.

### DIFF
--- a/app/src/main/java/org/xbmc/kore/Settings.java
+++ b/app/src/main/java/org/xbmc/kore/Settings.java
@@ -49,7 +49,8 @@ public class Settings {
             SORT_BY_ALBUM = 5,
             SORT_BY_ARTIST = 6,
             SORT_BY_ARTIST_YEAR = 7,
-            SORT_BY_LAST_PLAYED = 8;
+            SORT_BY_LAST_PLAYED = 8,
+            UNSORTED = 9;
 
     /**
      * Preferences keys.
@@ -135,6 +136,14 @@ public class Settings {
     // Show watched status on movie list
     public static final String KEY_PREF_TVSHOWS_SHOW_WATCHED_STATUS = "tvshows_show_watched_status";
     public static final boolean DEFAULT_PREF_TVSHOWS_SHOW_WATCHED_STATUS = true;
+
+    // Filter watched pvr recordings on movie list
+    public static final String KEY_PREF_PVR_RECORDINGS_FILTER_HIDE_WATCHED = "pvr_recordings_filter_hide_watched";
+    public static final boolean DEFAULT_PREF_PVR_RECORDINGS_FILTER_HIDE_WATCHED = false;
+
+    // Sort order on pvr recordings
+    public static final String KEY_PREF_PVR_RECORDINGS_SORT_ORDER = "pvr_recordings_sort_order";
+    public static final int DEFAULT_PREF_PVR_RECORDINGS_SORT_ORDER = UNSORTED;
 
     // Filter disabled addons on addons list
     public static final String KEY_PREF_ADDONS_FILTER_HIDE_DISABLED = "addons_filter_hide_disabled";

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRRecordingsListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRRecordingsListFragment.java
@@ -243,34 +243,34 @@ public class PVRRecordingsListFragment extends Fragment
                 SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
                 boolean hideWatched = preferences.getBoolean(Settings.KEY_PREF_PVR_RECORDINGS_FILTER_HIDE_WATCHED, Settings.DEFAULT_PREF_PVR_RECORDINGS_FILTER_HIDE_WATCHED);
 
-                boolean filter = hideWatched;
+                if (!hideWatched) {
+                    return itemList;
+                }
 
-                List<PVRType.DetailsRecording> result;
-                if(filter) {
-                    result = new ArrayList<>(itemList.size());
-                    for(PVRType.DetailsRecording item:itemList) {
-                        if(hideWatched) {
-                            if(item.playcount > 0) {
-                                continue; // Skip this item as it is played.
-                            } else {
-                                // Heuristic: Try to guess if it's play from resume timestamp.
-                                double resumePosition = item.resume.position;
-                                int runtime = item.runtime;
-                                if(runtime < resumePosition) {
-                                    // Tv show duration is smaller than resume positions.
-                                    // The tv show likely has been watched.
-                                    // It's still possible some minutes have not yet been watched
-                                    // at the end of the show as some minutes at the
-                                    // recording start do not belong to the show.
-                                    // Never the less skip this item.
-                                    continue;
-                                }
+                List<PVRType.DetailsRecording> result = new ArrayList<>(itemList.size());
+                for (PVRType.DetailsRecording item:itemList) {
+                    if (hideWatched) {
+                        if (item.playcount > 0) {
+                            continue; // Skip this item as it is played.
+                        } else {
+                            // Heuristic: Try to guess if it's play from resume timestamp.
+                            double resumePosition = item.resume.position;
+                            int runtime = item.runtime;
+                            if (runtime < resumePosition) {
+                                // Tv show duration is smaller than resume position.
+                                // The tv show likely has been watched.
+                                // It's still possible some minutes have not yet been watched
+                                // at the end of the show as some minutes at the
+                                // recording start do not belong to the show.
+                                // Never the less skip this item.
+                                continue;
                             }
                         }
-                        result.add(item);
                     }
-                }else {
-                    result = itemList;
+
+                    // more conditions may be added here
+
+                    result.add(item);
                 }
 
                 return result;
@@ -300,7 +300,7 @@ public class PVRRecordingsListFragment extends Fragment
                             @Override
                             public int compare(PVRType.DetailsRecording a, PVRType.DetailsRecording b) {
                                 int result = a.title.compareToIgnoreCase(b.title);
-                                if(0 == result) { // note the yoda condition ;)
+                                if (0 == result) { // note the yoda condition ;)
                                     // sort by starttime descending (most current first)
                                     result = b.starttime.compareTo(a.starttime);
                                 }

--- a/app/src/main/res/menu/pvr_recording_list.xml
+++ b/app/src/main/res/menu/pvr_recording_list.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+   Copyright 2015 Synced Synapse. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<menu
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:title="@string/sort_order"
+        app:showAsAction="never">
+        <menu>
+            <group
+                android:checkableBehavior="single">
+                <item
+                    android:id="@+id/action_sort_by_name_and_date_added"
+                    android:title="@string/sort_by_name"
+                    app:showAsAction="never"/>
+                <item
+                    android:id="@+id/action_sort_by_date_added"
+                    android:title="@string/sort_by_date_added"
+                    app:showAsAction="never"/>
+                <item
+                    android:id="@+id/action_unsorted"
+                    android:title="@string/unsorted"
+                    app:showAsAction="never"/>
+            </group>
+        </menu>
+    </item>
+
+    <group
+        android:checkableBehavior="all">
+        <item
+            android:id="@+id/action_hide_watched"
+            android:title="@string/hide_watched"
+            app:showAsAction="never"/>
+    </group>
+
+</menu>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -325,7 +325,7 @@
     <string name="sort_by_length">Nach Länge</string>
     <string name="sort_by_date_added">Nach Hinzufügungsdatum</string>
     <string name="sort_by_last_played">Zuletzt gespielt</string>
-    <string name="unsorted">Nicht Sortiert</string>
+    <string name="unsorted">Nicht sortiert</string>
     <string name="ignore_prefixes">Präfixe ignorieren</string>
 
     <!-- Preferences strings -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -325,6 +325,7 @@
     <string name="sort_by_length">Nach Länge</string>
     <string name="sort_by_date_added">Nach Hinzufügungsdatum</string>
     <string name="sort_by_last_played">Zuletzt gespielt</string>
+    <string name="unsorted">Nicht Sortiert</string>
     <string name="ignore_prefixes">Präfixe ignorieren</string>
 
     <!-- Preferences strings -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -339,6 +339,7 @@
     <string name="sort_by_length">By length</string>
     <string name="sort_by_date_added">By date added</string>
     <string name="sort_by_last_played">By last played</string>
+    <string name="unsorted">Unsorted</string>
     <string name="ignore_prefixes">Ignore prefixes</string>
     <string name="show_watched_status">Show watched status</string>
     <string name="show_rating">Show rating</string>


### PR DESCRIPTION
Implemented a new menu on PVRRecordings view:
Group Sorting:
 ( ) By name 
    -> Sorts the recordings by title (asc) and starttime (desc). Newest per title are thus visible on top
 ( ) By date added
    -> Sorts the recordings by starttime (desc) only, newest at the top.
 ( ) Unsorted
   -> Shows the recordings in same order as before as delivered by Kodi.

Additional Filter Checkbox
  [ ] Hide watched
  -> This is a heuristic that tries to hide recordings already watched:
      If recording.playcount is greater than 0, hide.
      If resume stamp is greater than tv show duration, hide.
      Tv show duration is typically smaller than total recording length as there are some minutes before and after the tv show recorded.
