### PR TITLE
Enabled legacy storage access in Android 10

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:requestLegacyExternalStorage="true"
         android:networkSecurityConfig="@xml/network_security_config">
 
         <!-- Activities -->


### PR DESCRIPTION
Related in #766.

This does not solve the problem with Android 11, just with Android 10

Read more in https://developer.android.com/training/data-storage/use-cases