### PR TITLE
Do not set download button state when cancelling download

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,6 +87,11 @@ android {
         exclude 'META-INF/LICENSE.txt'
         exclude 'META-INF/NOTICE.txt'
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 ext {

--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/MusicVideoInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/MusicVideoInfoFragment.java
@@ -269,13 +269,8 @@ public class MusicVideoInfoFragment extends AbstractInfoFragment
                                                                               callbackHandler);
                                          }
                                      })
-                   .setNegativeButton(android.R.string.cancel,
-                                      new DialogInterface.OnClickListener() {
-                                          @Override
-                                          public void onClick(DialogInterface dialog, int which) {
-                                              // Nothing to do
-                                          }
-                                      })
+
+                   .setNegativeButton(android.R.string.cancel, (dialog, which) -> dialog.cancel())
                    .show();
         } else {
             FileDownloadHelper.downloadFiles(getActivity(), getHostInfo(),

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/MovieInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/MovieInfoFragment.java
@@ -94,12 +94,6 @@ public class MovieInfoFragment extends AbstractInfoFragment
         setOnDownloadListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                DialogInterface.OnClickListener noopClickListener =
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) { }
-                        };
-
                 // Check if the directory exists and whether to overwrite it
                 File file = new File(movieDownloadInfo.getAbsoluteFilePath());
                 if (file.exists()) {
@@ -124,7 +118,7 @@ public class MovieInfoFragment extends AbstractInfoFragment
                                                                                       callbackHandler);
                                                  }
                                              })
-                           .setNegativeButton(android.R.string.cancel, noopClickListener)
+                           .setNegativeButton(android.R.string.cancel, (dialog, which) -> dialog.cancel())
                            .show();
                 } else {
                     // Confirm that the user really wants to download the file
@@ -140,7 +134,8 @@ public class MovieInfoFragment extends AbstractInfoFragment
                                                                                        callbackHandler);
                                                   }
                                               })
-                           .setNegativeButton(android.R.string.cancel, noopClickListener)
+                           .setNegativeButton(android.R.string.cancel, (dialog, which) -> dialog.cancel())
+                           .setOnCancelListener(dialog -> setDownloadButtonState(false))
                            .show();
                 }
 

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowEpisodeInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowEpisodeInfoFragment.java
@@ -244,12 +244,6 @@ public class TVShowEpisodeInfoFragment extends AbstractInfoFragment
     }
 
     private void downloadEpisode() {
-        DialogInterface.OnClickListener noopClickListener =
-                new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) { }
-                };
-
         // Check if the directory exists and whether to overwrite it
         File file = new File(fileDownloadHelper.getAbsoluteFilePath());
         if (file.exists()) {
@@ -274,7 +268,7 @@ public class TVShowEpisodeInfoFragment extends AbstractInfoFragment
                                                                               callbackHandler);
                                          }
                                      })
-                   .setNegativeButton(android.R.string.cancel, noopClickListener)
+                   .setNegativeButton(android.R.string.cancel, (dialog, which) -> dialog.cancel())
                    .show();
         } else {
             // Confirm that the user really wants to download the file
@@ -290,7 +284,8 @@ public class TVShowEpisodeInfoFragment extends AbstractInfoFragment
                                                                                callbackHandler);
                                           }
                                       })
-                   .setNegativeButton(android.R.string.cancel, noopClickListener)
+                   .setNegativeButton(android.R.string.cancel, (dialog, which) -> dialog.cancel())
+                   .setOnCancelListener(dialog -> setDownloadButtonState(false))
                    .show();
         }
     }


### PR DESCRIPTION
When pressing "Cancel" in the dialog or closing it by touching the back button, the download button stays highlighted, which is wrong.