### PR TITLE
Added support for Prime Videos shared from the official Amazon app

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
@@ -389,6 +389,21 @@ public class RemoteActivity extends BaseActivity
             videoUri = intent.getData();
         }
 
+        if (videoUri == null) {
+            // Some apps hide the link in the clip, try to detect any link by casting the intent
+            // to string a looking with a regular expression:
+
+            Matcher matcher = Pattern.compile("https?://[^\\s]+").matcher(intent.toString());
+            String matchedString = null;
+            if (matcher.find()) {
+                matchedString = matcher.group(0);
+                if (matchedString.endsWith("}")) {
+                    matchedString = matchedString.substring(0, matchedString.length() - 1);
+                }
+                videoUri = Uri.parse(matchedString);
+            }
+        }
+
         String url;
         if (videoUri == null) {
             url = getShareLocalUri(intent);
@@ -597,6 +612,12 @@ public class RemoteActivity extends BaseActivity
         } else if (host.endsWith("soundcloud.com")) {
             return "plugin://plugin.audio.soundcloud/play/?url="
                     + URLEncoder.encode(playuri.toString());
+        } else if (host.startsWith("app.primevideo.com")) {
+            Matcher amazonMatcher = Pattern.compile("gti=([^&]+)").matcher(playuri.toString());
+            if (amazonMatcher.find()) {
+                String gti = amazonMatcher.group(1);
+                return "plugin://plugin.video.amazon-test/?asin=" + gti + "&mode=PlayVideo&adult=0&name=&trailer=0&selbitrate=0";
+            }
         }
         return null;
     }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
@@ -390,26 +390,11 @@ public class RemoteActivity extends BaseActivity
         }
 
         if (videoUri == null) {
-            // Some apps hide the link in the clip, try to detect any link by casting the intent
-            // to string a looking with a regular expression:
-
-            Matcher matcher = Pattern.compile("https?://[^\\s]+").matcher(intent.toString());
-            String matchedString = null;
-            if (matcher.find()) {
-                matchedString = matcher.group(0);
-                if (matchedString.endsWith("}")) {
-                    matchedString = matchedString.substring(0, matchedString.length() - 1);
-                }
-                videoUri = Uri.parse(matchedString);
-            }
+            // Check if `intent` contains a URL or a link to a local file:
+            videoUri = getShareLocalUriOrHiddenUri(intent);
         }
 
-        String url;
-        if (videoUri == null) {
-            url = getShareLocalUri(intent);
-        } else {
-            url = toPluginUrl(videoUri);
-        }
+        String url = toPluginUrl(videoUri);
 
         if (url == null) {
             url = videoUri.toString();
@@ -457,12 +442,31 @@ public class RemoteActivity extends BaseActivity
         finish();
     }
 
-    private String getShareLocalUri(Intent intent) {
+    private Uri getUrlInsideIntent(Intent intent) {
+        // Some apps hide the link in the clip, try to detect any link by casting the intent
+        // to string a looking with a regular expression:
+
+        Matcher matcher = Pattern.compile("https?://[^\\s]+").matcher(intent.toString());
+        String matchedString = null;
+        if (matcher.find()) {
+            matchedString = matcher.group(0);
+            if (matchedString.endsWith("}")) {
+                matchedString = matchedString.substring(0, matchedString.length() - 1);
+            }
+            return Uri.parse(matchedString);
+        }
+        return null;
+    }
+
+    private Uri getShareLocalUriOrHiddenUri(Intent intent) {
         Uri contentUri = intent.getData();
 
         if (contentUri == null) {
             Bundle bundle = intent.getExtras();
             contentUri = (Uri) bundle.get(Intent.EXTRA_STREAM);
+        }
+        if (contentUri == null) {
+            return getUrlInsideIntent(intent);
         }
         if (contentUri == null) {
             return null;
@@ -480,7 +484,7 @@ public class RemoteActivity extends BaseActivity
         http_app.addUri(contentUri);
         String url = http_app.getLinkToFile();
 
-        return url;
+        return Uri.parse(url);
     }
 
     /**


### PR DESCRIPTION
Prime Video app supports sharing the links to videos. They can be shared through Kore.

Kore is currently unable to recognize the link, because the Prime Video app shares the link in a strange way (I cast the intent to a string, then match the link with regular expressions).

As a last step, I added the conversion logic to `plugin://plugin.video.amazon-test/...`, so that the movie can be watched on Kodi with the Amazon VOD addon.