### PR TITLE
Remove ResourceIDs from switch statements as they will be non-final

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/AbstractCursorListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractCursorListFragment.java
@@ -167,10 +167,9 @@ public abstract class AbstractCursorListFragment extends AbstractListFragment
 
 	@Override
 	public boolean onOptionsItemSelected(MenuItem item) {
-		switch(item.getItemId()) {
-			case R.id.action_refresh:
-				onRefresh();
-				break;
+		int itemId = item.getItemId();
+		if (itemId == R.id.action_refresh) {
+			onRefresh();
 		}
 		return super.onOptionsItemSelected(item);
 	}

--- a/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
@@ -226,9 +226,8 @@ abstract public class AbstractInfoFragment extends AbstractFragment
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.action_refresh:
-                onRefresh();
+        if (item.getItemId() == R.id.action_refresh) {
+            onRefresh();
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/java/org/xbmc/kore/ui/AbstractListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractListFragment.java
@@ -113,10 +113,9 @@ public abstract class AbstractListFragment extends Fragment implements
 
 	@Override
 	public boolean onOptionsItemSelected(MenuItem item) {
-		switch(item.getItemId()) {
-			case R.id.action_multi_single_columns:
-				toggleAmountOfColumns(item);
-				break;
+		int itemId = item.getItemId();
+		if (itemId == R.id.action_multi_single_columns) {
+			toggleAmountOfColumns(item);
 		}
 		return super.onOptionsItemSelected(item);
 	}

--- a/app/src/main/java/org/xbmc/kore/ui/AbstractSearchableFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractSearchableFragment.java
@@ -162,10 +162,9 @@ public abstract class AbstractSearchableFragment extends AbstractListFragment im
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch(item.getItemId()) {
-            case R.id.action_refresh:
-                refreshList();
-                break;
+        int itemId = item.getItemId();
+        if (itemId == R.id.action_refresh) {
+            refreshList();
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
@@ -246,14 +246,12 @@ public abstract class BaseMediaActivity extends BaseActivity
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.action_show_remote:
-                Intent launchIntent = new Intent(this, RemoteActivity.class)
-                        .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-                startActivity(launchIntent);
-                return true;
-            default:
-                break;
+        int itemId = item.getItemId();
+        if (itemId == R.id.action_show_remote) {
+            Intent launchIntent = new Intent(this, RemoteActivity.class)
+                    .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+            startActivity(launchIntent);
+            return true;
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListFragment.java
@@ -145,17 +145,14 @@ public class AddonListFragment extends AbstractListFragment {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
-        switch (item.getItemId()) {
-            case R.id.action_hide_disabled:
-                item.setChecked(!item.isChecked());
-                preferences.edit()
-                        .putBoolean(Settings.KEY_PREF_ADDONS_FILTER_HIDE_DISABLED, item.isChecked())
-                        .apply();
-                hideDisabledAddons = item.isChecked();
-                callGetAddonsAndSetup();
-                break;
-            default:
-                break;
+        int itemId = item.getItemId();
+        if (itemId == R.id.action_hide_disabled) {
+            item.setChecked(!item.isChecked());
+            preferences.edit()
+                       .putBoolean(Settings.KEY_PREF_ADDONS_FILTER_HIDE_DISABLED, item.isChecked())
+                       .apply();
+            hideDisabledAddons = item.isChecked();
+            callGetAddonsAndSetup();
         }
 
         return super.onOptionsItemSelected(item);

--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonsActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonsActivity.java
@@ -86,27 +86,24 @@ public class AddonsActivity extends BaseMediaActivity
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.action_show_remote:
-                // Starts remote
-                Intent launchIntent = new Intent(this, RemoteActivity.class)
-                        .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-                startActivity(launchIntent);
+        int itemId = item.getItemId();
+        if (itemId == R.id.action_show_remote) {
+            // Starts remote
+            Intent launchIntent = new Intent(this, RemoteActivity.class)
+                    .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+            startActivity(launchIntent);
+            return true;
+        } else if (itemId == android.R.id.home) {
+            // Only respond to this if we are showing the details in portrait mode,
+            // which can be checked by checking if selected movie != -1, in which case we
+            // should go back to the previous fragment, which is the list.
+            if (selectedAddonId != null) {
+                selectedAddonId = null;
+                selectedAddonTitle = null;
+                updateActionBar(getActionBarTitle(), false);
+                getSupportFragmentManager().popBackStack();
                 return true;
-            case android.R.id.home:
-                // Only respond to this if we are showing the details in portrait mode,
-                // which can be checked by checking if selected movie != -1, in which case we
-                // should go back to the previous fragment, which is the list.
-                if (selectedAddonId != null) {
-                    selectedAddonId = null;
-                    selectedAddonTitle = null;
-                    updateActionBar(getActionBarTitle(), false);
-                    getSupportFragmentManager().popBackStack();
-                    return true;
-                }
-                break;
-            default:
-                break;
+            }
         }
 
         return super.onOptionsItemSelected(item);

--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/AlbumListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/AlbumListFragment.java
@@ -129,37 +129,31 @@ public class AlbumListFragment extends AbstractCursorListFragment {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
-        switch (item.getItemId()) {
-            case R.id.action_sort_by_album:
-                item.setChecked(!item.isChecked());
-                preferences.edit()
-                           .putInt(Settings.KEY_PREF_ALBUMS_SORT_ORDER, Settings.SORT_BY_ALBUM)
-                           .apply();
-                refreshList();
-                break;
-            case R.id.action_sort_by_artist:
-                item.setChecked(!item.isChecked());
-                preferences.edit()
-                           .putInt(Settings.KEY_PREF_ALBUMS_SORT_ORDER, Settings.SORT_BY_ARTIST)
-                           .apply();
-                refreshList();
-                break;
-            case R.id.action_sort_by_artist_year:
-                item.setChecked(!item.isChecked());
-                preferences.edit()
-                           .putInt(Settings.KEY_PREF_ALBUMS_SORT_ORDER, Settings.SORT_BY_ARTIST_YEAR)
-                           .apply();
-                refreshList();
-                break;
-            case R.id.action_sort_by_year:
-                item.setChecked(!item.isChecked());
-                preferences.edit()
-                        .putInt(Settings.KEY_PREF_ALBUMS_SORT_ORDER, Settings.SORT_BY_YEAR)
-                        .apply();
-                refreshList();
-                break;
-            default:
-                break;
+        int itemId = item.getItemId();
+        if (itemId == R.id.action_sort_by_album) {
+            item.setChecked(!item.isChecked());
+            preferences.edit()
+                       .putInt(Settings.KEY_PREF_ALBUMS_SORT_ORDER, Settings.SORT_BY_ALBUM)
+                       .apply();
+            refreshList();
+        } else if (itemId == R.id.action_sort_by_artist) {
+            item.setChecked(!item.isChecked());
+            preferences.edit()
+                       .putInt(Settings.KEY_PREF_ALBUMS_SORT_ORDER, Settings.SORT_BY_ARTIST)
+                       .apply();
+            refreshList();
+        } else if (itemId == R.id.action_sort_by_artist_year) {
+            item.setChecked(!item.isChecked());
+            preferences.edit()
+                       .putInt(Settings.KEY_PREF_ALBUMS_SORT_ORDER, Settings.SORT_BY_ARTIST_YEAR)
+                       .apply();
+            refreshList();
+        } else if (itemId == R.id.action_sort_by_year) {
+            item.setChecked(!item.isChecked());
+            preferences.edit()
+                       .putInt(Settings.KEY_PREF_ALBUMS_SORT_ORDER, Settings.SORT_BY_YEAR)
+                       .apply();
+            refreshList();
         }
 
         return super.onOptionsItemSelected(item);
@@ -319,13 +313,13 @@ public class AlbumListFragment extends AbstractCursorListFragment {
                 popupMenu.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
                     @Override
                     public boolean onMenuItemClick(MenuItem item) {
-                        switch (item.getItemId()) {
-                            case R.id.action_play:
-                                MediaPlayerUtils.play(fragment, playListItem);
-                                return true;
-                            case R.id.action_queue:
-                                MediaPlayerUtils.queue(fragment, playListItem, PlaylistType.GetPlaylistsReturnType.AUDIO);
-                                return true;
+                        int itemId = item.getItemId();
+                        if (itemId == R.id.action_play) {
+                            MediaPlayerUtils.play(fragment, playListItem);
+                            return true;
+                        } else if (itemId == R.id.action_queue) {
+                            MediaPlayerUtils.queue(fragment, playListItem, PlaylistType.GetPlaylistsReturnType.AUDIO);
+                            return true;
                         }
                         return false;
                     }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/AlbumSongsListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/AlbumSongsListFragment.java
@@ -213,19 +213,19 @@ public class AlbumSongsListFragment extends AbstractAdditionalInfoFragment
             popupMenu.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
                 @Override
                 public boolean onMenuItemClick(MenuItem item) {
-                    switch (item.getItemId()) {
-                        case R.id.action_play_song:
-                            playSong(songId);
-                            return true;
-                        case R.id.action_add_to_playlist:
-                            addToPlaylist(songId);
-                            return true;
-                        case R.id.download:
-                            ArrayList<FileDownloadHelper.SongInfo> songInfoList = new ArrayList<>();
-                            songInfoList.add(songInfo);
-                            UIUtils.downloadSongs(getActivity(), songInfoList,
-                                                  HostManager.getInstance(getActivity()).getHostInfo(), callbackHandler);
-                            return true;
+                    int itemId = item.getItemId();
+                    if (itemId == R.id.action_play_song) {
+                        playSong(songId);
+                        return true;
+                    } else if (itemId == R.id.action_add_to_playlist) {
+                        addToPlaylist(songId);
+                        return true;
+                    } else if (itemId == R.id.download) {
+                        ArrayList<FileDownloadHelper.SongInfo> songInfoList = new ArrayList<>();
+                        songInfoList.add(songInfo);
+                        UIUtils.downloadSongs(getActivity(), songInfoList,
+                                              HostManager.getInstance(getActivity()).getHostInfo(), callbackHandler);
+                        return true;
                     }
                     return false;
                 }
@@ -396,20 +396,21 @@ public class AlbumSongsListFragment extends AbstractAdditionalInfoFragment
         popupMenu.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
             @Override
             public boolean onMenuItemClick(MenuItem item) {
-                switch (item.getItemId()) {
-                    case R.id.action_play_song:
-                        MediaPlayerUtils.play(AlbumSongsListFragment.this, playListItem);
-                        return true;
-                    case R.id.action_add_to_playlist:
-                        MediaPlayerUtils.queue(AlbumSongsListFragment.this, playListItem, PlaylistType.GetPlaylistsReturnType.AUDIO);
-                        return true;
-                    case R.id.download:
-                        ArrayList<FileDownloadHelper.SongInfo> songInfoList = new ArrayList<>();
-                        songInfoList.add(viewHolder.songInfo);
-                        UIUtils.downloadSongs(getActivity(),
-                                              songInfoList,
-                                              HostManager.getInstance(getActivity()).getHostInfo(),
-                                              callbackHandler);
+                int itemId = item.getItemId();
+                if (itemId == R.id.action_play_song) {
+                    MediaPlayerUtils.play(AlbumSongsListFragment.this, playListItem);
+                    return true;
+                } else if (itemId == R.id.action_add_to_playlist) {
+                    MediaPlayerUtils.queue(AlbumSongsListFragment.this, playListItem, PlaylistType.GetPlaylistsReturnType.AUDIO);
+                    return true;
+                } else if (itemId == R.id.download) {
+                    ArrayList<FileDownloadHelper.SongInfo> songInfoList = new ArrayList<>();
+                    songInfoList.add(viewHolder.songInfo);
+                    UIUtils.downloadSongs(getActivity(),
+                                          songInfoList,
+                                          HostManager.getInstance(getActivity()).getHostInfo(),
+                                          callbackHandler);
+                    return true;
                 }
                 return false;
             }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/ArtistListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/ArtistListFragment.java
@@ -172,13 +172,13 @@ public class ArtistListFragment extends AbstractCursorListFragment {
                 popupMenu.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
                     @Override
                     public boolean onMenuItemClick(MenuItem item) {
-                        switch (item.getItemId()) {
-                            case R.id.action_play:
-                                MediaPlayerUtils.play(fragment, playListItem);
-                                return true;
-                            case R.id.action_queue:
-                                MediaPlayerUtils.queue(fragment, playListItem, PlaylistType.GetPlaylistsReturnType.AUDIO);
-                                return true;
+                        int itemId = item.getItemId();
+                        if (itemId == R.id.action_play) {
+                            MediaPlayerUtils.play(fragment, playListItem);
+                            return true;
+                        } else if (itemId == R.id.action_queue) {
+                            MediaPlayerUtils.queue(fragment, playListItem, PlaylistType.GetPlaylistsReturnType.AUDIO);
+                            return true;
                         }
                         return false;
                     }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/AudioGenresListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/AudioGenresListFragment.java
@@ -208,13 +208,13 @@ public class AudioGenresListFragment extends AbstractCursorListFragment {
             popupMenu.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
                 @Override
                 public boolean onMenuItemClick(MenuItem item) {
-                    switch (item.getItemId()) {
-                        case R.id.action_play:
-                            MediaPlayerUtils.play(AudioGenresListFragment.this, playListItem);
-                            return true;
-                        case R.id.action_queue:
-                            MediaPlayerUtils.queue(AudioGenresListFragment.this, playListItem, PlaylistType.GetPlaylistsReturnType.AUDIO);
-                            return true;
+                    int itemId = item.getItemId();
+                    if (itemId == R.id.action_play) {
+                        MediaPlayerUtils.play(AudioGenresListFragment.this, playListItem);
+                        return true;
+                    } else if (itemId == R.id.action_queue) {
+                        MediaPlayerUtils.queue(AudioGenresListFragment.this, playListItem, PlaylistType.GetPlaylistsReturnType.AUDIO);
+                        return true;
                     }
                     return false;
                 }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/SongsListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/SongsListFragment.java
@@ -432,20 +432,20 @@ public class SongsListFragment extends AbstractCursorListFragment {
         popupMenu.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
             @Override
             public boolean onMenuItemClick(MenuItem item) {
-                switch (item.getItemId()) {
-                    case R.id.action_play_song:
-                        MediaPlayerUtils.play(SongsListFragment.this, playListItem);
-                        return true;
-                    case R.id.action_add_to_playlist:
-                        MediaPlayerUtils.queue(SongsListFragment.this, playListItem, PlaylistType.GetPlaylistsReturnType.AUDIO);
-                        return true;
-                    case R.id.download:
-                        ArrayList<FileDownloadHelper.SongInfo> songInfoList = new ArrayList<>();
-                        songInfoList.add(viewHolder.songInfo);
-                        UIUtils.downloadSongs(getContext(),
-                                              songInfoList,
-                                              HostManager.getInstance(getContext()).getHostInfo(),
-                                              callbackHandler);
+                int itemId = item.getItemId();
+                if (itemId == R.id.action_play_song) {
+                    MediaPlayerUtils.play(SongsListFragment.this, playListItem);
+                    return true;
+                } else if (itemId == R.id.action_add_to_playlist) {
+                    MediaPlayerUtils.queue(SongsListFragment.this, playListItem, PlaylistType.GetPlaylistsReturnType.AUDIO);
+                    return true;
+                } else if (itemId == R.id.download) {
+                    ArrayList<FileDownloadHelper.SongInfo> songInfoList = new ArrayList<>();
+                    songInfoList.add(viewHolder.songInfo);
+                    UIUtils.downloadSongs(getContext(),
+                                          songInfoList,
+                                          HostManager.getInstance(getContext()).getHostInfo(),
+                                          callbackHandler);
                 }
                 return false;
             }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/file/MediaFileListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/file/MediaFileListFragment.java
@@ -568,29 +568,28 @@ public class MediaFileListFragment extends AbstractListFragment {
                         popupMenu.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
                             @Override
                             public boolean onMenuItemClick(MenuItem item) {
-
-                                switch (item.getItemId()) {
-                                    case R.id.action_queue_item:
-                                        queueMediaFile(loc.file);
-                                        return true;
-                                    case R.id.action_play_item:
-                                        playMediaFile(loc.file);
-                                        return true;
-                                    case R.id.action_play_local_item:
-                                        playMediaFileLocally(loc.file);
-                                        return true;
-                                    case R.id.action_play_from_this_item:
-                                        mediaQueueFileLocation.clear();
-                                        FileLocation fl;
-                                        // start playing the selected one, then queue the rest
-                                        for (int i = position + 1; i < fileLocationItems.size(); i++) {
-                                            fl = fileLocationItems.get(i);
-                                            if (!fl.isDirectory) {
-                                                mediaQueueFileLocation.add(fl);
-                                            }
+                                int itemId = item.getItemId();
+                                if (itemId == R.id.action_queue_item) {
+                                    queueMediaFile(loc.file);
+                                    return true;
+                                } else if (itemId == R.id.action_play_item) {
+                                    playMediaFile(loc.file);
+                                    return true;
+                                } else if (itemId == R.id.action_play_local_item) {
+                                    playMediaFileLocally(loc.file);
+                                    return true;
+                                } else if (itemId == R.id.action_play_from_this_item) {
+                                    mediaQueueFileLocation.clear();
+                                    FileLocation fl;
+                                    // start playing the selected one, then queue the rest
+                                    for (int i = position + 1; i < fileLocationItems.size(); i++) {
+                                        fl = fileLocationItems.get(i);
+                                        if (!fl.isDirectory) {
+                                            mediaQueueFileLocation.add(fl);
                                         }
-                                        playMediaFile(loc.file);
-                                        return true;
+                                    }
+                                    playMediaFile(loc.file);
+                                    return true;
                                 }
                                 return false;
                             }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/hosts/HostListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/hosts/HostListFragment.java
@@ -172,12 +172,9 @@ public class HostListFragment extends Fragment {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.action_add_host:
-                startAddHostWizard();
-                break;
-            default:
-                break;
+        int itemId = item.getItemId();
+        if (itemId == R.id.action_add_host) {
+            startAddHostWizard();
         }
 
         return super.onOptionsItemSelected(item);
@@ -222,23 +219,23 @@ public class HostListFragment extends Fragment {
         final PopupMenu popupMenu = new PopupMenu(getActivity(), v);
         popupMenu.getMenuInflater().inflate(R.menu.hostlist_item, popupMenu.getMenu());
         popupMenu.setOnMenuItemClickListener(item -> {
-            switch (item.getItemId()) {
-                case R.id.action_remove_host:
-                    DialogFragment confirmDelete = ConfirmDeleteDialogFragment
-                            .getInstance(getDeleteDialogListener(hostInfo.getId()));
-                    confirmDelete.show(getFragmentManager(), "confirmdelete");
-                    return true;
-                case R.id.action_edit_host:
-                    Intent launchIntent = new Intent(getActivity(), EditHostActivity.class)
-                            .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
-                            .putExtra(HostFragmentManualConfiguration.HOST_ID, hostInfo.getId());
-                    startActivity(launchIntent);
-                    requireActivity().overridePendingTransition(R.anim.activity_in, R.anim.activity_out);
-                    return true;
-                case R.id.action_wake_up:
-                    // Send WoL magic packet on a new thread
-                    UIUtils.sendWolAsync(getActivity(), hostInfo);
-                    return true;
+            int itemId = item.getItemId();
+            if (itemId == R.id.action_remove_host) {
+                DialogFragment confirmDelete = ConfirmDeleteDialogFragment
+                        .getInstance(getDeleteDialogListener(hostInfo.getId()));
+                confirmDelete.show(getFragmentManager(), "confirmdelete");
+                return true;
+            } else if (itemId == R.id.action_edit_host) {
+                Intent launchIntent = new Intent(getActivity(), EditHostActivity.class)
+                        .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                        .putExtra(HostFragmentManualConfiguration.HOST_ID, hostInfo.getId());
+                startActivity(launchIntent);
+                requireActivity().overridePendingTransition(R.anim.activity_in, R.anim.activity_out);
+                return true;
+            } else if (itemId == R.id.action_wake_up) {
+                // Send WoL magic packet on a new thread
+                UIUtils.sendWolAsync(getActivity(), hostInfo);
+                return true;
             }
             return false;
         });

--- a/app/src/main/java/org/xbmc/kore/ui/sections/localfile/LocalMediaFileListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/localfile/LocalMediaFileListFragment.java
@@ -524,27 +524,26 @@ public class LocalMediaFileListFragment extends AbstractListFragment {
                         popupMenu.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
                             @Override
                             public boolean onMenuItemClick(MenuItem item) {
-
-                                switch (item.getItemId()) {
-                                    case R.id.action_queue_item:
-                                        queueMediaFile(loc);
-                                        return true;
-                                    case R.id.action_play_item:
-                                        playMediaFile(loc);
-                                        return true;
-                                    case R.id.action_play_from_this_item:
-                                        mediaQueueFileLocation.clear();
-                                        LocalFileLocation fl;
-                                        // start playing the selected one, then queue the rest
-                                        mediaQueueFileLocation.add(loc);
-                                        for (int i = position + 1; i < fileLocationItems.size(); i++) {
-                                            fl = fileLocationItems.get(i);
-                                            if (!fl.isDirectory) {
-                                                mediaQueueFileLocation.add(fl);
-                                            }
+                                int itemId = item.getItemId();
+                                if (itemId == R.id.action_queue_item) {
+                                    queueMediaFile(loc);
+                                    return true;
+                                } else if (itemId == R.id.action_play_item) {
+                                    playMediaFile(loc);
+                                    return true;
+                                } else if (itemId == R.id.action_play_from_this_item) {
+                                    mediaQueueFileLocation.clear();
+                                    LocalFileLocation fl;
+                                    // start playing the selected one, then queue the rest
+                                    mediaQueueFileLocation.add(loc);
+                                    for (int i = position + 1; i < fileLocationItems.size(); i++) {
+                                        fl = fileLocationItems.get(i);
+                                        if (!fl.isDirectory) {
+                                            mediaQueueFileLocation.add(fl);
                                         }
-                                        playMediaFile(loc);
-                                        return true;
+                                    }
+                                    playMediaFile(loc);
+                                    return true;
                                 }
                                 return false;
                             }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
@@ -340,53 +340,53 @@ public class NowPlayingFragment extends Fragment
         @Override
         public boolean onMenuItemClick(MenuItem item) {
             int selectedItem = -1;
-            switch (item.getItemId()) {
-                case R.id.audiostreams:
-                    // Setup audiostream select dialog
-                    String[] audiostreams = new String[(availableAudioStreams != null) ?
-                                                       availableAudioStreams.size() + ADDED_AUDIO_OPTIONS : ADDED_AUDIO_OPTIONS];
+            int itemId = item.getItemId();
+            if (itemId == R.id.audiostreams) {
+                // Setup audiostream select dialog
+                String[] audiostreams = new String[(availableAudioStreams != null) ?
+                                                   availableAudioStreams.size() + ADDED_AUDIO_OPTIONS : ADDED_AUDIO_OPTIONS];
 
-                    audiostreams[0] = getString(R.string.audio_sync);
+                audiostreams[0] = getString(R.string.audio_sync);
 
-                    if (availableAudioStreams != null) {
-                        for (int i = 0; i < availableAudioStreams.size(); i++) {
-                            PlayerType.AudioStream current = availableAudioStreams.get(i);
-                            audiostreams[i + ADDED_AUDIO_OPTIONS] = TextUtils.isEmpty(current.language) ?
-                                                                    current.name : current.language + " | " + current.name;
-                            if (current.index == currentAudiostreamIndex) {
-                                selectedItem = i + ADDED_AUDIO_OPTIONS;
-                            }
-                        }
-
-                        GenericSelectDialog dialog = GenericSelectDialog.newInstance(NowPlayingFragment.this,
-                                                                                     SELECT_AUDIOSTREAM, getString(R.string.audiostreams), audiostreams, selectedItem);
-                        dialog.show(NowPlayingFragment.this.getFragmentManager(), null);
-                    }
-                    return true;
-                case R.id.subtitles:
-                    // Setup subtitles select dialog
-                    String[] subtitles = new String[(availableSubtitles != null) ?
-                                                    availableSubtitles.size() + ADDED_SUBTITLE_OPTIONS : ADDED_SUBTITLE_OPTIONS];
-
-                    subtitles[0] = getString(R.string.download_subtitle);
-                    subtitles[1] = getString(R.string.subtitle_sync);
-                    subtitles[2] = getString(R.string.none);
-
-                    if (availableSubtitles != null) {
-                        for (int i = 0; i < availableSubtitles.size(); i++) {
-                            PlayerType.Subtitle current = availableSubtitles.get(i);
-                            subtitles[i + ADDED_SUBTITLE_OPTIONS] = TextUtils.isEmpty(current.language) ?
-                                                                    current.name : current.language + " | " + current.name;
-                            if (current.index == currentSubtitleIndex) {
-                                selectedItem = i + ADDED_SUBTITLE_OPTIONS;
-                            }
+                if (availableAudioStreams != null) {
+                    for (int i = 0; i < availableAudioStreams.size(); i++) {
+                        PlayerType.AudioStream current = availableAudioStreams.get(i);
+                        audiostreams[i + ADDED_AUDIO_OPTIONS] = TextUtils.isEmpty(current.language) ?
+                                                                current.name : current.language + " | " + current.name;
+                        if (current.index == currentAudiostreamIndex) {
+                            selectedItem = i + ADDED_AUDIO_OPTIONS;
                         }
                     }
 
                     GenericSelectDialog dialog = GenericSelectDialog.newInstance(NowPlayingFragment.this,
-                                                                                 SELECT_SUBTITLES, getString(R.string.subtitles), subtitles, selectedItem);
+                                                                                 SELECT_AUDIOSTREAM, getString(R.string.audiostreams), audiostreams, selectedItem);
                     dialog.show(NowPlayingFragment.this.getFragmentManager(), null);
-                    return true;
+                }
+                return true;
+            } else if (itemId == R.id.subtitles) {
+                // Setup subtitles select dialog
+                String[] subtitles = new String[(availableSubtitles != null) ?
+                                                availableSubtitles.size() + ADDED_SUBTITLE_OPTIONS : ADDED_SUBTITLE_OPTIONS];
+
+                subtitles[0] = getString(R.string.download_subtitle);
+                subtitles[1] = getString(R.string.subtitle_sync);
+                subtitles[2] = getString(R.string.none);
+
+                if (availableSubtitles != null) {
+                    for (int i = 0; i < availableSubtitles.size(); i++) {
+                        PlayerType.Subtitle current = availableSubtitles.get(i);
+                        subtitles[i + ADDED_SUBTITLE_OPTIONS] = TextUtils.isEmpty(current.language) ?
+                                                                current.name : current.language + " | " + current.name;
+                        if (current.index == currentSubtitleIndex) {
+                            selectedItem = i + ADDED_SUBTITLE_OPTIONS;
+                        }
+                    }
+                }
+
+                GenericSelectDialog dialog = GenericSelectDialog.newInstance(NowPlayingFragment.this,
+                                                                             SELECT_SUBTITLES, getString(R.string.subtitles), subtitles, selectedItem);
+                dialog.show(NowPlayingFragment.this.getFragmentManager(), null);
+                return true;
             }
             return false;
         }
@@ -857,17 +857,14 @@ public class NowPlayingFragment extends Fragment
      * @param panelResId The panel to show
      */
     private void switchToPanel(int panelResId) {
-        switch (panelResId) {
-            case R.id.info_panel:
-                binding.mediaPanel.setVisibility(View.GONE);
-                binding.art.setVisibility(View.GONE);
-                binding.includeInfoPanel.infoPanel.setVisibility(View.VISIBLE);
-                break;
-            case R.id.media_panel:
-                binding.includeInfoPanel.infoPanel.setVisibility(View.GONE);
-                binding.mediaPanel.setVisibility(View.VISIBLE);
-                binding.art.setVisibility(View.VISIBLE);
-                break;
+        if (panelResId == R.id.info_panel) {
+            binding.mediaPanel.setVisibility(View.GONE);
+            binding.art.setVisibility(View.GONE);
+            binding.includeInfoPanel.infoPanel.setVisibility(View.VISIBLE);
+        } else if (panelResId == R.id.media_panel) {
+            binding.includeInfoPanel.infoPanel.setVisibility(View.GONE);
+            binding.mediaPanel.setVisibility(View.VISIBLE);
+            binding.art.setVisibility(View.VISIBLE);
         }
     }
 

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/PlaylistFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/PlaylistFragment.java
@@ -191,16 +191,13 @@ public class PlaylistFragment extends Fragment
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.action_clear_playlist:
-                PlaylistHolder playlistHolder = playlists.get(binding.playlistsBar.getSelectedPlaylistType());
-                int playlistId = playlistHolder.getPlaylistId();
-                playlistOnClear(playlistId);
-                Playlist.Clear action = new Playlist.Clear(playlistId);
-                action.execute(hostManager.getConnection(), defaultStringActionCallback, callbackHandler);
-                break;
-            default:
-                break;
+        int itemId = item.getItemId();
+        if (itemId == R.id.action_clear_playlist) {
+            PlaylistHolder playlistHolder = playlists.get(binding.playlistsBar.getSelectedPlaylistType());
+            int playlistId = playlistHolder.getPlaylistId();
+            playlistOnClear(playlistId);
+            Playlist.Clear action = new Playlist.Clear(playlistId);
+            action.execute(hostManager.getConnection(), defaultStringActionCallback, callbackHandler);
         }
 
         return super.onOptionsItemSelected(item);
@@ -455,15 +452,12 @@ public class PlaylistFragment extends Fragment
      * @param panelResId The panel to show
      */
     private void switchToPanel(int panelResId) {
-        switch (panelResId) {
-            case R.id.info_panel:
-                binding.includeInfoPanel.infoPanel.setVisibility(View.VISIBLE);
-                binding.playlist.setVisibility(View.GONE);
-                break;
-            case R.id.playlist:
-                binding.includeInfoPanel.infoPanel.setVisibility(View.GONE);
-                binding.playlist.setVisibility(View.VISIBLE);
-                break;
+        if (panelResId == R.id.info_panel) {
+            binding.includeInfoPanel.infoPanel.setVisibility(View.VISIBLE);
+            binding.playlist.setVisibility(View.GONE);
+        } else if (panelResId == R.id.playlist) {
+            binding.includeInfoPanel.infoPanel.setVisibility(View.GONE);
+            binding.playlist.setVisibility(View.VISIBLE);
         }
     }
 
@@ -490,13 +484,13 @@ public class PlaylistFragment extends Fragment
                 final PopupMenu popupMenu = new PopupMenu(getActivity(), v);
                 popupMenu.getMenuInflater().inflate(R.menu.playlist_item, popupMenu.getMenu());
                 popupMenu.setOnMenuItemClickListener(item -> {
-                    switch (item.getItemId()) {
-                        case R.id.action_remove_playlist_item:
-                            // Remove this item from the playlist
-                            int playlistId = playlists.get(binding.playlistsBar.getSelectedPlaylistType()).getPlaylistId();
-                            Playlist.Remove action = new Playlist.Remove(playlistId, position);
-                            action.execute(hostManager.getConnection(), defaultStringActionCallback, callbackHandler);
-                            return true;
+                    int itemId = item.getItemId();
+                    if (itemId == R.id.action_remove_playlist_item) {
+                        // Remove this item from the playlist
+                        int playlistId = playlists.get(binding.playlistsBar.getSelectedPlaylistType()).getPlaylistId();
+                        Playlist.Remove action = new Playlist.Remove(playlistId, position);
+                        action.execute(hostManager.getConnection(), defaultStringActionCallback, callbackHandler);
+                        return true;
                     }
                     return false;
                 });

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
@@ -232,58 +232,56 @@ public class RemoteActivity extends BaseActivity
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         // Handle action bar item clicks here.
-        switch (item.getItemId()) {
-            case R.id.action_wake_up:
-                UIUtils.sendWolAsync(this, hostManager.getHostInfo());
-                return true;
-            case R.id.action_quit:
-                Application.Quit actionQuit = new Application.Quit();
-                // Fire and forget
-                actionQuit.execute(hostManager.getConnection(), null, null);
-                return true;
-            case R.id.action_suspend:
-                System.Suspend actionSuspend = new System.Suspend();
-                // Fire and forget
-                actionSuspend.execute(hostManager.getConnection(), null, null);
-                return true;
-            case R.id.action_reboot:
-                System.Reboot actionReboot = new System.Reboot();
-                // Fire and forget
-                actionReboot.execute(hostManager.getConnection(), null, null);
-                return true;
-            case R.id.action_shutdown:
-                System.Shutdown actionShutdown = new System.Shutdown();
-                // Fire and forget
-                actionShutdown.execute(hostManager.getConnection(), null, null);
-                return true;
-            case R.id.send_text:
-                SendTextDialogFragment dialog =
-                        SendTextDialogFragment.newInstance(getString(R.string.send_text));
-                dialog.show(getSupportFragmentManager(), null);
-                return true;
-            case R.id.toggle_fullscreen:
-                GUI.SetFullscreen actionSetFullscreen = new GUI.SetFullscreen();
+        int itemId = item.getItemId();
+        if (itemId == R.id.action_wake_up) {
+            UIUtils.sendWolAsync(this, hostManager.getHostInfo());
+            return true;
+        } else if (itemId == R.id.action_quit) {
+            Application.Quit actionQuit = new Application.Quit();
+            // Fire and forget
+            actionQuit.execute(hostManager.getConnection(), null, null);
+            return true;
+        } else if (itemId == R.id.action_suspend) {
+            System.Suspend actionSuspend = new System.Suspend();
+            // Fire and forget
+            actionSuspend.execute(hostManager.getConnection(), null, null);
+            return true;
+        } else if (itemId == R.id.action_reboot) {
+            System.Reboot actionReboot = new System.Reboot();
+            // Fire and forget
+            actionReboot.execute(hostManager.getConnection(), null, null);
+            return true;
+        } else if (itemId == R.id.action_shutdown) {
+            System.Shutdown actionShutdown = new System.Shutdown();
+            // Fire and forget
+            actionShutdown.execute(hostManager.getConnection(), null, null);
+            return true;
+        } else if (itemId == R.id.send_text) {
+            SendTextDialogFragment dialog =
+                    SendTextDialogFragment.newInstance(getString(R.string.send_text));
+            dialog.show(getSupportFragmentManager(), null);
+            return true;
+        } else if (itemId == R.id.toggle_fullscreen) {
+            GUI.SetFullscreen actionSetFullscreen = new GUI.SetFullscreen();
 //                Input.ExecuteAction actionSetFullscreen = new Input.ExecuteAction(Input.ExecuteAction.TOGGLEFULLSCREEN);
-                actionSetFullscreen.execute(hostManager.getConnection(), null, null);
-                return true;
-            case R.id.clean_video_library:
-                VideoLibrary.Clean actionCleanVideo = new VideoLibrary.Clean();
-                actionCleanVideo.execute(hostManager.getConnection(), null, null);
-                return true;
-            case R.id.clean_audio_library:
-                AudioLibrary.Clean actionCleanAudio = new AudioLibrary.Clean();
-                actionCleanAudio.execute(hostManager.getConnection(), null, null);
-                return true;
-            case R.id.update_video_library:
-                VideoLibrary.Scan actionScanVideo = new VideoLibrary.Scan();
-                actionScanVideo.execute(hostManager.getConnection(), null, null);
-                return true;
-            case R.id.update_audio_library:
-                AudioLibrary.Scan actionScanAudio = new AudioLibrary.Scan();
-                actionScanAudio.execute(hostManager.getConnection(), null, null);
-                return true;
-            default:
-                break;
+            actionSetFullscreen.execute(hostManager.getConnection(), null, null);
+            return true;
+        } else if (itemId == R.id.clean_video_library) {
+            VideoLibrary.Clean actionCleanVideo = new VideoLibrary.Clean();
+            actionCleanVideo.execute(hostManager.getConnection(), null, null);
+            return true;
+        } else if (itemId == R.id.clean_audio_library) {
+            AudioLibrary.Clean actionCleanAudio = new AudioLibrary.Clean();
+            actionCleanAudio.execute(hostManager.getConnection(), null, null);
+            return true;
+        } else if (itemId == R.id.update_video_library) {
+            VideoLibrary.Scan actionScanVideo = new VideoLibrary.Scan();
+            actionScanVideo.execute(hostManager.getConnection(), null, null);
+            return true;
+        } else if (itemId == R.id.update_audio_library) {
+            AudioLibrary.Scan actionScanAudio = new AudioLibrary.Scan();
+            actionScanAudio.execute(hostManager.getConnection(), null, null);
+            return true;
         }
 
         return super.onOptionsItemSelected(item);

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteFragment.java
@@ -461,15 +461,12 @@ public class RemoteFragment extends Fragment
      * @param panelResId The panel to show
      */
     private void switchToPanel(int panelResId, boolean showRemote) {
-        switch (panelResId) {
-            case R.id.info_panel:
-                binding.mediaPanel.setVisibility(View.GONE);
-                binding.includeInfoPanel.infoPanel.setVisibility(View.VISIBLE);
-                break;
-            case R.id.media_panel:
-                binding.includeInfoPanel.infoPanel.setVisibility(View.GONE);
-                binding.mediaPanel.setVisibility(View.VISIBLE);
-                break;
+        if (panelResId == R.id.info_panel) {
+            binding.mediaPanel.setVisibility(View.GONE);
+            binding.includeInfoPanel.infoPanel.setVisibility(View.VISIBLE);
+        } else if (panelResId == R.id.media_panel) {
+            binding.includeInfoPanel.infoPanel.setVisibility(View.GONE);
+            binding.mediaPanel.setVisibility(View.VISIBLE);
         }
 
         if (showRemote) {

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/MovieListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/MovieListFragment.java
@@ -208,81 +208,69 @@ public class MovieListFragment extends AbstractCursorListFragment {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
-        switch (item.getItemId()) {
-            case R.id.action_hide_watched:
-                item.setChecked(!item.isChecked());
-                preferences.edit()
-                           .putBoolean(Settings.KEY_PREF_MOVIES_FILTER_HIDE_WATCHED, item.isChecked())
-                           .apply();
-                refreshList();
-                break;
-            case R.id.action_show_watched_status:
-                item.setChecked(!item.isChecked());
-                preferences.edit()
-                           .putBoolean(Settings.KEY_PREF_MOVIES_SHOW_WATCHED_STATUS, item.isChecked())
-                           .apply();
-                showWatchedStatus = item.isChecked();
-                refreshList();
-                break;
-            case R.id.action_show_rating:
-                item.setChecked(!item.isChecked());
-                preferences.edit()
-                        .putBoolean(Settings.KEY_PREF_MOVIES_SHOW_RATING, item.isChecked())
-                        .apply();
-                showRating = item.isChecked();
-                refreshList();
-                break;
-            case R.id.action_ignore_prefixes:
-                item.setChecked(!item.isChecked());
-                preferences.edit()
-                           .putBoolean(Settings.KEY_PREF_MOVIES_IGNORE_PREFIXES, item.isChecked())
-                           .apply();
-                refreshList();
-                break;
-            case R.id.action_sort_by_name:
-                item.setChecked(true);
-                preferences.edit()
-                           .putInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.SORT_BY_NAME)
-                           .apply();
-                refreshList();
-                break;
-            case R.id.action_sort_by_year:
-                item.setChecked(true);
-                preferences.edit()
-                           .putInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.SORT_BY_YEAR)
-                           .apply();
-                refreshList();
-                break;
-            case R.id.action_sort_by_rating:
-                item.setChecked(true);
-                preferences.edit()
-                           .putInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.SORT_BY_RATING)
-                           .apply();
-                refreshList();
-                break;
-            case R.id.action_sort_by_date_added:
-                item.setChecked(true);
-                preferences.edit()
-                           .putInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.SORT_BY_DATE_ADDED)
-                           .apply();
-                refreshList();
-                break;
-            case R.id.action_sort_by_last_played:
-                item.setChecked(true);
-                preferences.edit()
-                        .putInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.SORT_BY_LAST_PLAYED)
-                        .apply();
-                refreshList();
-                break;
-            case R.id.action_sort_by_length:
-                item.setChecked(true);
-                preferences.edit()
-                           .putInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.SORT_BY_LENGTH)
-                           .apply();
-                refreshList();
-                break;
-            default:
-                break;
+        int itemId = item.getItemId();
+        if (itemId == R.id.action_hide_watched) {
+            item.setChecked(!item.isChecked());
+            preferences.edit()
+                       .putBoolean(Settings.KEY_PREF_MOVIES_FILTER_HIDE_WATCHED, item.isChecked())
+                       .apply();
+            refreshList();
+        } else if (itemId == R.id.action_show_watched_status) {
+            item.setChecked(!item.isChecked());
+            preferences.edit()
+                       .putBoolean(Settings.KEY_PREF_MOVIES_SHOW_WATCHED_STATUS, item.isChecked())
+                       .apply();
+            showWatchedStatus = item.isChecked();
+            refreshList();
+        } else if (itemId == R.id.action_show_rating) {
+            item.setChecked(!item.isChecked());
+            preferences.edit()
+                       .putBoolean(Settings.KEY_PREF_MOVIES_SHOW_RATING, item.isChecked())
+                       .apply();
+            showRating = item.isChecked();
+            refreshList();
+        } else if (itemId == R.id.action_ignore_prefixes) {
+            item.setChecked(!item.isChecked());
+            preferences.edit()
+                       .putBoolean(Settings.KEY_PREF_MOVIES_IGNORE_PREFIXES, item.isChecked())
+                       .apply();
+            refreshList();
+        } else if (itemId == R.id.action_sort_by_name) {
+            item.setChecked(true);
+            preferences.edit()
+                       .putInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.SORT_BY_NAME)
+                       .apply();
+            refreshList();
+        } else if (itemId == R.id.action_sort_by_year) {
+            item.setChecked(true);
+            preferences.edit()
+                       .putInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.SORT_BY_YEAR)
+                       .apply();
+            refreshList();
+        } else if (itemId == R.id.action_sort_by_rating) {
+            item.setChecked(true);
+            preferences.edit()
+                       .putInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.SORT_BY_RATING)
+                       .apply();
+            refreshList();
+        } else if (itemId == R.id.action_sort_by_date_added) {
+            item.setChecked(true);
+            preferences.edit()
+                       .putInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.SORT_BY_DATE_ADDED)
+                       .apply();
+            refreshList();
+        } else if (itemId == R.id.action_sort_by_last_played) {
+            item.setChecked(true);
+            preferences.edit()
+                       .putInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.SORT_BY_LAST_PLAYED)
+                       .apply();
+            refreshList();
+        } else if (itemId == R.id.action_sort_by_length) {
+            item.setChecked(true);
+            preferences.edit()
+                       .putInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.SORT_BY_LENGTH)
+                       .apply();
+            refreshList();
         }
 
         return super.onOptionsItemSelected(item);

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRChannelsListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRChannelsListFragment.java
@@ -506,31 +506,31 @@ public class PVRChannelsListFragment extends AbstractSearchableFragment
                 popupMenu.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
                     @Override
                     public boolean onMenuItemClick(MenuItem item) {
-                        switch (item.getItemId()) {
-                            case R.id.action_record_item:
-                                PVR.Record action = new PVR.Record(channelId);
-                                action.execute(hostManager.getConnection(), new ApiCallback<String>() {
-                                    @Override
-                                    public void onSuccess(String result) {
-                                        if (!isAdded()) return;
-                                        LogUtils.LOGD(TAG, "Started recording");
-                                    }
+                        int itemId = item.getItemId();
+                        if (itemId == R.id.action_record_item) {
+                            PVR.Record action = new PVR.Record(channelId);
+                            action.execute(hostManager.getConnection(), new ApiCallback<String>() {
+                                @Override
+                                public void onSuccess(String result) {
+                                    if (!isAdded()) return;
+                                    LogUtils.LOGD(TAG, "Started recording");
+                                }
 
-                                    @Override
-                                    public void onError(int errorCode, String description) {
-                                        if (!isAdded()) return;
-                                        LogUtils.LOGD(TAG, "Error starting to record: " + description);
+                                @Override
+                                public void onError(int errorCode, String description) {
+                                    if (!isAdded()) return;
+                                    LogUtils.LOGD(TAG, "Error starting to record: " + description);
 
-                                        Toast.makeText(getActivity(),
-                                                       String.format(getString(R.string.error_starting_to_record), description),
-                                                       Toast.LENGTH_SHORT).show();
+                                    Toast.makeText(getActivity(),
+                                                   String.format(getString(R.string.error_starting_to_record), description),
+                                                   Toast.LENGTH_SHORT).show();
 
-                                    }
-                                }, callbackHandler);
-                                return true;
-                            case R.id.action_epg_item:
-                                listenerActivity.onChannelGuideSelected(channelId, channelName, singleChannelGroup);
-                                return true;
+                                }
+                            }, callbackHandler);
+                            return true;
+                        } else if (itemId == R.id.action_epg_item) {
+                            listenerActivity.onChannelGuideSelected(channelId, channelName, singleChannelGroup);
+                            return true;
                         }
                         return false;
                     }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRRecordingsListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRRecordingsListFragment.java
@@ -181,37 +181,31 @@ public class PVRRecordingsListFragment extends AbstractSearchableFragment
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
-        switch (item.getItemId()) {
-            case R.id.action_hide_watched:
-                item.setChecked(!item.isChecked());
-                preferences.edit()
-                        .putBoolean(Settings.KEY_PREF_PVR_RECORDINGS_FILTER_HIDE_WATCHED, item.isChecked())
-                        .apply();
-                refreshList();
-                break;
-            case R.id.action_sort_by_name_and_date_added:
-                item.setChecked(true);
-                preferences.edit()
-                        .putInt(Settings.KEY_PREF_PVR_RECORDINGS_SORT_ORDER, Settings.SORT_BY_NAME)
-                        .apply();
-                refreshList();
-                break;
-            case R.id.action_sort_by_date_added:
-                item.setChecked(true);
-                preferences.edit()
-                        .putInt(Settings.KEY_PREF_PVR_RECORDINGS_SORT_ORDER, Settings.SORT_BY_DATE_ADDED)
-                        .apply();
-                refreshList();
-                break;
-            case R.id.action_unsorted:
-                item.setChecked(true);
-                preferences.edit()
-                        .putInt(Settings.KEY_PREF_PVR_RECORDINGS_SORT_ORDER, Settings.UNSORTED)
-                        .apply();
-                refreshList();
-                break;
-            default:
-                break;
+        int itemId = item.getItemId();
+        if (itemId == R.id.action_hide_watched) {
+            item.setChecked(!item.isChecked());
+            preferences.edit()
+                       .putBoolean(Settings.KEY_PREF_PVR_RECORDINGS_FILTER_HIDE_WATCHED, item.isChecked())
+                       .apply();
+            refreshList();
+        } else if (itemId == R.id.action_sort_by_name_and_date_added) {
+            item.setChecked(true);
+            preferences.edit()
+                       .putInt(Settings.KEY_PREF_PVR_RECORDINGS_SORT_ORDER, Settings.SORT_BY_NAME)
+                       .apply();
+            refreshList();
+        } else if (itemId == R.id.action_sort_by_date_added) {
+            item.setChecked(true);
+            preferences.edit()
+                       .putInt(Settings.KEY_PREF_PVR_RECORDINGS_SORT_ORDER, Settings.SORT_BY_DATE_ADDED)
+                       .apply();
+            refreshList();
+        } else if (itemId == R.id.action_unsorted) {
+            item.setChecked(true);
+            preferences.edit()
+                       .putInt(Settings.KEY_PREF_PVR_RECORDINGS_SORT_ORDER, Settings.UNSORTED)
+                       .apply();
+            refreshList();
         }
 
         return super.onOptionsItemSelected(item);

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowEpisodeListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowEpisodeListFragment.java
@@ -176,17 +176,14 @@ public class TVShowEpisodeListFragment extends AbstractCursorListFragment {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.action_hide_watched:
-                item.setChecked(!item.isChecked());
-                SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
-                preferences.edit()
-                           .putBoolean(Settings.KEY_PREF_TVSHOW_EPISODES_FILTER_HIDE_WATCHED, item.isChecked())
-                           .apply();
-                refreshList();
-                break;
-            default:
-                break;
+        int itemId = item.getItemId();
+        if (itemId == R.id.action_hide_watched) {
+            item.setChecked(!item.isChecked());
+            SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
+            preferences.edit()
+                       .putBoolean(Settings.KEY_PREF_TVSHOW_EPISODES_FILTER_HIDE_WATCHED, item.isChecked())
+                       .apply();
+            refreshList();
         }
 
         return super.onOptionsItemSelected(item);
@@ -341,13 +338,13 @@ public class TVShowEpisodeListFragment extends AbstractCursorListFragment {
             popupMenu.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
                 @Override
                 public boolean onMenuItemClick(MenuItem item) {
-                    switch (item.getItemId()) {
-                        case R.id.action_play:
-                            MediaPlayerUtils.play(TVShowEpisodeListFragment.this, playListItem);
-                            return true;
-                        case R.id.action_queue:
-                            MediaPlayerUtils.queue(TVShowEpisodeListFragment.this, playListItem, PlaylistType.GetPlaylistsReturnType.VIDEO);
-                            return true;
+                    int itemId = item.getItemId();
+                    if (itemId == R.id.action_play) {
+                        MediaPlayerUtils.play(TVShowEpisodeListFragment.this, playListItem);
+                        return true;
+                    } else if (itemId == R.id.action_queue) {
+                        MediaPlayerUtils.queue(TVShowEpisodeListFragment.this, playListItem, PlaylistType.GetPlaylistsReturnType.VIDEO);
+                        return true;
                     }
                     return false;
                 }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowListFragment.java
@@ -200,66 +200,56 @@ public class TVShowListFragment extends AbstractCursorListFragment {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
-        switch (item.getItemId()) {
-            case R.id.action_hide_watched:
-                item.setChecked(!item.isChecked());
-                preferences.edit()
-                           .putBoolean(Settings.KEY_PREF_TVSHOWS_FILTER_HIDE_WATCHED, item.isChecked())
-                           .apply();
-                refreshList();
-                break;
-            case R.id.action_show_watched_status:
-                item.setChecked(!item.isChecked());
-                preferences.edit()
-                           .putBoolean(Settings.KEY_PREF_TVSHOWS_SHOW_WATCHED_STATUS, item.isChecked())
-                           .apply();
-                showWatchedStatus = item.isChecked();
-                refreshList();
-                break;
-            case R.id.action_ignore_prefixes:
-                item.setChecked(!item.isChecked());
-                preferences.edit()
-                           .putBoolean(Settings.KEY_PREF_TVSHOWS_IGNORE_PREFIXES, item.isChecked())
-                           .apply();
-                refreshList();
-                break;
-            case R.id.action_sort_by_name:
-                item.setChecked(true);
-                preferences.edit()
-                           .putInt(Settings.KEY_PREF_TVSHOWS_SORT_ORDER, Settings.SORT_BY_NAME)
-                           .apply();
-                refreshList();
-                break;
-            case R.id.action_sort_by_year:
-                item.setChecked(true);
-                preferences.edit()
-                           .putInt(Settings.KEY_PREF_TVSHOWS_SORT_ORDER, Settings.SORT_BY_YEAR)
-                           .apply();
-                refreshList();
-                break;
-            case R.id.action_sort_by_rating:
-                item.setChecked(true);
-                preferences.edit()
-                           .putInt(Settings.KEY_PREF_TVSHOWS_SORT_ORDER, Settings.SORT_BY_RATING)
-                           .apply();
-                refreshList();
-                break;
-            case R.id.action_sort_by_date_added:
-                item.setChecked(true);
-                preferences.edit()
-                           .putInt(Settings.KEY_PREF_TVSHOWS_SORT_ORDER, Settings.SORT_BY_DATE_ADDED)
-                           .apply();
-                refreshList();
-                break;
-            case R.id.action_sort_by_last_played:
-                item.setChecked(true);
-                preferences.edit()
-                        .putInt(Settings.KEY_PREF_TVSHOWS_SORT_ORDER, Settings.SORT_BY_LAST_PLAYED)
-                        .apply();
-                refreshList();
-                break;
-            default:
-                break;
+        int itemId = item.getItemId();
+        if (itemId == R.id.action_hide_watched) {
+            item.setChecked(!item.isChecked());
+            preferences.edit()
+                       .putBoolean(Settings.KEY_PREF_TVSHOWS_FILTER_HIDE_WATCHED, item.isChecked())
+                       .apply();
+            refreshList();
+        } else if (itemId == R.id.action_show_watched_status) {
+            item.setChecked(!item.isChecked());
+            preferences.edit()
+                       .putBoolean(Settings.KEY_PREF_TVSHOWS_SHOW_WATCHED_STATUS, item.isChecked())
+                       .apply();
+            showWatchedStatus = item.isChecked();
+            refreshList();
+        } else if (itemId == R.id.action_ignore_prefixes) {
+            item.setChecked(!item.isChecked());
+            preferences.edit()
+                       .putBoolean(Settings.KEY_PREF_TVSHOWS_IGNORE_PREFIXES, item.isChecked())
+                       .apply();
+            refreshList();
+        } else if (itemId == R.id.action_sort_by_name) {
+            item.setChecked(true);
+            preferences.edit()
+                       .putInt(Settings.KEY_PREF_TVSHOWS_SORT_ORDER, Settings.SORT_BY_NAME)
+                       .apply();
+            refreshList();
+        } else if (itemId == R.id.action_sort_by_year) {
+            item.setChecked(true);
+            preferences.edit()
+                       .putInt(Settings.KEY_PREF_TVSHOWS_SORT_ORDER, Settings.SORT_BY_YEAR)
+                       .apply();
+            refreshList();
+        } else if (itemId == R.id.action_sort_by_rating) {
+            item.setChecked(true);
+            preferences.edit()
+                       .putInt(Settings.KEY_PREF_TVSHOWS_SORT_ORDER, Settings.SORT_BY_RATING)
+                       .apply();
+            refreshList();
+        } else if (itemId == R.id.action_sort_by_date_added) {
+            item.setChecked(true);
+            preferences.edit()
+                       .putInt(Settings.KEY_PREF_TVSHOWS_SORT_ORDER, Settings.SORT_BY_DATE_ADDED)
+                       .apply();
+            refreshList();
+        } else if (itemId == R.id.action_sort_by_last_played) {
+            item.setChecked(true);
+            preferences.edit()
+                       .putInt(Settings.KEY_PREF_TVSHOWS_SORT_ORDER, Settings.SORT_BY_LAST_PLAYED)
+                       .apply();
+            refreshList();
         }
 
         return super.onOptionsItemSelected(item);

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowProgressFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowProgressFragment.java
@@ -348,13 +348,13 @@ public class TVShowProgressFragment extends AbstractAdditionalInfoFragment imple
             popupMenu.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
                 @Override
                 public boolean onMenuItemClick(MenuItem item) {
-                    switch (item.getItemId()) {
-                        case R.id.action_play:
-                            MediaPlayerUtils.play(TVShowProgressFragment.this, playListItem);
-                            return true;
-                        case R.id.action_queue:
-                            MediaPlayerUtils.queue(TVShowProgressFragment.this, playListItem, PlaylistType.GetPlaylistsReturnType.VIDEO);
-                            return true;
+                    int itemId = item.getItemId();
+                    if (itemId == R.id.action_play) {
+                        MediaPlayerUtils.play(TVShowProgressFragment.this, playListItem);
+                        return true;
+                    } else if (itemId == R.id.action_queue) {
+                        MediaPlayerUtils.queue(TVShowProgressFragment.this, playListItem, PlaylistType.GetPlaylistsReturnType.VIDEO);
+                        return true;
                     }
                     return false;
                 }

--- a/app/src/main/java/org/xbmc/kore/ui/widgets/ControlPad.java
+++ b/app/src/main/java/org/xbmc/kore/ui/widgets/ControlPad.java
@@ -112,37 +112,27 @@ public class ControlPad extends SquareGridLayout
     public void onClick(View v) {
         if (onPadButtonsListener == null)
             return;
-
-        switch (v.getId()) {
-            case R.id.select:
-                onPadButtonsListener.selectButtonClicked();
-                break;
-            case R.id.left:
-                onPadButtonsListener.leftButtonClicked();
-                break;
-            case R.id.right:
-                onPadButtonsListener.rightButtonClicked();
-                break;
-            case R.id.up:
-                onPadButtonsListener.upButtonClicked();
-                break;
-            case R.id.down:
-                onPadButtonsListener.downButtonClicked();
-                break;
-            case R.id.back:
-                onPadButtonsListener.backButtonClicked();
-                break;
-            case R.id.info:
-                onPadButtonsListener.infoButtonClicked();
-                break;
-            case R.id.context:
-                onPadButtonsListener.contextButtonClicked();
-                break;
-            case R.id.osd:
-                onPadButtonsListener.osdButtonClicked();
-                break;
-            default:
-                LogUtils.LOGD(TAG, "Unknown button "+v.getId()+" clicked");
+        int viewId = v.getId();
+        if (viewId == R.id.select) {
+            onPadButtonsListener.selectButtonClicked();
+        } else if (viewId == R.id.left) {
+            onPadButtonsListener.leftButtonClicked();
+        } else if (viewId == R.id.right) {
+            onPadButtonsListener.rightButtonClicked();
+        } else if (viewId == R.id.up) {
+            onPadButtonsListener.upButtonClicked();
+        } else if (viewId == R.id.down) {
+            onPadButtonsListener.downButtonClicked();
+        } else if (viewId == R.id.back) {
+            onPadButtonsListener.backButtonClicked();
+        } else if (viewId == R.id.info) {
+            onPadButtonsListener.infoButtonClicked();
+        } else if (viewId == R.id.context) {
+            onPadButtonsListener.contextButtonClicked();
+        } else if (viewId == R.id.osd) {
+            onPadButtonsListener.osdButtonClicked();
+        } else {
+            LogUtils.LOGD(TAG, "Unknown button " + viewId + " clicked");
         }
     }
 

--- a/app/src/main/java/org/xbmc/kore/ui/widgets/NowPlayingPanel.java
+++ b/app/src/main/java/org/xbmc/kore/ui/widgets/NowPlayingPanel.java
@@ -179,28 +179,21 @@ public class NowPlayingPanel extends SlidingUpPanelLayout {
             if (onPanelButtonsClickListener == null)
                 return;
 
-            switch (view.getId()) {
-                case R.id.npp_previous:
-                    onPanelButtonsClickListener.onPreviousClicked();
-                    break;
-                case R.id.npp_next:
-                    onPanelButtonsClickListener.onNextClicked();
-                    break;
-                case R.id.npp_play:
-                    onPanelButtonsClickListener.onPlayClicked();
-                    break;
-                case R.id.npp_volume_mute:
-                    onPanelButtonsClickListener.onVolumeMuteClicked();
-                    break;
-                case R.id.npp_repeat:
-                    onPanelButtonsClickListener.onRepeatClicked();
-                    break;
-                case R.id.npp_shuffle:
-                    onPanelButtonsClickListener.onShuffleClicked();
-                    break;
-                case R.id.npp_volume_muted_indicator:
-                    onPanelButtonsClickListener.onVolumeMutedIndicatorClicked();
-                    break;
+            int viewId = view.getId();
+            if (viewId == R.id.npp_previous) {
+                onPanelButtonsClickListener.onPreviousClicked();
+            } else if (viewId == R.id.npp_next) {
+                onPanelButtonsClickListener.onNextClicked();
+            } else if (viewId == R.id.npp_play) {
+                onPanelButtonsClickListener.onPlayClicked();
+            } else if (viewId == R.id.npp_volume_mute) {
+                onPanelButtonsClickListener.onVolumeMuteClicked();
+            } else if (viewId == R.id.npp_repeat) {
+                onPanelButtonsClickListener.onRepeatClicked();
+            } else if (viewId == R.id.npp_shuffle) {
+                onPanelButtonsClickListener.onShuffleClicked();
+            } else if (viewId == R.id.npp_volume_muted_indicator) {
+                onPanelButtonsClickListener.onVolumeMutedIndicatorClicked();
             }
         }
     };


### PR DESCRIPTION
In a future Gradle release, `ResourceIDs` will be non-final, so they can't be used on `switch` statements.