### PR TITLE
Remember last-used tab

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/AbstractTabsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractTabsFragment.java
@@ -16,6 +16,8 @@
 
 package org.xbmc.kore.ui;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.view.ViewPager;
@@ -36,8 +38,11 @@ import butterknife.Unbinder;
 abstract public class AbstractTabsFragment extends AbstractFragment
         implements SharedElementTransition.SharedElement {
     private static final String TAG = LogUtils.makeLogTag(AbstractTabsFragment.class);
+    private static final String PREFERENCES_NAME = "AbstractTabsFragmentPreferences";
+    private static final String PREFERENCE_PREFIX_LAST_TAB = "lastTab_";
 
     @BindView(R.id.pager) ViewPager viewPager;
+    private SharedPreferences preferences;
 
     private Unbinder unbinder;
 
@@ -57,11 +62,26 @@ abstract public class AbstractTabsFragment extends AbstractFragment
             return null;
         }
 
+        preferences = getContext().getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE);
         ViewGroup root = (ViewGroup) inflater.inflate(R.layout.fragment_default_view_pager, container, false);
         unbinder = ButterKnife.bind(this, root);
 
         viewPager.setAdapter(createTabsAdapter(getDataHolder()));
+
+        if (shouldRememberLastTab()) {
+            viewPager.setCurrentItem(preferences.getInt(PREFERENCE_PREFIX_LAST_TAB + getClass().getName(), 0), false);
+        }
         return root;
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        if (shouldRememberLastTab()) {
+            preferences.edit()
+                    .putInt(PREFERENCE_PREFIX_LAST_TAB + getClass().getName(), viewPager.getCurrentItem())
+                    .apply();
+        }
     }
 
     @Override
@@ -106,4 +126,10 @@ abstract public class AbstractTabsFragment extends AbstractFragment
      * @return
      */
     abstract protected TabsAdapter createTabsAdapter(AbstractInfoFragment.DataHolder dataHolder);
+
+    /**
+     * Specifies whether to store the last-used tab.
+     * @return <code>true</code> if the fragment should remember the last-used tab.
+     */
+    abstract protected boolean shouldRememberLastTab();
 }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonDetailsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonDetailsFragment.java
@@ -54,4 +54,9 @@ public class AddonDetailsFragment extends AbstractTabsFragment {
                 .addTab(MediaFileListFragment.class, contentArgs(args), R.string.addon_content, baseFragmentId++)
                 ;
     }
+
+    @Override
+    protected boolean shouldRememberLastTab() {
+        return false;
+    }
 }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListContainerFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListContainerFragment.java
@@ -75,4 +75,9 @@ public class AddonListContainerFragment extends AbstractTabsFragment {
 
         return tabsAdapter;
     }
+
+    @Override
+    protected boolean shouldRememberLastTab() {
+        return true;
+    }
 }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/ArtistDetailsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/ArtistDetailsFragment.java
@@ -43,4 +43,10 @@ public class ArtistDetailsFragment extends AbstractTabsFragment {
                 .addTab(SongsListFragment.class, arguments,
                         R.string.songs, baseFragmentId + 2);
     }
+
+
+    @Override
+    protected boolean shouldRememberLastTab() {
+        return false;
+    }
 }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/MusicListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/MusicListFragment.java
@@ -84,4 +84,9 @@ public class MusicListFragment extends AbstractTabsFragment {
                 .addTab(MusicVideoListFragment.class, getArguments(), R.string.music_videos, 5);
         return tabsAdapter;
     }
+
+    @Override
+    protected boolean shouldRememberLastTab() {
+        return true;
+    }
 }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/file/FileListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/file/FileListFragment.java
@@ -77,4 +77,9 @@ public class FileListFragment extends AbstractTabsFragment
         // Not handled, let the activity handle it
         return false;
     }
+
+    @Override
+    protected boolean shouldRememberLastTab() {
+        return true;
+    }
 }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/localfile/LocalFileListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/localfile/LocalFileListFragment.java
@@ -104,4 +104,9 @@ public class LocalFileListFragment extends AbstractTabsFragment
         // Not handled, let the activity handle it
         return false;
     }
+
+    @Override
+    protected boolean shouldRememberLastTab() {
+        return true;
+    }
 }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRListFragment.java
@@ -68,4 +68,8 @@ public class PVRListFragment extends AbstractTabsFragment
         return false;
     }
 
+    @Override
+    protected boolean shouldRememberLastTab() {
+        return true;
+    }
 }


### PR DESCRIPTION
I never use the "artists" tab, so I always have to switch to the "albums" tab when opening the app. With this PR, Kore now remembers the last-used tab.