### PR TITLE
Fixed refreshing playlist on HTTP connections

### DIFF
--- a/app/src/main/java/org/xbmc/kore/host/HostConnectionObserver.java
+++ b/app/src/main/java/org/xbmc/kore/host/HostConnectionObserver.java
@@ -594,8 +594,11 @@ public class HostConnectionObserver
                     return;
                 }
 
-                for (PlaylistEventsObserver observer : playlistEventsObservers) {
-                    observer.playlistsAvailable(result);
+                if (!(hostState.lastGetPlaylistResults != null &&
+                    hostState.lastGetPlaylistResults.equals(result))) {
+                    for (PlaylistEventsObserver observer : playlistEventsObservers) {
+                        observer.playlistsAvailable(result);
+                    }
                 }
 
                 // Handle cleared playlists

--- a/app/src/main/java/org/xbmc/kore/host/actions/GetPlaylist.java
+++ b/app/src/main/java/org/xbmc/kore/host/actions/GetPlaylist.java
@@ -17,6 +17,8 @@
 package org.xbmc.kore.host.actions;
 
 
+import androidx.annotation.Nullable;
+
 import org.xbmc.kore.jsonrpc.ApiMethod;
 import org.xbmc.kore.jsonrpc.HostConnection;
 import org.xbmc.kore.jsonrpc.method.Playlist;
@@ -171,6 +173,12 @@ public class GetPlaylist implements Callable<ArrayList<GetPlaylist.GetPlaylistRe
             this.id = playlistId;
             this.type = type;
             this.items = items;
+        }
+
+        @Override
+        public boolean equals(@Nullable Object obj) {
+            return obj instanceof GetPlaylistResult &&
+                   this.items.equals(((GetPlaylistResult) obj).items);
         }
     }
 }

--- a/app/src/main/java/org/xbmc/kore/jsonrpc/type/ListType.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/type/ListType.java
@@ -18,10 +18,13 @@ package org.xbmc.kore.jsonrpc.type;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import androidx.annotation.Nullable;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import org.xbmc.kore.host.actions.GetPlaylist;
 import org.xbmc.kore.utils.JsonUtils;
 
 import java.util.List;
@@ -286,6 +289,12 @@ public class ListType {
             watchedepisodes = JsonUtils.intFromJsonNode(node, WATCHEDEPISODES, -1);
             writer = JsonUtils.stringListFromJsonNode(node, WRITER);
             year = JsonUtils.intFromJsonNode(node, YEAR, -1);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object obj) {
+            return obj instanceof ItemBase &&
+                   this.id == ((ItemBase) obj).id;
         }
     }
 


### PR DESCRIPTION
When Kore retrieves the data over HTTP the playlist would be
refreshed every 4 seconds. This caused the playlist to jump to
the top when scrolled down. This has been fixed by checking if
the new playlist is different from the current playlist. If not
nothing changes.

This should fix issue #739 