### PR TITLE
Add support to sharing from Arte's video to Kodi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+Version 2.5.1
+-------------
+- Add support to sharing from Arte video (The European Culture Channel) to Kodi
+
 Version 2.5.0
 -------------
 - Include search option in PVR section

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,7 +75,7 @@
                 <data android:host="www.svtplay.se"/>
                 <data android:host="soundcloud.com"/>
                 <data android:host="m.soundcloud.com"/>
-				<data android:host="www.arte.tv"/>
+                <data android:host="www.arte.tv"/>
             </intent-filter>
 
             <meta-data android:name="android.service.chooser.chooser_target_service"
@@ -129,6 +129,7 @@
                 <data android:host="www.svtplay.se"/>
                 <data android:host="soundcloud.com"/>
                 <data android:host="m.soundcloud.com"/>
+                <data android:host="www.arte.tv"/>
             </intent-filter>
 
         </activity>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,6 +75,7 @@
                 <data android:host="www.svtplay.se"/>
                 <data android:host="soundcloud.com"/>
                 <data android:host="m.soundcloud.com"/>
+				<data android:host="www.arte.tv"/>
             </intent-filter>
 
             <meta-data android:name="android.service.chooser.chooser_target_service"

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
@@ -64,6 +64,7 @@ import org.xbmc.kore.utils.LogUtils;
 import org.xbmc.kore.utils.TabsAdapter;
 import org.xbmc.kore.utils.UIUtils;
 import org.xbmc.kore.utils.Utils;
+import org.xbmc.kore.utils.PluginUrlUtils;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -623,6 +624,8 @@ public class RemoteActivity extends BaseActivity
                 String gti = amazonMatcher.group(1);
                 return "plugin://plugin.video.amazon-test/?asin=" + gti + "&mode=PlayVideo&adult=0&name=&trailer=0&selbitrate=0";
             }
+        } else if (PluginUrlUtils.isHostArte(host)) {
+            return PluginUrlUtils.toPluginUrlArte(playuri);
         }
         return null;
     }

--- a/app/src/main/java/org/xbmc/kore/utils/PluginUrlUtils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/PluginUrlUtils.java
@@ -26,7 +26,7 @@ import java.util.regex.Pattern;
 public class PluginUrlUtils {
 
     public static boolean isHostArte(String host) {
-        return host.endsWith("www.arte.tv");
+        return host.equals("www.arte.tv");
     }
 
     public static String toPluginUrlArte(Uri playUri) {

--- a/app/src/main/java/org/xbmc/kore/utils/PluginUrlUtils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/PluginUrlUtils.java
@@ -30,7 +30,7 @@ public class PluginUrlUtils {
     }
 
     public static String toPluginUrlArte(Uri playUri) {
-        Pattern pattern = Pattern.compile("/videos/(.*)/.*/");
+        Pattern pattern = Pattern.compile("^https://www.arte.tv/[a-z]{2}/videos/([0-9]{6}-[0-9]{3}-[A-Z])/.*$");
         Matcher matcher = pattern.matcher(playUri.toString());
         if (matcher.matches()) {
             String kind="SHOW";

--- a/app/src/main/java/org/xbmc/kore/utils/PluginUrlUtils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/PluginUrlUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015 Synced Synapse. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.xbmc.kore.utils;
+
+import android.net.Uri;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Misc util methods for use with plugin URL
+ */
+public class PluginUrlUtils {
+
+    public static boolean isHostArte(String host) {
+        return host.endsWith("www.arte.tv");
+    }
+
+    public static String toPluginUrlArte(Uri playUri) {
+        Pattern pattern = Pattern.compile("/videos/(.*)/.*/");
+        Matcher matcher = pattern.matcher(playUri.toString());
+        if (matcher.matches()) {
+            String kind="SHOW";
+            String program_id=matcher.group(1);
+            return "plugin://plugin.video.arteplussept/play/" + kind + "/" + program_id;
+        }
+        return null;
+    }
+}

--- a/app/src/main/java/org/xbmc/kore/utils/PluginUrlUtils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/PluginUrlUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Synced Synapse. All rights reserved.
+ * Copyright 2020 STB Land. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/test/java/org/xbmc/kore/utils/PluginUrlUtilsTest.java
+++ b/app/src/test/java/org/xbmc/kore/utils/PluginUrlUtilsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Martijn Brekhof. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.xbmc.kore.utils;
+
+import android.net.Uri;
+
+import org.junit.runner.RunWith;
+import org.junit.Test;
+import org.robolectric.annotation.Config;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+@Config(sdk = 28)
+public class PluginUrlUtilsTest {
+	
+    @Test
+    public void isHostArte() throws Exception {
+        assertTrue(PluginUrlUtils.isHostArte("www.arte.tv"));
+    }
+	
+    @Test
+    public void toPluginUrlArte() throws Exception {
+        Uri playUri = Uri.parse("https://www.arte.tv/fr/videos/084692-000-A/mongolie-le-reve-d-une-jeune-nomade/");
+		String pluginUrl = PluginUrlUtils.toPluginUrlArte(playUri);
+        assertNotNull(pluginUrl);
+		assertEquals("plugin://plugin.video.arteplussept/play/SHOW/084692-000-A", pluginUrl);
+    }	
+}

--- a/app/src/test/java/org/xbmc/kore/utils/PluginUrlUtilsTest.java
+++ b/app/src/test/java/org/xbmc/kore/utils/PluginUrlUtilsTest.java
@@ -39,9 +39,9 @@ public class PluginUrlUtilsTest {
 	
     @Test
     public void toPluginUrlArte() throws Exception {
-        Uri playUri = Uri.parse("https://www.arte.tv/fr/videos/084692-000-A/mongolie-le-reve-d-une-jeune-nomade/");
-		String pluginUrl = PluginUrlUtils.toPluginUrlArte(playUri);
-        assertNotNull(pluginUrl);
-		assertEquals("plugin://plugin.video.arteplussept/play/SHOW/084692-000-A", pluginUrl);
+    Uri playUri = Uri.parse("https://www.arte.tv/fr/videos/084692-000-A/mongolie-le-reve-d-une-jeune-nomade/");
+	String pluginUrl = PluginUrlUtils.toPluginUrlArte(playUri);
+    assertNotNull(pluginUrl);
+	assertEquals("plugin://plugin.video.arteplussept/play/SHOW/084692-000-A", pluginUrl);
     }	
 }


### PR DESCRIPTION
Add support to sharing from [Arte's video](https://www.arte.tv/) (The European Culture Channel) to Kodi, using the  [Arte +7 plugin.](https://kodi.wiki/view/Add-on:Arte_%2B7) maintained by @known-as-bmf

Two JUnit tests has beed added and runned on [Travis CI](https://travis-ci.org/github/stbland).