### PR TITLE
Redesign the Remote screen to show Playback, Progress and Media actions controls

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/widgets/MediaActionsBar.java
+++ b/app/src/main/java/org/xbmc/kore/ui/widgets/MediaActionsBar.java
@@ -35,13 +35,14 @@ import java.util.List;
 /**
  * This presents a row of buttons that allow for media actions, namely:
  * mute, sound level control, repeat, shuffle, audiostreams and subtitles
- * This can be included in a layout, and on the corresponding activity/fragment call
- * {@link MediaActionsBar#setOnClickListener(OnClickListener)} to set a specific {@link OnClickListener} for the
- * buttons, or call {@link MediaActionsBar#setDefaultOnClickListener(Context, FragmentManager)} to set a default click
- * listener that just sends each command to the Kodi host without further processing. Note that the default action
- * for the "audiostream" and "subtitles" is to show a UI Dialog with the available audiostreams or subtitles, so
- * this class needs a reference to the calling Fragment to show that Dialog. It also needs to be kept updated
- * during playback, by calling {@link MediaActionsBar#setPlaybackState(PlayerType.GetActivePlayersReturnType, PlayerType.PropertyValue)}
+ * Include this in a layout and the buttons work as expected, sending each command to Kodi without further processing.
+ * Note that the action for the "audiostream" and "subtitles" is to show a UI Dialog with the available audiostreams
+ * or subtitles, so this class needs a reference to the calling Fragment to show that Dialog, which should be provided
+ * by calling {@link MediaActionsBar#completeSetup} in the Fragment/Activity onCreateView.
+ * During playback this view needs to be manually updated, by calling {@link MediaActionsBar#setPlaybackState}
+ * when the playback state changes on Kodi. This view could be auto-suficient by subscribing to
+ * {@link org.xbmc.kore.host.HostConnectionObserver} and keeping itself updated when the state changes, but given
+ * that clients of this view are most likely already subscribers of that, this prevents the proliferation of observers
  */
 public class MediaActionsBar extends LinearLayout {
     private static final String TAG = LogUtils.makeLogTag(MediaActionsBar.class);
@@ -295,9 +296,7 @@ public class MediaActionsBar extends LinearLayout {
 
         updateMutableButtons();
 
-        if (activePlayerType.equals(PlayerType.GetActivePlayersReturnType.VIDEO)) {
-            binding.subtitles.setHighlight(getPropertiesResult.subtitleenabled);
-        } else {
+        if (!activePlayerType.equals(PlayerType.GetActivePlayersReturnType.VIDEO)) {
             setRepeatShuffleState(getPropertiesResult.repeat, getPropertiesResult.shuffled, getPropertiesResult.partymode);
         }
     }

--- a/app/src/main/java/org/xbmc/kore/ui/widgets/MediaPlaybackBar.java
+++ b/app/src/main/java/org/xbmc/kore/ui/widgets/MediaPlaybackBar.java
@@ -33,6 +33,7 @@ public class MediaPlaybackBar extends LinearLayout {
             VIEW_MODE_NO_STOP_BUTTON = 1,
             VIEW_MODE_SINGLE_MOVEMENT_BUTTONS = 2;
 
+    HostConnection connection;
     MediaPlaybackBarBinding binding;
     int activePlayerId = -1;
     String activePlayerType = PlayerType.GetActivePlayersReturnType.VIDEO;
@@ -48,8 +49,6 @@ public class MediaPlaybackBar extends LinearLayout {
 
     public MediaPlaybackBar(Context context, AttributeSet attributeSet, int defStyle) {
         super(context, attributeSet, defStyle);
-        initializeView(context);
-
         if (isInEditMode()) return;
 
         TypedArray a = context.getTheme().obtainStyledAttributes(attributeSet, R.styleable.MediaPlaybackBar, 0, 0);
@@ -58,6 +57,7 @@ public class MediaPlaybackBar extends LinearLayout {
         } finally {
             a.recycle();
         }
+        initializeView(context);
         updateViewMode();
     }
 
@@ -65,7 +65,7 @@ public class MediaPlaybackBar extends LinearLayout {
         LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         binding = MediaPlaybackBarBinding.inflate(inflater, this);
 
-        final HostConnection connection = HostManager.getInstance(context).getConnection();
+        connection = HostManager.getInstance(context).getConnection();
         binding.play.setOnClickListener(v -> {
             new Player.PlayPause(activePlayerId)
                     .execute(connection, null, null);

--- a/app/src/main/res/layout-land/fragment_remote.xml
+++ b/app/src/main/res/layout-land/fragment_remote.xml
@@ -22,7 +22,7 @@
 
     <!-- Right button bar -->
     <LinearLayout
-        android:id="@+id/button_bar"
+        android:id="@+id/sections_button_bar"
         android:layout_width="@dimen/buttonbar_height"
         android:layout_height="match_parent"
         android:layout_alignParentEnd="true"
@@ -132,7 +132,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_toStartOf="@+id/button_bar">
+        android:layout_toStartOf="@+id/sections_button_bar">
 
         <include
             android:id="@+id/include_info_panel"
@@ -170,49 +170,43 @@
                 android:layout_alignStart="@id/title"
                 style="@style/TextAppearance.Media.Remote.Details"
                 android:background="?attr/contentBackgroundColor"/>
-            <LinearLayout
-                android:id="@+id/media_button_bar"
+
+            <!-- Media playback control buttons -->
+            <org.xbmc.kore.ui.widgets.MediaPlaybackBar
+                android:id="@+id/media_playback_bar"
                 android:layout_width="match_parent"
-                android:layout_height="@dimen/default_icon_size"
+                android:layout_height="@dimen/buttonbar_height"
                 android:layout_below="@id/details"
                 android:layout_alignStart="@id/details"
                 android:layout_alignBottom="@+id/art"
                 android:orientation="horizontal"
                 style="@style/ButtonBar"
-                android:background="?attr/contentBackgroundColor">
-                <ImageButton
-                    android:id="@+id/rewind"
-                    android:layout_width="0dp"
-                    android:layout_weight="1"
-                    android:layout_height="match_parent"
-                    style="@style/Widget.Button.Borderless"
-                    android:src="?attr/iconRewind"
-                    android:contentDescription="@string/rewind"/>
-                <ImageButton
-                    android:id="@+id/play"
-                    android:layout_width="0dp"
-                    android:layout_weight="1"
-                    android:layout_height="match_parent"
-                    style="@style/Widget.Button.Borderless"
-                    android:src="?attr/iconPlay"
-                    android:contentDescription="@string/play"/>
-                <ImageButton
-                    android:id="@+id/stop"
-                    android:layout_width="0dp"
-                    android:layout_weight="1"
-                    android:layout_height="match_parent"
-                    style="@style/Widget.Button.Borderless"
-                    android:src="?attr/iconStop"
-                    android:contentDescription="@string/stop"/>
-                <ImageButton
-                    android:id="@+id/fast_forward"
-                    android:layout_width="0dp"
-                    android:layout_weight="1"
-                    android:layout_height="match_parent"
-                    style="@style/Widget.Button.Borderless"
-                    android:src="?attr/iconFastForward"
-                    android:contentDescription="@string/fast_forward"/>
-            </LinearLayout>
+                android:background="?attr/contentBackgroundColor" />
+
+            <!-- Progress bar -->
+            <org.xbmc.kore.ui.widgets.MediaProgressIndicator
+                android:id="@+id/progress_info"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/art"
+                android:layout_alignStart="@id/art"
+                android:paddingTop="@dimen/default_padding"
+                android:paddingRight="@dimen/small_padding"
+                android:paddingLeft="@dimen/small_padding"
+                android:orientation="horizontal"
+                android:background="?attr/contentBackgroundColor"/>
+
+            <!-- Media action buttons -->
+            <org.xbmc.kore.ui.widgets.MediaActionsBar
+                android:id="@+id/media_actions_bar"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/buttonbar_height"
+                android:layout_below="@id/progress_info"
+                android:layout_alignStart="@id/art"
+                android:orientation="horizontal"
+                style="@style/ButtonBar"
+                android:background="?attr/contentBackgroundColor" />
+
         </RelativeLayout>
 
         <org.xbmc.kore.ui.widgets.ControlPad

--- a/app/src/main/res/layout/fragment_now_playing.xml
+++ b/app/src/main/res/layout/fragment_now_playing.xml
@@ -98,21 +98,11 @@
                 style="@style/ButtonBar"
                 app:view_mode="full" />
 
-            <!-- Media action buttons -->
-            <org.xbmc.kore.ui.widgets.MediaActionsBar
-                android:id="@+id/media_actions_bar"
-                android:layout_width="match_parent"
-                android:layout_height="@dimen/buttonbar_height"
-                android:layout_below="@id/media_playback_bar"
-                android:orientation="horizontal"
-                style="@style/ButtonBar"
-                android:background="?attr/contentBackgroundColor" />
-
             <RelativeLayout
                 android:id="@+id/media_details"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_below="@id/media_actions_bar"
+                android:layout_below="@id/media_playback_bar"
                 android:paddingTop="@dimen/default_padding"
                 android:paddingBottom="@dimen/default_padding"
                 android:paddingLeft="@dimen/default_padding"

--- a/app/src/main/res/layout/fragment_remote.xml
+++ b/app/src/main/res/layout/fragment_remote.xml
@@ -24,7 +24,7 @@
     <FrameLayout
         android:id="@+id/top_panel"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/remote_top_panel_height"
+        android:layout_height="wrap_content"
         android:layout_alignParentStart="true">
 
         <include
@@ -47,53 +47,6 @@
                 android:contentDescription="@string/poster"
                 android:scaleType="centerCrop"/>
 
-            <LinearLayout
-                android:id="@+id/media_button_bar"
-                style="@style/ButtonBar"
-                android:layout_width="match_parent"
-                android:layout_height="@dimen/default_icon_size"
-                android:layout_alignBottom="@id/art"
-                android:layout_toEndOf="@id/art"
-                android:background="?attr/contentBackgroundColor"
-                android:orientation="horizontal">
-
-                <ImageButton
-                    android:id="@+id/rewind"
-                    style="@style/Widget.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:contentDescription="@string/rewind"
-                    android:src="?attr/iconRewind"/>
-
-                <ImageButton
-                    android:id="@+id/play"
-                    style="@style/Widget.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:contentDescription="@string/play"
-                    android:src="?attr/iconPlay"/>
-
-                <ImageButton
-                    android:id="@+id/stop"
-                    style="@style/Widget.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:contentDescription="@string/stop"
-                    android:src="?attr/iconStop"/>
-
-                <ImageButton
-                    android:id="@+id/fast_forward"
-                    style="@style/Widget.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:contentDescription="@string/fast_forward"
-                    android:src="?attr/iconFastForward"/>
-            </LinearLayout>
-
             <TextView
                 android:id="@+id/title"
                 style="@style/TextAppearance.Media.Remote.Title"
@@ -108,16 +61,52 @@
                 style="@style/TextAppearance.Media.Remote.Details"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_above="@id/media_button_bar"
                 android:layout_below="@id/title"
                 android:layout_toEndOf="@id/art"
+                android:layout_above="@id/media_playback_bar"
                 android:background="?attr/contentBackgroundColor"/>
+
+            <!-- Media playback control buttons -->
+            <org.xbmc.kore.ui.widgets.MediaPlaybackBar
+                android:id="@+id/media_playback_bar"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/buttonbar_height"
+                android:layout_alignBottom="@id/art"
+                android:layout_toEndOf="@id/art"
+                android:orientation="horizontal"
+                style="@style/ButtonBar"
+                android:background="?attr/contentBackgroundColor"
+                app:view_mode="single_movement_buttons" />
+
+            <!-- Progress bar -->
+            <org.xbmc.kore.ui.widgets.MediaProgressIndicator
+                android:id="@+id/progress_info"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/art"
+                android:layout_alignStart="@id/art"
+                android:paddingTop="@dimen/default_padding"
+                android:paddingRight="@dimen/small_padding"
+                android:paddingLeft="@dimen/small_padding"
+                android:orientation="horizontal"
+                android:background="?attr/contentBackgroundColor"/>
+
+            <!-- Media action buttons -->
+            <org.xbmc.kore.ui.widgets.MediaActionsBar
+                android:id="@+id/media_actions_bar"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/buttonbar_height"
+                android:layout_below="@id/progress_info"
+                android:layout_alignStart="@id/art"
+                android:orientation="horizontal"
+                style="@style/ButtonBar"
+                android:background="?attr/contentBackgroundColor" />
         </RelativeLayout>
     </FrameLayout>
 
     <!-- Bottom button bar -->
     <LinearLayout
-        android:id="@+id/button_bar"
+        android:id="@+id/sections_button_bar"
         android:layout_width="match_parent"
         android:layout_height="@dimen/buttonbar_height"
         android:layout_alignParentBottom="true"
@@ -226,8 +215,9 @@
 
     <FrameLayout
         style="@style/ControlPad.FrameLayout"
-        android:layout_above="@id/button_bar"
+        android:layout_above="@id/sections_button_bar"
         android:layout_below="@id/top_panel"
+        android:layout_marginTop="@dimen/default_padding"
         android:layout_marginBottom="@dimen/default_padding">
         <org.xbmc.kore.ui.widgets.ControlPad
             android:id="@+id/remote"

--- a/app/src/main/res/values-sw360dp/dimens.xml
+++ b/app/src/main/res/values-sw360dp/dimens.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="remote_icon_size">76dp</dimen>
-    <dimen name="remote_size">228dp</dimen>
+    <dimen name="remote_size">216dp</dimen>
 </resources>

--- a/app/src/main/res/values-sw400dp/dimens.xml
+++ b/app/src/main/res/values-sw400dp/dimens.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="remote_icon_size">84dp</dimen>
-    <dimen name="remote_size">252dp</dimen>
+    <dimen name="remote_size">264dp</dimen>
 </resources>


### PR DESCRIPTION
On current phone displays the remote screen has more than enough space to show more controls, so make it show buttons for playback control, progress info and media actions. These controls were placed in the Now Playing screen which is not immediately accesible, so moving them to the remote makes it more user-friendly.
Also remove the media actions controls from the Now Playing screen, as these are now redundant. The playback and progress info are also redundant, but we choose to keep them there to keep the UI balanced and because these controls are more useful to the user so they should be accessible in as many places as sensible.