### PR TITLE
Implemented search field for PVR views. (#695)

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/AbstractSearchableFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractSearchableFragment.java
@@ -140,11 +140,7 @@ public abstract class AbstractSearchableFragment extends Fragment implements Sea
 
         /**
          * When this fragment is paused, onQueryTextChange is called with an empty string.
-         * This causes problems restoring the list fragment when returning. On return the fragment
-         * is recreated, which will cause the cursor adapter to be recreated. Although
-         * the search view will have the query restored to its saved state, the CursorAdapter
-         * will use the empty search filter. This is due to the fact that we don't restart the
-         * loader when it is still loading after its been created.
+         * This causes problems restoring the list fragment when returning.
          */
         if (isPaused)
             return true;

--- a/app/src/main/java/org/xbmc/kore/ui/AbstractSearchableFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractSearchableFragment.java
@@ -183,6 +183,15 @@ public abstract class AbstractSearchableFragment extends Fragment implements Sea
         isPaused = true;
     }
 
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        if (!TextUtils.isEmpty(searchFilter)) {
+            savedSearchFilter = searchFilter;
+        }
+        outState.putString(BUNDLE_KEY_SEARCH_QUERY, savedSearchFilter);
+        super.onSaveInstanceState(outState);
+    }
+
     /**
      * Event bus post. Called when the syncing process ended
      *

--- a/app/src/main/java/org/xbmc/kore/ui/AbstractSearchableFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractSearchableFragment.java
@@ -19,8 +19,6 @@ import android.widget.EditText;
 import org.xbmc.kore.R;
 import org.xbmc.kore.jsonrpc.event.MediaSyncEvent;
 
-import de.greenrobot.event.EventBus;
-
 public abstract class AbstractSearchableFragment extends Fragment implements SearchView.OnQueryTextListener {
 
     private String searchFilter = null;
@@ -28,7 +26,6 @@ public abstract class AbstractSearchableFragment extends Fragment implements Sea
     private boolean supportsSearch;
     private boolean isPaused;
 
-    private EventBus bus;
     private SearchView searchView;
 
     private final String BUNDLE_KEY_SEARCH_QUERY = "search_query";
@@ -37,8 +34,6 @@ public abstract class AbstractSearchableFragment extends Fragment implements Sea
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View root = super.onCreateView(inflater, container, savedInstanceState);
-
-        bus = EventBus.getDefault();
 
         if (savedInstanceState != null) {
             savedSearchFilter = savedInstanceState.getString(BUNDLE_KEY_SEARCH_QUERY);
@@ -109,7 +104,7 @@ public abstract class AbstractSearchableFragment extends Fragment implements Sea
                 @Override
                 public boolean onMenuItemActionCollapse(MenuItem item) {
                     searchFilter = savedSearchFilter = null;
-                    restartLoader();
+                    refreshList();
                     return true;
                 }
             });
@@ -125,7 +120,7 @@ public abstract class AbstractSearchableFragment extends Fragment implements Sea
                     editText.setText("");
                     searchView.setQuery("", false);
                     searchFilter = savedSearchFilter = "";
-                    restartLoader();
+                    refreshList();
                 }
             });
         }
@@ -156,7 +151,7 @@ public abstract class AbstractSearchableFragment extends Fragment implements Sea
 
         searchFilter = newText;
 
-        restartLoader();
+        refreshList();
 
         return true;
     }
@@ -172,7 +167,7 @@ public abstract class AbstractSearchableFragment extends Fragment implements Sea
     public boolean onOptionsItemSelected(MenuItem item) {
         switch(item.getItemId()) {
             case R.id.action_refresh:
-                restartLoader();
+                refreshList();
                 break;
         }
         return super.onOptionsItemSelected(item);
@@ -182,14 +177,12 @@ public abstract class AbstractSearchableFragment extends Fragment implements Sea
 
     @Override
     public void onResume() {
- //       bus.register(this);
         super.onResume();
         isPaused = false;
     }
 
     @Override
     public void onPause() {
-//        bus.unregister(this);
         super.onPause();
         isPaused = true;
     }
@@ -207,5 +200,8 @@ public abstract class AbstractSearchableFragment extends Fragment implements Sea
 
     }
 
-    protected abstract void restartLoader();
+    /**
+     * Use this to reload the items in the list
+     */
+    protected abstract void refreshList();
 }

