### PR TITLE
Refactor MediaProgressIndicator to have a default progress change listener

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
@@ -69,7 +69,6 @@ public class NowPlayingFragment extends Fragment
         implements HostConnectionObserver.PlayerEventsObserver,
                    HostConnectionObserver.ApplicationEventsObserver,
                    GenericSelectDialog.GenericSelectDialogListener,
-                   MediaProgressIndicator.OnProgressChangeListener,
                    ViewTreeObserver.OnScrollChangedListener {
     private static final String TAG = LogUtils.makeLogTag(NowPlayingFragment.class);
 
@@ -152,7 +151,7 @@ public class NowPlayingFragment extends Fragment
         binding.volumeLevelIndicator.setOnVolumeChangeListener(volume -> new Application.SetVolume(volume)
                 .execute(hostManager.getConnection(), defaultIntActionCallback, callbackHandler));
 
-        binding.progressInfo.setOnProgressChangeListener(this);
+        binding.progressInfo.setOnProgressChangeListener(MediaProgressIndicator.ProgressChangeListener.buildDefault(requireContext(), callbackHandler));
 
         binding.volumeLevelIndicator.setOnVolumeChangeListener(volume -> new Application.SetVolume(volume)
                 .execute(hostManager.getConnection(), defaultIntActionCallback, callbackHandler));
@@ -570,25 +569,6 @@ public class NowPlayingFragment extends Fragment
     public void inputOnInputRequested(String title, String type, String value) {}
     public void observerOnStopObserving() {}
 
-    @Override
-    public void onProgressChanged(int progress) {
-        PlayerType.PositionTime positionTime = new PlayerType.PositionTime(progress);
-        Player.Seek seekAction = new Player.Seek(currentActivePlayerId, positionTime);
-        seekAction.execute(HostManager.getInstance(requireContext()).getConnection(), new ApiCallback<PlayerType.SeekReturnType>() {
-            @Override
-            public void onSuccess(PlayerType.SeekReturnType result) {
-                // Ignore
-            }
-
-            @Override
-            public void onError(int errorCode, String description) {
-                LogUtils.LOGD("MediaSeekBar", "Got an error calling Player.Seek. Error code: " + errorCode + ", description: " + description);
-            }
-        }, callbackHandler);
-
-
-    }
-
     /**
      * Sets whats playing information
      * @param getItemResult Return from method {@link org.xbmc.kore.jsonrpc.method.Player.GetItem}
@@ -701,7 +681,7 @@ public class NowPlayingFragment extends Fragment
         binding.mediaTitle.post(UIUtils.getMarqueeToggleableAction(binding.mediaTitle));
         binding.mediaUndertitle.setText(underTitle);
 
-        binding.progressInfo.setOnProgressChangeListener(this);
+        binding.progressInfo.setActivePlayerId(getActivePlayerResult.playerid);
         binding.progressInfo.setMaxProgress(getPropertiesResult.totaltime.toSeconds());
         binding.progressInfo.setProgress(getPropertiesResult.time.toSeconds());
 

--- a/app/src/main/java/org/xbmc/kore/ui/widgets/NowPlayingPanel.java
+++ b/app/src/main/java/org/xbmc/kore/ui/widgets/NowPlayingPanel.java
@@ -84,7 +84,7 @@ public class NowPlayingPanel extends SlidingUpPanelLayout {
         binding.nppVolumeLevelIndicator.setOnVolumeChangeListener(listener);
     }
 
-    public void setOnProgressChangeListener(MediaProgressIndicator.OnProgressChangeListener listener) {
+    public void setOnProgressChangeListener(MediaProgressIndicator.ProgressChangeListener listener) {
         binding.nppProgressIndicator.setOnProgressChangeListener(listener);
     }
 
@@ -110,28 +110,18 @@ public class NowPlayingPanel extends SlidingUpPanelLayout {
     }
 
     /**
-     * Sets the state of the play button
-     * @param play true if playing, false if paused
+     * Sets the playback state of the panel
+     * @param activePlayerId Current player id
+     * @param speed Playback speed
+     * @param time Playback time
+     * @param totalTime Total playback time
      */
-    public void setPlayButton(boolean play) {
-        UIUtils.setPlayPauseButtonIcon(getContext(), binding.nppPlay, play);
-    }
-
-    public void setMediaProgress(GlobalType.Time time, GlobalType.Time totalTime) {
+    public void setPlaybackState(int activePlayerId, int speed, GlobalType.Time time, GlobalType.Time totalTime) {
+        binding.nppProgressIndicator.setActivePlayerId(activePlayerId);
         binding.nppProgressIndicator.setMaxProgress(totalTime.toSeconds());
         binding.nppProgressIndicator.setProgress(time.toSeconds());
-    }
-
-    /**
-     * Returns the progression indicator used for media progression
-     * @return Media progress indicator
-     */
-    public MediaProgressIndicator getMediaProgress() {
-        return binding.nppProgressIndicator;
-    }
-
-    public void setSpeed(int speed) {
         binding.nppProgressIndicator.setSpeed(speed);
+        UIUtils.setPlayPauseButtonIcon(getContext(), binding.nppPlay, speed == 1);
     }
 
     public CharSequence getTitle() {


### PR DESCRIPTION
To avoid duplicating code in BaseMediaActivity and NowPlayingFragment, create a default ProgressChangeListener that handles progress changes by default