### PR TITLE
Support sharing of unlisted Vimeo videos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Usage: docker build -t kore:latest .
+#        docker run -it -v $(pwd):/opt/kore kore:latest bash
+#        gradle
+FROM ubuntu:20.04
+
+# Install Java
+ARG JDK_VERSION=8
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends openjdk-${JDK_VERSION}-jdk && \
+    apt-get install -y --no-install-recommends git wget unzip
+
+# Install Gradle
+# https://services.gradle.org/distributions/
+ARG GRADLE_VERSION=6.7
+ARG GRADLE_DIST=bin
+RUN cd /opt && \
+    wget -q https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-${GRADLE_DIST}.zip && \
+    unzip gradle*.zip && \
+    ls -d */ | sed 's/\/*$//g' | xargs -I{} mv {} gradle && \
+    rm gradle*.zip
+
+# Install Android SDK and build-tools
+# https://developer.android.com/studio#command-tools
+ARG ANDROID_SDK_VERSION=6858069
+ENV ANDROID_SDK_ROOT /opt/android/sdk
+RUN mkdir -p ${ANDROID_SDK_ROOT}/tools && \
+    wget -q https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_SDK_VERSION}_latest.zip && \
+    unzip *tools*linux*.zip -d ${ANDROID_SDK_ROOT} && \
+    rm /commandlinetools*linux*.zip
+
+# Install Android build-tools (should match version in ./app/build.gradle)
+ARG ANDROID_BUILD_TOOLS_VERSION=29.0.2
+RUN yes Y | /opt/android/sdk/cmdline-tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_ROOT} --install "build-tools;${ANDROID_BUILD_TOOLS_VERSION}"
+RUN yes Y | /opt/android/sdk/cmdline-tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_ROOT} --licenses
+
+# Set the environment variables
+ENV JAVA_HOME /usr/lib/jvm/java-${JDK_VERSION}-openjdk-amd64
+ENV GRADLE_HOME /opt/gradle
+ENV PATH ${PATH}:${GRADLE_HOME}/bin:${ANDROID_SDK_ROOT}/cmdline-tools/bin:${ANDROID_SDK_ROOT}/tools/bin:${ANDROID_SDK_ROOT}/platform-tools:${ANDROID_SDK_ROOT}/build-tools/${ANDROID_BUILD_TOOLS_VERSION}
+
+WORKDIR /opt/kore