--- a/app/src/main/java/org/xbmc/kore/ui/AbstractSearchableFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractSearchableFragment.java
@@ -1,0 +1,211 @@
+package org.xbmc.kore.ui;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v4.view.MenuItemCompat;
+import android.support.v7.widget.SearchView;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.EditText;
+
+import org.xbmc.kore.R;
+import org.xbmc.kore.jsonrpc.event.MediaSyncEvent;
+
+import de.greenrobot.event.EventBus;
+
+public abstract class AbstractSearchableFragment extends Fragment implements SearchView.OnQueryTextListener {
+
+    private String searchFilter = null;
+    private String savedSearchFilter;
+    private boolean supportsSearch;
+    private boolean isPaused;
+
+    private EventBus bus;
+    private SearchView searchView;
+
+    private final String BUNDLE_KEY_SEARCH_QUERY = "search_query";
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        View root = super.onCreateView(inflater, container, savedInstanceState);
+
+        bus = EventBus.getDefault();
+
+        if (savedInstanceState != null) {
+            savedSearchFilter = savedInstanceState.getString(BUNDLE_KEY_SEARCH_QUERY);
+        }
+        searchFilter = savedSearchFilter;
+
+        return root;
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        inflater.inflate(R.menu.abstractcursorlistfragment, menu);
+
+        if (supportsSearch) {
+            setupSearchMenuItem(menu, inflater);
+        }
+
+        super.onCreateOptionsMenu(menu, inflater);
+    }
+
+    /**
+     * Use this to indicate your fragment supports search queries.
+     * Get the entered search query using {@link #getSearchFilter()}
+     * <br/>
+     * Note: make sure this is set before {@link #onCreateOptionsMenu(Menu, MenuInflater)} is called.
+     * For instance in {@link #onAttach(Activity)}
+     *
+     * @param supportsSearch true if you support search queries, false otherwise
+     */
+    public void setSupportsSearch(boolean supportsSearch) {
+        this.supportsSearch = supportsSearch;
+    }
+
+    /**
+     * Save the search state of the list fragment
+     */
+    public void saveSearchState() {
+        savedSearchFilter = searchFilter;
+    }
+
+    /**
+     * @return text entered in searchview
+     */
+    public String getSearchFilter() {
+        return searchFilter;
+    }
+
+    private void setupSearchMenuItem(Menu menu, MenuInflater inflater) {
+        inflater.inflate(R.menu.media_search, menu);
+        MenuItem searchMenuItem = menu.findItem(R.id.action_search);
+        if (searchMenuItem != null) {
+            searchView = (SearchView) MenuItemCompat.getActionView(searchMenuItem);
+            searchView.setOnQueryTextListener(this);
+            searchView.setQueryHint(getString(R.string.action_search));
+            if (!TextUtils.isEmpty(savedSearchFilter)) {
+                searchMenuItem.expandActionView();
+                searchView.setQuery(savedSearchFilter, false);
+                //noinspection RestrictedApi
+                searchView.clearFocus();
+            }
+
+            MenuItemCompat.setOnActionExpandListener(searchMenuItem, new MenuItemCompat.OnActionExpandListener() {
+                @Override
+                public boolean onMenuItemActionExpand(MenuItem item) {
+                    return true;
+                }
+
+                @Override
+                public boolean onMenuItemActionCollapse(MenuItem item) {
+                    searchFilter = savedSearchFilter = null;
+                    restartLoader();
+                    return true;
+                }
+            });
+        }
+
+        //Handle clearing search query using the close button (X button).
+        View view = searchView.findViewById(R.id.search_close_btn);
+        if (view != null) {
+            view.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    EditText editText = (EditText) searchView.findViewById(R.id.search_src_text);
+                    editText.setText("");
+                    searchView.setQuery("", false);
+                    searchFilter = savedSearchFilter = "";
+                    restartLoader();
+                }
+            });
+        }
+    }
+
+
+    /**
+     * Search view callbacks
+     */
+    /** {@inheritDoc} */
+    @Override
+    public boolean onQueryTextChange(String newText) {
+        if ((!searchView.hasFocus()) && TextUtils.isEmpty(newText)) {
+            //onQueryTextChange called as a result of manually expanding the searchView in setupSearchMenuItem(...)
+            return true;
+        }
+
+        /**
+         * When this fragment is paused, onQueryTextChange is called with an empty string.
+         * This causes problems restoring the list fragment when returning. On return the fragment
+         * is recreated, which will cause the cursor adapter to be recreated. Although
+         * the search view will have the query restored to its saved state, the CursorAdapter
+         * will use the empty search filter. This is due to the fact that we don't restart the
+         * loader when it is still loading after its been created.
+         */
+        if (isPaused)
+            return true;
+
+        searchFilter = newText;
+
+        restartLoader();
+
+        return true;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean onQueryTextSubmit(String newText) {
+        // All is handled in onQueryTextChange
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch(item.getItemId()) {
+            case R.id.action_refresh:
+                restartLoader();
+                break;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+
+
+    @Override
+    public void onResume() {
+ //       bus.register(this);
+        super.onResume();
+        isPaused = false;
+    }
+
+    @Override
+    public void onPause() {
+//        bus.unregister(this);
+        super.onPause();
+        isPaused = true;
+    }
+
+    /**
+     * Event bus post. Called when the syncing process ended
+     *
+     * @param event Refreshes data
+     */
+    public void onEventMainThread(MediaSyncEvent event) {
+        onSyncProcessEnded(event);
+    }
+
+    protected void onSyncProcessEnded(MediaSyncEvent event) {
+
+    }
+
+    protected abstract void restartLoader();
+}

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRChannelsListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRChannelsListFragment.java
@@ -20,7 +20,6 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.Handler;
-import android.support.v4.app.Fragment;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -179,7 +178,7 @@ public class PVRChannelsListFragment extends AbstractSearchableFragment
     }
 
     @Override
-    protected void restartLoader() {
+    protected void refreshList() {
         onRefresh();
     }
 
@@ -269,7 +268,7 @@ public class PVRChannelsListFragment extends AbstractSearchableFragment
         }
 
         // Split searchFilter to multiple lowercase words
-        String[] lcWords  = searchFilter.toLowerCase().split(" ");;
+        String[] lcWords = searchFilter.toLowerCase().split(" ");;
 
         List<PVRType.DetailsChannel> result = new ArrayList<>(itemList.size());
         for(PVRType.DetailsChannel item:itemList) {

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRChannelsListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRChannelsListFragment.java
@@ -120,6 +120,8 @@ public class PVRChannelsListFragment extends AbstractSearchableFragment
         });
         gridView.setEmptyView(emptyView);
 
