### PR TITLE
fix for seek bar issue for Kodi 19

### DIFF
--- a/app/src/main/java/org/xbmc/kore/jsonrpc/ApiMethod.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/ApiMethod.java
@@ -104,7 +104,43 @@ public abstract class ApiMethod<T> {
         return params;
     }
 
-    /**
+	/**
+	 * Returns the parameters node of the json request object for Kodi 19+
+	 * Creates one if necessary
+	 * @return Parameters node
+	 */
+	protected ArrayNode getParametersNodeNew() {
+		ArrayNode params;
+		if (jsonRequest.has(PARAMS_NODE)) {
+			params = (ArrayNode)jsonRequest.get(PARAMS_NODE);
+		} else {
+			params = objectMapper.createArrayNode();
+			jsonRequest.put(PARAMS_NODE, params);
+		}
+
+		return params;
+	}
+
+	/**
+	 * Adds a parameter to the request for Kodi 19+
+	 * @param value Value to add
+	 */
+	protected void addParameterToRequestNew(int value) {
+		getParametersNodeNew().add(value);
+	}
+
+	/**
+	 * Adds a parameter to the request for Kodi 19+
+	 * @param value Value to add
+	 */
+	protected void addParameterToRequestNew(String fieldName, Double value) {
+		ObjectNode paramObject = objectMapper.createObjectNode();
+		paramObject.put(fieldName, value);
+		getParametersNodeNew().add(paramObject);
+	}
+
+
+	/**
      * Adds a parameter to the request
      * @param parameter Parameter name
      * @param value Value to add

--- a/app/src/main/java/org/xbmc/kore/jsonrpc/ApiMethod.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/ApiMethod.java
@@ -122,20 +122,20 @@ public abstract class ApiMethod<T> {
 	}
 
 	/**
-	 * Adds a parameter to the request for Kodi 19+
+	 * Adds a parameter to the request for Kodi Matrix
 	 * @param value Value to add
 	 */
