### PR TITLE
Fixed OutOfBounds exception

### DIFF
--- a/app/src/main/java/org/xbmc/kore/host/HostConnectionObserver.java
+++ b/app/src/main/java/org/xbmc/kore/host/HostConnectionObserver.java
@@ -975,7 +975,7 @@ public class HostConnectionObserver
      * @param observer Playlist observer to call with last result
      */
     private void replyWithLastResult(PlaylistEventsObserver observer) {
-        if (hostState.lastGetPlaylistResults != null)
+        if (hostState.lastGetPlaylistResults != null && !hostState.lastGetPlaylistResults.isEmpty())
             observer.playlistsAvailable(hostState.lastGetPlaylistResults);
         else
             checkPlaylist();


### PR DESCRIPTION
This fixes an array out of bounds exception when the playlist is cleared
and the PlaylistFragment.playlistsAvailable is called with an empty
list. Although I am unable to actually create a situation where this can happen numerous crash reports from different users suggests it may happen. From the reports it seems to be only happening on Android 9 and 10.