### PR TITLE
Improve showing lists when there's no connection to Kodi

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/AbstractListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractListFragment.java
@@ -37,6 +37,7 @@ import org.xbmc.kore.R;
 import org.xbmc.kore.Settings;
 import org.xbmc.kore.databinding.FragmentMediaListBinding;
 import org.xbmc.kore.host.HostConnectionObserver;
+import org.xbmc.kore.host.HostInfo;
 import org.xbmc.kore.host.HostManager;
 import org.xbmc.kore.ui.viewgroups.RecyclerViewEmptyViewSupport;
 import org.xbmc.kore.utils.LogUtils;
@@ -165,20 +166,24 @@ public abstract class AbstractListFragment
 		return binding.includeEmptyView.empty;
 	}
 
-
-	private int lastConnectionStatusResult = CONNECTION_NO_RESULT;
+	protected int lastConnectionStatusResult = CONNECTION_NO_RESULT;
 	/**
-	 * Disable Swipe refresh as, by default it doesn't make sense without a connection
-	 * Override in subclasses if this isn't the intended behaviour
+	 * Disable Swipe refresh, hide the list and show an error message. By default, this is what make sense without a
+	 * connection. Override in subclasses if this isn't the intended behaviour
 	 */
 	@Override
 	public void connectionStatusOnError(int errorCode, String description) {
 		lastConnectionStatusResult = CONNECTION_ERROR;
 		binding.swipeRefreshLayout.setEnabled(false);
+		binding.list.setVisibility(View.GONE);
+		getEmptyView().setVisibility(View.VISIBLE);
+		HostInfo hostInfo = HostManager.getInstance(requireContext()).getHostInfo();
+		getEmptyView().setText(String.format(getString(R.string.connecting_to), hostInfo.getName(), hostInfo.getAddress()));
 	}
 
 	/**
-	 * Enable swipe refresh when there's a connection
+	 * Enable swipe refresh and show the list when there's a connection
+	 * In subclasses make sure you populate the list
 	 */
 	@Override
 	public void connectionStatusOnSuccess() {
@@ -186,6 +191,8 @@ public abstract class AbstractListFragment
 		// If transitioning from Sucess or No results the enabled UI is already being shown
 		if (lastConnectionStatusResult == CONNECTION_ERROR) {
 			binding.swipeRefreshLayout.setEnabled(true);
+			getEmptyView().setVisibility(View.GONE);
+			binding.list.setVisibility(View.VISIBLE);
 		}
 		lastConnectionStatusResult = CONNECTION_SUCCESS;
 	}

--- a/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
@@ -279,7 +279,9 @@ public abstract class BaseMediaActivity
     }
 
     @Override
-    public void playerOnConnectionError(int errorCode, String description) {}
+    public void playerOnConnectionError(int errorCode, String description) {
+        binding.nowPlayingPanel.setPanelState(SlidingUpPanelLayout.PanelState.HIDDEN);
+    }
 
     @Override
     public void playerNoResultsYet() {}

--- a/app/src/main/java/org/xbmc/kore/ui/sections/localfile/LocalMediaFileListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/localfile/LocalMediaFileListFragment.java
@@ -142,8 +142,8 @@ public class LocalMediaFileListFragment extends AbstractListFragment {
     }
 
     /**
-     * Override parent Connection Status callbacks, so that they don't disable the SwipreRefreshLayout.
-     * In this fragment a refresh should be always available as it is local only
+     * Override parent Connection Status callbacks, so that they don't disable the SwipeRefreshLayout and the list.
+     * This fragment doesn't need a Kodi connection to show results
      */
     @Override
     public void connectionStatusOnError(int errorCode, String description) {}

--- a/app/src/main/res/layout/empty_view.xml
+++ b/app/src/main/res/layout/empty_view.xml
@@ -16,12 +16,13 @@
 -->
 
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
-          android:id="@android:id/empty"
-          android:textAppearance="@style/TextAppearance.Kore.Title"
-          android:layout_height="match_parent"
-          android:layout_width="match_parent"
-          android:layout_gravity="center"
-          android:gravity="center"
-          android:visibility="gone"
-          android:text="@string/loading"/>
+    android:id="@android:id/empty"
+    android:textAppearance="@style/TextAppearance.Kore.Title"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    android:layout_gravity="center"
+    android:gravity="center"
+    android:visibility="gone"
+    android:padding="@dimen/large_padding"
+    android:text="@string/loading"/>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -221,7 +221,7 @@
 
     <string name="error_getting_properties">Couldn\'t get Kodi properties.\nError message:%1$s.</string>
     <string name="error_executing_subtitles">Couldn\'t execute subtitles addon.\nError message: %1$s.</string>
-    <string name="error_getting_addon_info">Couldn\'t get Addon information.\nError message:%1$s.</string>
+    <string name="error_getting_addon_info">Couldn\'t get addons list.\nError message:%1$s.</string>
     <string name="error_getting_source_info">Couldn\'t browse files.\nError message:%1$s.</string>
     <string name="error_play_media_file">Couldn\'t play media file.\nError message:%1$s.</string>
     <string name="error_play_local_file">Couldn\'t play local media file.\nError message:%1$s.</string>
@@ -253,7 +253,7 @@
     <string name="no_albums_found_refresh">No albums found\n\nSwipe down to refresh</string>
     <string name="no_genres_found_refresh">No genres found\n\nSwipe down to refresh</string>
     <string name="no_songs_found_refresh">No songs found\n\nSwipe down to refresh</string>
-    <string name="no_addons_found_refresh">No addons found or not connected\n\nSwipe down to refresh</string>
+    <string name="no_addons_found_refresh">No addons found\n\nSwipe down to refresh</string>
     <string name="no_music_videos_found_refresh">No videos found\n\nSwipe down to refresh</string>
     <string name="no_channel_groups_found_refresh">No channel groups found\n\nSwipe down to refresh</string>
     <string name="no_channels_found_refresh">No channels found\n\nSwipe down to refresh</string>
@@ -400,11 +400,11 @@
     <string name="might_not_have_pvr">An error occurred while getting channels info, probably because your media center doesn\'t have a tuner or it isn\'t configured.\n\n
     	If that\'s the case and you\'d like to remove this entry from the side menu, you can do it in the Settings.</string>
     <string name="error_starting_channel">An error occurred starting channel playback: %1$s</string>
-    <string name="error_favourites">An error occurred while getting the favourites with description: %1$s</string>
     <string name="error_starting_recording">An error occurred starting a recording: %1$s</string>
     <string name="error_starting_to_record">An error occurred while recording: %1$s</string>
     <string name="channel_switching">Switching to channel %1$s</string>
     <string name="starting_recording">Starting recording %1$s</string>
+    <string name="error_favourites">Couldn\'t get favourites\n\nError description: %1$s</string>
     <string name="refresh">Refresh</string>
 
     <string name="tv">TV</string>


### PR DESCRIPTION
When there's no connection to Kodi, disable the Swipe to Refresh, hide the item list and show the empty view with a message that we're trying to connect to Kodi.
This behaviour is overriden if the list doesn't need a connection to show, as is the case of items that are stored in the local database, descendents from AbstractCursorListFragment
Improve Favourites and Addons list, to only fetch their items when there's a connection.