-	protected void addParameterToRequestNew(int value) {
+	protected void addParameterToRequestMatrix(int value) {
 		getParametersNodeNew().add(value);
 	}
 
 	/**
-	 * Adds a parameter to the request for Kodi 19+
+	 * Adds a parameter to the request for Kodi Matrix
 	 * @param value Value to add
 	 */
-	protected void addParameterToRequestNew(String fieldName, Double value) {
+	protected void addParameterToRequestMatrix(String parameter, Double value) {
 		ObjectNode paramObject = objectMapper.createObjectNode();
-		paramObject.put(fieldName, value);
+		paramObject.put(parameter, value);
 		getParametersNodeNew().add(paramObject);
 	}
 

--- a/app/src/main/java/org/xbmc/kore/jsonrpc/ApiMethod.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/ApiMethod.java
@@ -105,11 +105,11 @@ public abstract class ApiMethod<T> {
     }
 
 	/**
-	 * Returns the parameters node of the json request object for Kodi 19+
+	 * Returns the parameters node of the json request object for Kodi Matrix
 	 * Creates one if necessary
 	 * @return Parameters node
 	 */
-	protected ArrayNode getParametersNodeNew() {
+	protected ArrayNode getParametersNodeMatrix() {
 		ArrayNode params;
 		if (jsonRequest.has(PARAMS_NODE)) {
 			params = (ArrayNode)jsonRequest.get(PARAMS_NODE);
@@ -126,17 +126,18 @@ public abstract class ApiMethod<T> {
 	 * @param value Value to add
 	 */
 	protected void addParameterToRequestMatrix(int value) {
-		getParametersNodeNew().add(value);
+		getParametersNodeMatrix().add(value);
 	}
 
 	/**
 	 * Adds a parameter to the request for Kodi Matrix
+	 * @param parameter Parameter name
 	 * @param value Value to add
 	 */
 	protected void addParameterToRequestMatrix(String parameter, Double value) {
 		ObjectNode paramObject = objectMapper.createObjectNode();
 		paramObject.put(parameter, value);
-		getParametersNodeNew().add(paramObject);
+		getParametersNodeMatrix().add(paramObject);
 	}
 
 

--- a/app/src/main/java/org/xbmc/kore/jsonrpc/method/Player.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/method/Player.java
@@ -249,14 +249,14 @@ public class Player {
 
 
         /**
-         * Seek through the playing item (by percentage)
+         * Seek through the playing item (by percentage double)
          * @param playerId Player id for which to stop playback
          * @param percentage Where to seek
          */
         public Seek(int playerId, Double percentage) {
             super();
-            addParameterToRequestNew(1);
-            addParameterToRequestNew("percentage", percentage);
+            addParameterToRequestMatrix(playerId);
+            addParameterToRequestMatrix("percentage", percentage);
         }
 
         /**

--- a/app/src/main/java/org/xbmc/kore/jsonrpc/method/Player.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/method/Player.java
@@ -247,15 +247,16 @@ public class Player {
         public static final String BACKWARD = "smallbackward";
         public static final String FORWARD = "smallforward";
 
+
         /**
-         * Seek through the playing item (by time)
+         * Seek through the playing item (by percentage)
          * @param playerId Player id for which to stop playback
-         * @param value Where to seek
+         * @param percentage Where to seek
          */
-        public Seek(int playerId, PlayerType.PositionTime value) {
+        public Seek(int playerId, Double percentage) {
             super();
-            addParameterToRequest("playerid", playerId);
-            addParameterToRequest("value", value);
+            addParameterToRequestNew(1);
+            addParameterToRequestNew("percentage", percentage);
         }
 
         /**

--- a/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
@@ -342,9 +342,8 @@ public abstract class BaseMediaActivity extends BaseActivity
     }
 
     @Override
-    public void onProgressChanged(int progress) {
-        PlayerType.PositionTime positionTime = new PlayerType.PositionTime(progress);
-        Player.Seek seekAction = new Player.Seek(currentActivePlayerId, positionTime);
+    public void onProgressChanged(Double percentage) {
+        Player.Seek seekAction = new Player.Seek(currentActivePlayerId, percentage);
         seekAction.execute(HostManager.getInstance(this).getConnection(), new ApiCallback<PlayerType.SeekReturnType>() {
             @Override
             public void onSuccess(PlayerType.SeekReturnType result) {

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
@@ -628,9 +628,8 @@ public class NowPlayingFragment extends Fragment
     public void observerOnStopObserving() {}
 
     @Override
-    public void onProgressChanged(int progress) {
-        PlayerType.PositionTime positionTime = new PlayerType.PositionTime(progress);
-        Player.Seek seekAction = new Player.Seek(currentActivePlayerId, positionTime);
+    public void onProgressChanged(Double percentage) {
+        Player.Seek seekAction = new Player.Seek(currentActivePlayerId, percentage);
         seekAction.execute(HostManager.getInstance(getContext()).getConnection(), new ApiCallback<PlayerType.SeekReturnType>() {
             @Override
             public void onSuccess(PlayerType.SeekReturnType result) {

--- a/app/src/main/java/org/xbmc/kore/ui/widgets/MediaProgressIndicator.java
+++ b/app/src/main/java/org/xbmc/kore/ui/widgets/MediaProgressIndicator.java
@@ -50,7 +50,7 @@ public class MediaProgressIndicator extends LinearLayout {
     private OnProgressChangeListener onProgressChangeListener;
 
     public interface OnProgressChangeListener {
-        void onProgressChanged(int progress);
+        void onProgressChanged(Double percentage);
     }
 
     public MediaProgressIndicator(Context context) {
@@ -92,9 +92,13 @@ public class MediaProgressIndicator extends LinearLayout {
 
             @Override
             public void onStopTrackingTouch(SeekBar seekBar) {
-                if (onProgressChangeListener != null)
-                    onProgressChangeListener.onProgressChanged(seekBar.getProgress());
-
+                if (onProgressChangeListener != null){
+                    int progress = seekBar.getProgress();
+                    int max = seekBar.getMax();
+                    float fPercentage = (((float)progress/(float)max) * 100);
+                    Double percentage = new Double(fPercentage);
+                    onProgressChangeListener.onProgressChanged(percentage);
+                }
                 if (speed > 0)
                     seekBar.postDelayed(seekBarUpdater, SEEK_BAR_UPDATE_INTERVAL);
             }


### PR DESCRIPTION
I have added new array type params in jsonrpc request which is required by Kodi 19. Then used percentage instead of time for the seek bar.

This is more of a quick and dirty fix. I am not so much of an Android developer, so I am leaving this here for some else to pick up from there.