--- a/README.md
+++ b/README.md
@@ -11,16 +11,14 @@ Doxygen documentation [![Documentation](https://codedocs.xyz/xbmc/Kore.svg)](htt
   <img src="https://f-droid.org/badge/get-it-on.png" height="80"/>
 </a>
 
-Kore - Kodi/XBMC remote for Android
------------------------------------
+# Kore - Kodi/XBMC remote for Android
 
 GitHub repository for the [Kore][1] Android app.
 
 Kore is the official remote for [Kodi](http://kodi.tv/), and aims to be a simple and easy to use remote.
 
 
-Building
----------
+## Building
 
 1. Make sure you have a working [Android build system](http://developer.android.com/sdk/installing/studio-build.html);
 2. The version of Android SDK and Build Tools needed is specified in app/build.gradle. Make sure you have them installed;
@@ -28,9 +26,7 @@ Building
 4. Git pull
 5. Gradle should be able to fetch all the other needed libraries.
 
-
-Testing
--------
+## Testing
 
 1. Make sure you are able to build Kore as described in the previous section.
 2. To run the local tests see [README](https://github.com/xbmc/Kore/blob/master/app/src/test/README.md)
@@ -39,8 +35,17 @@ Testing
 We currently use [travis-ci](https://travis-ci.org/xbmc/Kore/) to automatically build
 and run the local tests for each pull request.
 
-Credits
--------
+## Using Docker
+
+1. Make sure you have a working [Docker installation](https://docs.docker.com/docker-for-windows/install/);
+2. Check out the repository
+3. Build the container image: `docker build -t kore:latest .`
+4. Start container: `docker run -it -v $(pwd):/opt/kore kore:latest bash`
+
+For listing all tasks, run `gradle tasks`, for building the app, execute `gradle assembleRelease`.
+If you want to run tests, execute `gradle testDebugUnitTest`.
+
+## Credits
 
 **Libraries used**
 - [Jackson](https://github.com/FasterXML/jackson)
@@ -54,17 +59,14 @@ Credits
 - [ExpandableTextView](https://github.com/Blogcat/Android-ExpandableTextView)
 - [AndroidSlidingUpPanel](https://github.com/umano/AndroidSlidingUpPanel)
 
-Links
------
+## Links
 
 - [Kodi forum thread](http://forum.kodi.tv/forumdisplay.php?fid=129)
 - [F-Droid](https://f-droid.org/repository/browse/?fdid=org.xbmc.kore)
 - [Google Play][1]
 - [Google+ community](https://plus.google.com/communities/115506510322045554124)
 
-
-License
--------
+## License
 
     Copyright 2017 XBMC Foundation
 

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
@@ -610,10 +610,7 @@ public class RemoteActivity extends BaseActivity
                 return "plugin://plugin.video.youtube/play/?video_id="
                         + playuri.getLastPathSegment();
             } else if (host.endsWith("vimeo.com")) {
-                String last = playuri.getLastPathSegment();
-                if (last.matches("\\d+")) {
-                    return "plugin://plugin.video.vimeo/play/?video_id=" + last;
-                }
+                return PluginUrlUtils.toPluginUrlVimeo(playuri);
             } else if (host.endsWith("svtplay.se")) {
                 Pattern pattern = Pattern.compile(
                         "^(?:https?:\\/\\/)?(?:www\\.)?svtplay\\.se\\/video\\/(\\d+\\/.*)",

--- a/app/src/main/java/org/xbmc/kore/utils/PluginUrlUtils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/PluginUrlUtils.java
@@ -24,7 +24,6 @@ import java.util.regex.Pattern;
  * Misc util methods for use with plugin URL
  */
 public class PluginUrlUtils {
-
     public static boolean isHostArte(String host) {
         return host.equals("www.arte.tv");
     }
@@ -52,4 +51,27 @@ public class PluginUrlUtils {
         return null;
     }
 
+    public static String toPluginUrlVimeo(Uri playUri) {
+        String route = playUri.getPath();
+        String[] routePatterns = {
+            "^\\/(?<id>\\d+)$",
+            "^\\/(?<id>\\d+)\\/(?<hash>\\w+)$",
+            "\\/(?<id>\\d+)$",
+        };
+
+        for (String routePattern: routePatterns) {
+            Matcher routeMatcher = Pattern.compile(routePattern).matcher(route);
+
+            if (routeMatcher.find()) {
+                String videoId = routeMatcher.group(1);
+                if (routeMatcher.groupCount() == 2) {
+                    videoId = routeMatcher.group(1) + ":" + routeMatcher.group(2);
+                }
+
+                return "plugin://plugin.video.vimeo/play/?video_id=" + videoId;
+            }
+        }
+
+        return null;
+    }
 }

--- a/app/src/test/java/org/xbmc/kore/utils/PluginUrlUtilsTest.java
+++ b/app/src/test/java/org/xbmc/kore/utils/PluginUrlUtilsTest.java
@@ -31,17 +31,36 @@ import static org.junit.Assert.assertTrue;
 @RunWith(AndroidJUnit4.class)
 @Config(sdk = 28)
 public class PluginUrlUtilsTest {
-	
+
     @Test
     public void isHostArte() throws Exception {
         assertTrue(PluginUrlUtils.isHostArte("www.arte.tv"));
     }
-	
+
     @Test
     public void toPluginUrlArte() throws Exception {
-    Uri playUri = Uri.parse("https://www.arte.tv/fr/videos/084692-000-A/mongolie-le-reve-d-une-jeune-nomade/");
-	String pluginUrl = PluginUrlUtils.toPluginUrlArte(playUri);
-    assertNotNull(pluginUrl);
-	assertEquals("plugin://plugin.video.arteplussept/play/SHOW/084692-000-A", pluginUrl);
-    }	
+        Uri playUri = Uri.parse("https://www.arte.tv/fr/videos/084692-000-A/mongolie-le-reve-d-une-jeune-nomade/");
+        String pluginUrl = PluginUrlUtils.toPluginUrlArte(playUri);
+        assertNotNull(pluginUrl);
+        assertEquals("plugin://plugin.video.arteplussept/play/SHOW/084692-000-A", pluginUrl);
+    }
+
+    @Test
+    public void toPluginUrlVimeo() throws Exception {
+        Uri playUriDefault = Uri.parse("https://vimeo.com/12345");
+        String pluginUrlDefault = PluginUrlUtils.toPluginUrlVimeo(playUriDefault);
+        assertEquals("plugin://plugin.video.vimeo/play/?video_id=12345", pluginUrlDefault);
+
+        Uri playUriChannel = Uri.parse("https://vimeo.com/channels/staffpicks/654321");
+        String pluginUrlChannel = PluginUrlUtils.toPluginUrlVimeo(playUriChannel);
+        assertEquals("plugin://plugin.video.vimeo/play/?video_id=654321", pluginUrlChannel);
+
+        Uri playUriShowcase = Uri.parse("https://vimeo.com/showcase/123/video/1234567");
+        String pluginUrlShowcase = PluginUrlUtils.toPluginUrlVimeo(playUriShowcase);
+        assertEquals("plugin://plugin.video.vimeo/play/?video_id=1234567", pluginUrlShowcase);
+
+        Uri playUriUnlisted = Uri.parse("https://vimeo.com/1234/hash");
+        String pluginUrlUnlisted = PluginUrlUtils.toPluginUrlVimeo(playUriUnlisted);
+        assertEquals("plugin://plugin.video.vimeo/play/?video_id=1234:hash", pluginUrlUnlisted);
+    }
 }


### PR DESCRIPTION
This commit makes it possible to share an unlisted Vimeo video.

Those videos have an additional ID which has to be parsed correctly.

Example link: https://vimeo.com/355062058/5293454954

Related to https://github.com/jaylinski/kodi-addon-vimeo/issues/43.