### PR TITLE
Automatically focus on "send text to media center" TextField

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/generic/SendTextDialogFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/generic/SendTextDialogFragment.java
@@ -137,6 +137,7 @@ public class SendTextDialogFragment extends DialogFragment {
                 }
             }
         });
+        textToSend.requestFocus();
         textToSend.setOnEditorActionListener(new TextView.OnEditorActionListener() {
             @Override
             public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {


### PR DESCRIPTION
When using the option "send text to media center" the user has to automatically tap the TextField in order for input to work.
This PR aims to fix this.