### PR TITLE
Allowed cleartext traffic for Api >27

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config>
+    <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
             <certificates src="user" />
         </trust-anchors>


### PR DESCRIPTION
From API 28 cleartext traffic is by default denied. This means that
HTTP connections with Kodi fail to download files through the
download manager.