### PR TITLE
Uri encoding for local filenames.

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/sections/localfile/HttpApp.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/localfile/HttpApp.java
@@ -163,9 +163,8 @@ public class HttpApp extends NanoHTTPD {
             String filename = localFileLocationList.get(currentIndex).fileName;
             path = Uri.encode(filename) + "?number=" + currentIndex;
         } else {
-            Uri uri = localUriList.get(currentIndex);
-            String filename = getFileNameFromUri(uri);
-            path = filename + "?uri=" + currentIndex;
+            String filename = getFileNameFromUri(localUriList.get(currentIndex));
+            path = Uri.encode(filename) + "?uri=" + currentIndex;
         }
         return "http://" + ip + ":" + getListeningPort() + "/" + path + "&token=" + token;
     }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/localfile/HttpApp.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/localfile/HttpApp.java
@@ -160,7 +160,8 @@ public class HttpApp extends NanoHTTPD {
         }
         String path = null;
         if (currentIsFile) {
-            path = localFileLocationList.get(currentIndex).fileName + "?number=" + currentIndex;
+            String filename = localFileLocationList.get(currentIndex).fileName;
+            path = Uri.encode(filename) + "?number=" + currentIndex;
         } else {
             Uri uri = localUriList.get(currentIndex);
             String filename = getFileNameFromUri(uri);


### PR DESCRIPTION
Kodi couldn't play http-served files with spaces or other special characters in their names. It turned out that it was easy to fix by simply URI encoding the filename so that a valid link is created.

The else branch seems to be using URIs already, so i didn't touch it, I assume those are already properly encoded.