### PR TITLE
Simplify MediaPlaybackBar, MediaActionsBar and MediaProgressIndicator

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
@@ -101,9 +101,7 @@ public class NowPlayingFragment extends Fragment
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         binding = FragmentNowPlayingBinding.inflate(inflater, container, false);
-        binding.progressInfo.setDefaultOnProgressChangeListener(requireContext());
-        binding.mediaPlaybackBar.setDefaultOnClickListener(requireContext());
-        binding.mediaActionsBar.setDefaultOnClickListener(requireContext(), this.getParentFragmentManager());
+        binding.mediaActionsBar.completeSetup(requireContext(), this.getParentFragmentManager());
         return binding.getRoot();
     }
 

--- a/app/src/main/java/org/xbmc/kore/ui/widgets/MediaActionsBar.java
+++ b/app/src/main/java/org/xbmc/kore/ui/widgets/MediaActionsBar.java
@@ -46,8 +46,6 @@ import java.util.List;
 public class MediaActionsBar extends LinearLayout {
     private static final String TAG = LogUtils.makeLogTag(MediaActionsBar.class);
 
-    HostConnection connection;
-
     MediaActionsBarBinding binding;
 
     int activePlayerId = -1;
@@ -55,19 +53,6 @@ public class MediaActionsBar extends LinearLayout {
     // List of available subtitles and audiostremas to show the user
     private List<PlayerType.Subtitle> availableSubtitles;
     private List<PlayerType.AudioStream> availableAudioStreams;
-
-    private OnClickListener onClickListener;
-
-    interface OnClickListener {
-        void onVolumeChangeListener(int volume);
-
-        void onVolumeMuteClicked();
-        void onShuffleClicked();
-        void onRepeatClicked();
-        void onAudiostreamsClicked();
-        void onSubtitlesClicked();
-        void onPartyModeClicked();
-    }
 
     public MediaActionsBar(Context context) {
         super(context);
@@ -87,30 +72,6 @@ public class MediaActionsBar extends LinearLayout {
     private void initializeView(Context context) {
         LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         binding = MediaActionsBarBinding.inflate(inflater, this);
-
-        connection = HostManager.getInstance(context).getConnection();
-
-        binding.volumeLevelIndicator.setOnVolumeChangeListener(volume -> onClickListener.onVolumeChangeListener(volume));
-        binding.volumeMute.setOnClickListener(v -> onClickListener.onVolumeMuteClicked());
-        binding.repeat.setOnClickListener(v -> onClickListener.onRepeatClicked());
-        binding.shuffle.setOnClickListener(v -> onClickListener.onShuffleClicked());
-        binding.audiostreams.setOnClickListener(v -> onClickListener.onAudiostreamsClicked());
-        binding.subtitles.setOnClickListener(v -> onClickListener.onSubtitlesClicked());
-        binding.partyMode.setOnClickListener(v -> onClickListener.onPartyModeClicked());
-        binding.overflow.setOnClickListener(v -> {
-            PopupMenu popup = new PopupMenu(context, binding.overflow);
-            popup.inflate(R.menu.actions_overflow_video);
-            popup.setOnMenuItemClickListener(item -> {
-                if (item.getItemId() == R.id.repeat) {
-                    onClickListener.onRepeatClicked();
-                } else if (item.getItemId() == R.id.shuffle) {
-                    onClickListener. onShuffleClicked();
-                }
-                return true;
-            });
-            popup.show();
-        });
-
         updateMutableButtons();
     }
 
@@ -136,21 +97,17 @@ public class MediaActionsBar extends LinearLayout {
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
         binding = null;
-        onClickListener = null;
-    }
-
-    public void setOnClickListener(OnClickListener listener) {
-        onClickListener = listener;
     }
 
     /**
-     * This sets default actions for each of the buttons, that sends the corresponding action to Kodi or,
-     * for the audiostreams/subtitles options, shows the user a Dialog with the available audiostreams/subtitles,
-     * and reacts according to its selection
+     * This completes the View setup. This needs to be called explicitly because some options, namely the audiostreams
+     * and subtitles options show the user a Dialog which needs a FragmentManager to display, and that needs to be
+     * supplied by the enclosing Activity/Fragment
      * @param context Context
      * @param fragmentManager FragmentManager needed to show a Dialog
      */
-    public void setDefaultOnClickListener(final Context context, final FragmentManager fragmentManager) {
+    public void completeSetup(final Context context, final FragmentManager fragmentManager) {
+        final HostConnection connection = HostManager.getInstance(context).getConnection();
         final HostConnectionObserver hostConnectionObserver = HostManager.getInstance(context).getHostConnectionObserver();
         final Handler callbackHandler = new Handler(Looper.getMainLooper());
         // Callback that forces a refresh of what's playing
@@ -164,9 +121,7 @@ public class MediaActionsBar extends LinearLayout {
         // Callback that switches to the remore screen
         final ApiCallback<String> switchToRemoteCallback = new ApiCallback<String>() {
             @Override
-            public void onSuccess(String result) {
-                // nowPlayingListener.SwitchToRemotePanel();
-            }
+            public void onSuccess(String result) {/* nowPlayingListener.SwitchToRemotePanel();*/}
 
             @Override
             public void onError(int errorCode, String description) { }
@@ -177,162 +132,155 @@ public class MediaActionsBar extends LinearLayout {
         final int SELECT_AUDIOSTREAM = 0, SELECT_SUBTITLES = 1;
 
         // Dialog listener that reacts to the users selection after being shown the Audiostreams/Subtitles Dialog
-        final GenericSelectDialog.GenericSelectDialogListener dialogListener = new GenericSelectDialog.GenericSelectDialogListener() {
-            @Override
-            public void onDialogSelect(int token, int which) {
-                switch (token) {
-                    case SELECT_AUDIOSTREAM:
-                        // 0 is to sync audio, other is for a specific audiostream
-                        switch (which) {
-                            case 0:
-                                new Input.ExecuteAction(Input.ExecuteAction.AUDIODELAY)
-                                        .execute(connection, switchToRemoteCallback, callbackHandler);
-                                break;
-                            default:
-                                new Player.SetAudioStream(activePlayerId, which - ADDED_AUDIO_OPTIONS)
-                                        .execute(connection, null, null);
-                                break;
-                        }
-                        break;
-                    case SELECT_SUBTITLES:
-                        // 0 is to download subtitles, 1 is for sync, 2 is for none, other is for a specific subtitle index
-                        switch (which) {
-                            case 0:
-                                // Download subtitles. First check host version to see which method to call
-                                HostInfo hostInfo = HostManager.getInstance(getContext()).getHostInfo();
-                                if (hostInfo.isGothamOrLater()) {
-                                    showDownloadSubtitlesPostGotham();
-                                } else {
-                                    showDownloadSubtitlesPreGotham();
+        final GenericSelectDialog.GenericSelectDialogListener dialogListener = (token, which) -> {
+            switch (token) {
+                case SELECT_AUDIOSTREAM:
+                    // 0 is to sync audio, other is for a specific audiostream
+                    switch (which) {
+                        case 0:
+                            new Input.ExecuteAction(Input.ExecuteAction.AUDIODELAY)
+                                    .execute(connection, switchToRemoteCallback, callbackHandler);
+                            break;
+                        default:
+                            new Player.SetAudioStream(activePlayerId, which - ADDED_AUDIO_OPTIONS)
+                                    .execute(connection, null, null);
+                            break;
+                    }
+                    break;
+                case SELECT_SUBTITLES:
+                    // 0 is to download subtitles, 1 is for sync, 2 is for none, other is for a specific subtitle index
+                    switch (which) {
+                        case 0:
+                            ApiCallback<String> subtitlesDownloadCallback = new ApiCallback<String>() {
+                                @Override
+                                public void onSuccess(String result) {/* nowPlayingListener.SwitchToRemotePanel();*/}
+
+                                @Override
+                                public void onError(int errorCode, String description) {
+                                    Toast.makeText(getContext(),
+                                                   getResources().getString(R.string.error_executing_subtitles, description),
+                                                   Toast.LENGTH_SHORT)
+                                         .show();
                                 }
-                                break;
-                            case 1:
-                                new Input.ExecuteAction(Input.ExecuteAction.SUBTITLEDELAY)
-                                        .execute(connection, switchToRemoteCallback, callbackHandler);
-                                break;
-                            case 2:
-                                new Player.SetSubtitle(activePlayerId, Player.SetSubtitle.OFF, true)
-                                        .execute(connection, forceRefreshCallback, callbackHandler);
-                                break;
-                            default:
-                                new Player.SetSubtitle(activePlayerId, which - ADDED_SUBTITLE_OPTIONS, true)
-                                        .execute(connection, forceRefreshCallback, callbackHandler);
-                                break;
-                        }
-                        break;
-                }
-            }
+                            };
 
-            private void showDownloadSubtitlesPreGotham() {
-                // Pre-Gotham
-                Addons.ExecuteAddon action = new Addons.ExecuteAddon(Addons.ExecuteAddon.ADDON_SUBTITLES);
-                action.execute(connection, new ApiCallback<String>() {
-                    @Override
-                    public void onSuccess(String result) {
-                        // Notify enclosing activity to switch panels
-                        // nowPlayingListener.SwitchToRemotePanel();
+                            // Download subtitles. First check host version to see which method to call
+                            HostInfo hostInfo = HostManager.getInstance(getContext()).getHostInfo();
+                            if (hostInfo.isGothamOrLater()) {
+                                // Post-Gotham - Hack. Apparently Gui.ActivateWindow with subtitlesearch blocks the TCP listener
+                                // thread on XBMC While the subtitles windows is showing, i get no response to any call. See:
+                                // http://forum.xbmc.org/showthread.php?tid=198156
+                                // Forcing this call through HTTP works, as it doesn't block the TCP listener thread on XBMC
+                                HostInfo currentHostInfo = HostManager.getInstance(getContext()).getHostInfo();
+                                HostConnection httpHostConnection = new HostConnection(currentHostInfo);
+                                httpHostConnection.setProtocol(HostConnection.PROTOCOL_HTTP);
+                                new GUI.ActivateWindow(GUI.ActivateWindow.SUBTITLESEARCH)
+                                        .execute(httpHostConnection, subtitlesDownloadCallback, callbackHandler);
+                            } else {
+                                // Pre-Gotham
+                                new Addons.ExecuteAddon(Addons.ExecuteAddon.ADDON_SUBTITLES)
+                                        .execute(connection, subtitlesDownloadCallback, callbackHandler);
+                            }
+                            break;
+                        case 1:
+                            new Input.ExecuteAction(Input.ExecuteAction.SUBTITLEDELAY)
+                                    .execute(connection, switchToRemoteCallback, callbackHandler);
+                            break;
+                        case 2:
+                            new Player.SetSubtitle(activePlayerId, Player.SetSubtitle.OFF, true)
+                                    .execute(connection, forceRefreshCallback, callbackHandler);
+                            break;
+                        default:
+                            new Player.SetSubtitle(activePlayerId, which - ADDED_SUBTITLE_OPTIONS, true)
+                                    .execute(connection, forceRefreshCallback, callbackHandler);
+                            break;
                     }
-
-                    @Override
-                    public void onError(int errorCode, String description) {
-                        Toast.makeText(getContext(),
-                                       getResources().getString(R.string.error_executing_subtitles, description),
-                                       Toast.LENGTH_SHORT)
-                             .show();
-                    }
-                }, callbackHandler);
-            }
-
-            private void showDownloadSubtitlesPostGotham() {
-                // Post-Gotham - Hack. Apparently Gui.ActivateWindow with subtitlesearch blocks the TCP listener
-                // thread on XBMC While the subtitles windows is showing, i get no response to any call. See:
-                // http://forum.xbmc.org/showthread.php?tid=198156
-                // Forcing this call through HTTP works, as it doesn't block the TCP listener thread on XBMC
-                HostInfo currentHostInfo = HostManager.getInstance(getContext()).getHostInfo();
-                HostConnection httpHostConnection = new HostConnection(currentHostInfo);
-                httpHostConnection.setProtocol(HostConnection.PROTOCOL_HTTP);
-
-                GUI.ActivateWindow action = new GUI.ActivateWindow(GUI.ActivateWindow.SUBTITLESEARCH);
-                action.execute(httpHostConnection, null, null);
-                // Notify enclosing activity to switch panels
-                // nowPlayingListener.SwitchToRemotePanel();
+                    break;
             }
         };
 
         // Default actions: send to Kodi or show the popupmenu
-        onClickListener = new OnClickListener() {
-            @Override
-            public void onVolumeChangeListener(int volume) {
-                new Application.SetVolume(volume).execute(connection, null, null);
-            }
-
-            @Override
-            public void onVolumeMuteClicked() {
-                new Application.SetMute().execute(connection, null, null);
-            }
-
-            @Override
-            public void onShuffleClicked() {
-                // Force a refresh
-                new Player.SetShuffle(activePlayerId).execute(connection, forceRefreshCallback, callbackHandler);
-            }
-
-            @Override
-            public void onRepeatClicked() {
-                new Player.SetRepeat(activePlayerId, PlayerType.Repeat.CYCLE)
-                        .execute(connection, forceRefreshCallback, callbackHandler);
-            }
-
-            @Override
-            public void onPartyModeClicked() {
-                new Player.SetPartymode(activePlayerId)
-                        .execute(connection, forceRefreshCallback, callbackHandler);
-            }
-
-            @Override
-            public void onAudiostreamsClicked() {
-                // Setup audiostream select dialog
-                String[] audiostreams = new String[(availableAudioStreams != null) ?
-                                                   availableAudioStreams.size() + ADDED_AUDIO_OPTIONS : ADDED_AUDIO_OPTIONS];
-                audiostreams[0] = getResources().getString(R.string.audio_sync);
-                if (availableAudioStreams != null) {
-                    for (int i = 0; i < availableAudioStreams.size(); i++) {
-                        PlayerType.AudioStream current = availableAudioStreams.get(i);
-                        audiostreams[i + ADDED_AUDIO_OPTIONS] = TextUtils.isEmpty(current.language) || current.language.equals("und") ?
-                                                                current.name : current.language + " | " + current.name;
-                    }
+        binding.volumeLevelIndicator.setOnVolumeChangeListener(volume -> {
+            new Application.SetVolume(volume)
+                    .execute(connection, null, null);
+        });
+        binding.volumeMute.setOnClickListener(v -> {
+            new Application.SetMute()
+                    .execute(connection, null, null);
+        });
+        binding.repeat.setOnClickListener(v -> {
+            onRepeatClicked(connection, forceRefreshCallback, callbackHandler);
+        });
+        binding.shuffle.setOnClickListener(v -> {
+            onShuffleClicked(connection, forceRefreshCallback, callbackHandler);
+        });
+        binding.audiostreams.setOnClickListener(v -> {
+            // Setup audiostream select dialog
+            String[] audiostreams = new String[(availableAudioStreams != null) ?
+                                               availableAudioStreams.size() + ADDED_AUDIO_OPTIONS : ADDED_AUDIO_OPTIONS];
+            audiostreams[0] = getResources().getString(R.string.audio_sync);
+            if (availableAudioStreams != null) {
+                for (int i = 0; i < availableAudioStreams.size(); i++) {
+                    PlayerType.AudioStream current = availableAudioStreams.get(i);
+                    audiostreams[i + ADDED_AUDIO_OPTIONS] = TextUtils.isEmpty(current.language) || current.language.equals("und") ?
+                                                            current.name : current.language + " | " + current.name;
                 }
-                GenericSelectDialog.newInstance(dialogListener,
-                                                SELECT_AUDIOSTREAM,
-                                                getResources().getString(R.string.audiostreams),
-                                                audiostreams, -1)
-                                   .show(fragmentManager, null);
             }
+            GenericSelectDialog.newInstance(dialogListener,
+                                            SELECT_AUDIOSTREAM,
+                                            getResources().getString(R.string.audiostreams),
+                                            audiostreams, -1)
+                               .show(fragmentManager, null);
+        });
+        binding.subtitles.setOnClickListener(v -> {
+            String[] subtitles = new String[(availableSubtitles != null) ?
+                                            availableSubtitles.size() + ADDED_SUBTITLE_OPTIONS : ADDED_SUBTITLE_OPTIONS];
 
-            @Override
-            public void onSubtitlesClicked() {
-                String[] subtitles = new String[(availableSubtitles != null) ?
-                                                availableSubtitles.size() + ADDED_SUBTITLE_OPTIONS : ADDED_SUBTITLE_OPTIONS];
+            subtitles[0] = getResources().getString(R.string.download_subtitle);
+            subtitles[1] = getResources().getString(R.string.subtitle_sync);
+            subtitles[2] = getResources().getString(R.string.none);
 
-                subtitles[0] = getResources().getString(R.string.download_subtitle);
-                subtitles[1] = getResources().getString(R.string.subtitle_sync);
-                subtitles[2] = getResources().getString(R.string.none);
-
-                if (availableSubtitles != null) {
-                    for (int i = 0; i < availableSubtitles.size(); i++) {
-                        PlayerType.Subtitle current = availableSubtitles.get(i);
-                        subtitles[i + ADDED_SUBTITLE_OPTIONS] = TextUtils.isEmpty(current.language) ?
-                                                                current.name : current.language + " | " + current.name;
-                    }
+            if (availableSubtitles != null) {
+                for (int i = 0; i < availableSubtitles.size(); i++) {
+                    PlayerType.Subtitle current = availableSubtitles.get(i);
+                    subtitles[i + ADDED_SUBTITLE_OPTIONS] = TextUtils.isEmpty(current.language) ?
+                                                            current.name : current.language + " | " + current.name;
                 }
-
-                GenericSelectDialog.newInstance(dialogListener,
-                                                SELECT_SUBTITLES,
-                                                getResources().getString(R.string.subtitles),
-                                                subtitles, -1)
-                                   .show(fragmentManager, null);
             }
-        };
+
+            GenericSelectDialog.newInstance(dialogListener,
+                                            SELECT_SUBTITLES,
+                                            getResources().getString(R.string.subtitles),
+                                            subtitles, -1)
+                               .show(fragmentManager, null);
+        });
+        binding.partyMode.setOnClickListener(v -> {
+            new Player.SetPartymode(activePlayerId)
+                    .execute(connection, forceRefreshCallback, callbackHandler);
+        });
+        binding.overflow.setOnClickListener(v -> {
+            PopupMenu popup = new PopupMenu(context, binding.overflow);
+            popup.inflate(R.menu.actions_overflow_video);
+            popup.setOnMenuItemClickListener(item -> {
+                if (item.getItemId() == R.id.repeat) {
+                    onRepeatClicked(connection, forceRefreshCallback, callbackHandler);
+                } else if (item.getItemId() == R.id.shuffle) {
+                    onShuffleClicked(connection, forceRefreshCallback, callbackHandler);
+                }
+                return true;
+            });
+            popup.show();
+        });
+    }
+
+    private void onRepeatClicked(HostConnection connection, ApiCallback<String> forceRefreshCallback, Handler callbackHandler) {
+        new Player.SetRepeat(activePlayerId, PlayerType.Repeat.CYCLE)
+                .execute(connection, forceRefreshCallback, callbackHandler);
+    }
+
+    private void onShuffleClicked(HostConnection connection, ApiCallback<String> forceRefreshCallback, Handler callbackHandler) {
+        new Player.SetShuffle(activePlayerId)
+                .execute(connection, forceRefreshCallback, callbackHandler);
     }
 
     /**

--- a/app/src/main/java/org/xbmc/kore/ui/widgets/NowPlayingPanel.java
+++ b/app/src/main/java/org/xbmc/kore/ui/widgets/NowPlayingPanel.java
@@ -70,25 +70,10 @@ public class NowPlayingPanel extends SlidingUpPanelLayout {
         setDragView(binding.collapsedView);
 
         final HostConnection connection = HostManager.getInstance(context).getConnection();
-        final Handler callbackHandler = new Handler(Looper.getMainLooper());
-        final ApiCallback<Integer> defaultPlaySpeedChangedCallback = new ApiCallback<Integer>() {
-            @Override
-            public void onSuccess(Integer result) {
-                UIUtils.setPlayPauseButtonIcon(context, binding.play, result == 1);
-            }
-
-            @Override
-            public void onError(int errorCode, String description) { }
-        };
-
         binding.play.setOnClickListener(v -> new Player.PlayPause(activePlayerId)
-                .execute(connection, defaultPlaySpeedChangedCallback, callbackHandler));
+                .execute(connection, null, null));
         binding.volumeMutedIndicator.setOnClickListener(v -> new Application.SetMute()
                 .execute(connection, null, null));
-
-        binding.progressInfo.setDefaultOnProgressChangeListener(context);
-        binding.progressInfo.setDefaultOnProgressChangeListener(context);
-        binding.mediaPlaybackBar.setDefaultOnClickListener(context);
     }
 
     /**
@@ -98,7 +83,7 @@ public class NowPlayingPanel extends SlidingUpPanelLayout {
      * @param fragmentManager FragmentManager needed to show a Dialog
      */
     public void completeSetup(final Context context, final FragmentManager fragmentManager) {
-        binding.mediaActionsBar.setDefaultOnClickListener(context, fragmentManager);
+        binding.mediaActionsBar.completeSetup(context, fragmentManager);
     }
 
     @Override


### PR DESCRIPTION
There's no need for these Views to define an interface to post click events, as these should be handled by the views themselves, making them self-contained.
This also simplifies the seting up of these views, as clients no longer need to call `setDefaultClickListeners`, except on the MediaActionsBar, where a explicit `completeSetup` method must be called to supply a FragmentManager.
There's still a need to call `setPlaybackState` to update their state and UI.