+        super.onCreateView(inflater, container, savedInstanceState);
+
         return root;
     }
 
@@ -271,16 +273,16 @@ public class PVRChannelsListFragment extends AbstractSearchableFragment
         String[] lcWords = searchFilter.toLowerCase().split(" ");;
 
         List<PVRType.DetailsChannel> result = new ArrayList<>(itemList.size());
-        for(PVRType.DetailsChannel item:itemList) {
+        for (PVRType.DetailsChannel item:itemList) {
             // Require all words to match the item:
             boolean allWordsMatch = true;
-            for(String lcWord:lcWords) {
-                if(!searchFilterWordMatches(lcWord, item)) {
+            for (String lcWord:lcWords) {
+                if (!searchFilterWordMatches(lcWord, item)) {
                     allWordsMatch = false;
                     break;
                 }
             }
-            if(!allWordsMatch) {
+            if (!allWordsMatch) {
                 continue; // skip this item
             }
 
@@ -291,10 +293,10 @@ public class PVRChannelsListFragment extends AbstractSearchableFragment
     }
 
     public boolean searchFilterWordMatches(String lcWord, PVRType.DetailsChannel item) {
-        if(item.label.toLowerCase().contains(lcWord)) {
+        if (item.label.toLowerCase().contains(lcWord)) {
             return true;
         }
-        if(item.broadcastnow != null && item.broadcastnow.title.toLowerCase().contains(lcWord)){
+        if (item.broadcastnow != null && item.broadcastnow.title.toLowerCase().contains(lcWord)){
             return true;
         }
         return false;

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRRecordingsListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRRecordingsListFragment.java
@@ -21,7 +21,6 @@ import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.Handler;
 import android.preference.PreferenceManager;
-import android.support.v4.app.Fragment;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -159,16 +158,9 @@ public class PVRRecordingsListFragment extends AbstractSearchableFragment
     }
 
 
-    /**
-     * Use this to reload the items in the list
-     */
+    @Override
     public void refreshList() {
        onRefresh();
-    }
-
-    @Override
-    protected void restartLoader() {
-        onRefresh();
     }
 
     @Override
@@ -256,7 +248,7 @@ public class PVRRecordingsListFragment extends AbstractSearchableFragment
                 String searchFilter = getSearchFilter();
                 boolean hasSearchFilter = !TextUtils.isEmpty(searchFilter);
                 // Split searchFilter to multiple lowercase words
-                String[] lcWords= hasSearchFilter ? searchFilter.toLowerCase().split(" ") : null;
+                String[] lcWords = hasSearchFilter ? searchFilter.toLowerCase().split(" ") : null;
 
                 if (!(hideWatched || hasSearchFilter)) {
                     return itemList;


### PR DESCRIPTION
This implements a multi-word search for PVR Recordings, PVR Channels and PVR Radiochannels.
On channel views, when typing multiple words, a channel is displayed if all words each match either the channel name or the title of the current broadcast (match mode: case insensitive contains).
On recordings view, a recording is displayed if all words each match either the recording title or the channel name it has been recorded on (match mode: case insensitive contains)

For `AbstractSearchableFragment` I mostly copied code from `AbstractCursorListFragment` and I'm not sure if all of this is at all reqiured. I'm not sure what savedSearchFilter is used for, what `onPause()` or `onResume()` does and if `AbstractSearchableFragment#onCreateView` is required at all.