### PR TITLE
Update language preferences

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,9 +20,10 @@ android {
         versionName = getVersionName()
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 
-        def supportedLocales = ["en", "ast", "ru", "it", "ca", "cs", "zh-CN", "ja", "pt", "pt-BR",
-                                "pl", "sl", "sk", "lt", "eu", "iw", "fr", "es", "hr", "hu", "nl",
-                                "bg", "de", "ko", "uk"]
+        def supportedLocales = ["en",
+                "af-za", "ast", "be-by", "bg", "ca", "cs", "da-dk", "de",
+                "es", "es-MX", "eu", "fi", "fr", "hr", "hu", "it", "iw", "ja",
+                "ko", "lt", "nl", "pl", "pt", "pt-BR", "ru", "sk", "sl", "zh-CN"]
         buildConfigField "String[]", "SUPPORTED_LOCALES", "new String[]{\""+
                 supportedLocales.join("\",\"")+"\"}"
     }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteFragment.java
@@ -377,6 +377,7 @@ public class RemoteFragment extends Fragment
         int vis = (config.orientation == Configuration.ORIENTATION_PORTRAIT && config.screenHeightDp <= 600) ?
                   View.GONE : View.VISIBLE;
         binding.sectionsButtonBar.setVisibility(vis);
+        //LogUtils.LOGD(TAG, "Screen DP. Width: " + config.screenWidthDp + ", Height: " + config.screenHeightDp);
     }
 
     /**


### PR DESCRIPTION
Add the system default language on the first position of the language select dialog, so that the user can always return to it in an easy way
Update the available languages on the build configuration