### PR TITLE
Make sure we don't access Views on callbaks if View Binding is null 

### DIFF
--- a/app/src/main/java/org/xbmc/kore/host/HostConnectionObserver.java
+++ b/app/src/main/java/org/xbmc/kore/host/HostConnectionObserver.java
@@ -41,7 +41,7 @@ import java.util.List;
  * to enable to get notifications not only through TCP but also through HTTP.
  * Depending on the connection protocol this class registers itself as an observer for
  * {@link HostConnection.PlayerNotificationsObserver} and forwards the notifications it gets,
- * or, if through HTTP, starts a periodic polling of XBMC, and tries to discern when a change in
+ * or, if through HTTP, starts a periodic polling of Kodi, and tries to discern when a change in
  * the player has occurred, notifying the listeners
  *
  * NOTE: An object of this class should always be called from the same thread.
@@ -59,20 +59,20 @@ public class HostConnectionObserver
          * Notifies that a playlist has been cleared
          * @param playlistId of playlist that has been cleared
          */
-        void playlistOnClear(int playlistId);
+        void onPlaylistClear(int playlistId);
 
         /**
          * Notifies about the available playlists on Kodi
          * @param playlists Available playlists
          */
-        void playlistsAvailable(ArrayList<GetPlaylist.GetPlaylistResult> playlists);
+        void onPlaylistsAvailable(ArrayList<GetPlaylist.GetPlaylistResult> playlists);
 
         /**
          * Notifies that an error occured when fetching playlists
          * @param errorCode Error code
          * @param description Error description
          */
-        void playlistOnError(int errorCode, String description);
+        void onPlaylistError(int errorCode, String description);
     }
 
     /**
@@ -84,7 +84,7 @@ public class HostConnectionObserver
          * @param volume Volume level
          * @param muted Is muted
          */
-        void applicationOnVolumeChanged(int volume, boolean muted);
+        void onApplicationVolumeChanged(int volume, boolean muted);
     }
 
     /**
@@ -101,7 +101,7 @@ public class HostConnectionObserver
                 PLAYER_IS_PAUSED = 3,
                 PLAYER_IS_STOPPED = 4;
 
-        void playerOnPropertyChanged(NotificationsData notificationsData);
+        void onPlayerPropertyChanged(NotificationsData notificationsData);
 
         /**
          * Notifies that something is playing
@@ -109,7 +109,7 @@ public class HostConnectionObserver
          * @param getPropertiesResult Properties obtained by a call to {@link org.xbmc.kore.jsonrpc.method.Player.GetProperties}
          * @param getItemResult Currently playing item, obtained by a call to {@link org.xbmc.kore.jsonrpc.method.Player.GetItem}
          */
-        void playerOnPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
+        void onPlayerPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                           PlayerType.PropertyValue getPropertiesResult,
                           ListType.ItemsAll getItemResult);
 
@@ -119,41 +119,41 @@ public class HostConnectionObserver
          * @param getPropertiesResult Properties obtained by a call to {@link org.xbmc.kore.jsonrpc.method.Player.GetProperties}
          * @param getItemResult Currently paused item, obtained by a call to {@link org.xbmc.kore.jsonrpc.method.Player.GetItem}
          */
-        void playerOnPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
+        void onPlayerPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                            PlayerType.PropertyValue getPropertiesResult,
                            ListType.ItemsAll getItemResult);
 
         /**
          * Notifies that media is stopped/nothing is playing
          */
-        void playerOnStop();
+        void onPlayerStop();
 
         /**
          * Called when we get a connection error
          * @param errorCode Code
          * @param description Description
          */
-        void playerOnConnectionError(int errorCode, String description);
+        void onPlayerConnectionError(int errorCode, String description);
 
         /**
          * Notifies that we don't have a result yet
          */
-        void playerNoResultsYet();
+        void onPlayerNoResultsYet();
 
         /**
-         * Notifies that XBMC has quit/shutdown/sleep
+         * Notifies that Kodi has quit/shutdown/sleep
          */
-        void systemOnQuit();
+        void onSystemQuit();
 
         /**
-         * Notifies that XBMC has requested input
+         * Notifies that Kodi has requested input
          */
-        void inputOnInputRequested(String title, String type, String value);
+        void onInputRequested(String title, String type, String value);
 
         /**
          * Notifies the observer that it this is stopping
          */
-        void observerOnStopObserving();
+        void onObserverStopObserving();
     }
 
     /**
@@ -170,19 +170,19 @@ public class HostConnectionObserver
         /**
          * Notifies that we don't have a result yet
          */
-        void connectionStatusNoResultsYet();
+        void onConnectionStatusNoResultsYet();
 
         /**
          * Notifies that we're successfully connected
          */
-        void connectionStatusOnSuccess();
+        void onConnectionStatusSuccess();
 
         /**
          * Called when we get a connection error
          * @param errorCode Code
          * @param description Description
          */
-        void connectionStatusOnError(int errorCode, String description);
+        void onConnectionStatusError(int errorCode, String description);
     }
 
     /**
@@ -491,7 +491,7 @@ public class HostConnectionObserver
      */
     public void stopObserving() {
         for (final PlayerEventsObserver observer : playerEventsObservers)
-            observer.observerOnStopObserving();
+            observer.onObserverStopObserving();
 
         playerEventsObservers.clear();
         playlistEventsObservers.clear();
@@ -513,7 +513,7 @@ public class HostConnectionObserver
     public void onPropertyChanged(org.xbmc.kore.jsonrpc.notification.Player.OnPropertyChanged notification) {
         List<PlayerEventsObserver> allObservers = new ArrayList<>(playerEventsObservers);
         for (final PlayerEventsObserver observer : allObservers) {
-            observer.playerOnPropertyChanged(notification.data);
+            observer.onPlayerPropertyChanged(notification.data);
         }
     }
 
@@ -572,7 +572,7 @@ public class HostConnectionObserver
         // Copy list to prevent ConcurrentModificationExceptions
         List<PlayerEventsObserver> allObservers = new ArrayList<>(playerEventsObservers);
         for (final PlayerEventsObserver observer : allObservers) {
-            observer.systemOnQuit();
+            observer.onSystemQuit();
         }
     }
 
@@ -580,7 +580,7 @@ public class HostConnectionObserver
         // Copy list to prevent ConcurrentModificationExceptions
         List<PlayerEventsObserver> allObservers = new ArrayList<>(playerEventsObservers);
         for (final PlayerEventsObserver observer : allObservers) {
-            observer.systemOnQuit();
+            observer.onSystemQuit();
         }
     }
 
@@ -588,7 +588,7 @@ public class HostConnectionObserver
         // Copy list to prevent ConcurrentModificationExceptions
         List<PlayerEventsObserver> allObservers = new ArrayList<>(playerEventsObservers);
         for (final PlayerEventsObserver observer : allObservers) {
-            observer.systemOnQuit();
+            observer.onSystemQuit();
         }
     }
 
@@ -596,7 +596,7 @@ public class HostConnectionObserver
         // Copy list to prevent ConcurrentModificationExceptions
         List<PlayerEventsObserver> allObservers = new ArrayList<>(playerEventsObservers);
         for (final PlayerEventsObserver observer : allObservers) {
-            observer.inputOnInputRequested(notification.title, notification.type, notification.value);
+            observer.onInputRequested(notification.title, notification.type, notification.value);
         }
     }
 
@@ -606,7 +606,7 @@ public class HostConnectionObserver
         hostState.volumeLevel = notification.volume;
 
         for (ApplicationEventsObserver observer : applicationEventsObservers) {
-            observer.applicationOnVolumeChanged(notification.volume, notification.muted);
+            observer.onApplicationVolumeChanged(notification.volume, notification.muted);
         }
     }
 
@@ -618,7 +618,7 @@ public class HostConnectionObserver
             hostState.lastGetPlaylistResults = new ArrayList<>();
 
         for (PlaylistEventsObserver observer : playlistEventsObservers) {
-            observer.playlistOnClear(notification.playlistId);
+            observer.onPlaylistClear(notification.playlistId);
         }
     }
 
@@ -656,7 +656,7 @@ public class HostConnectionObserver
                 hostState.volumeLevel = result.volume;
 
                 for (ApplicationEventsObserver observer : applicationEventsObservers) {
-                    observer.applicationOnVolumeChanged(result.volume, result.muted);
+                    observer.onApplicationVolumeChanged(result.volume, result.muted);
                 }
             }
 
@@ -690,7 +690,7 @@ public class HostConnectionObserver
                 if (!(hostState.lastGetPlaylistResults != null &&
                     hostState.lastGetPlaylistResults.equals(result))) {
                     for (PlaylistEventsObserver observer : playlistEventsObservers) {
-                        observer.playlistsAvailable(result);
+                        observer.onPlaylistsAvailable(result);
                     }
                 }
 
@@ -714,7 +714,7 @@ public class HostConnectionObserver
                 isCheckingPlaylist = false;
 
                 for (PlaylistEventsObserver observer : playlistEventsObservers) {
-                    observer.playlistOnError(errorCode, description);
+                    observer.onPlaylistError(errorCode, description);
                 }
             }
         }, checkerHandler);
@@ -724,7 +724,7 @@ public class HostConnectionObserver
         if (clearedPlaylists == null) return;
         for (GetPlaylist.GetPlaylistResult getPlaylistResult : clearedPlaylists) {
             for (PlaylistEventsObserver observer : playlistEventsObservers) {
-                observer.playlistOnClear(getPlaylistResult.id);
+                observer.onPlaylistClear(getPlaylistResult.id);
             }
         }
     }
@@ -753,7 +753,7 @@ public class HostConnectionObserver
         if (hostState.lastConnectionStatusResult != ConnectionStatusObserver.CONNECTION_SUCCESS) {
             hostState.lastConnectionStatusResult = ConnectionStatusObserver.CONNECTION_SUCCESS;
             for (final ConnectionStatusObserver observer : observers) {
-                observer.connectionStatusOnSuccess();
+                observer.onConnectionStatusSuccess();
             }
         }
     }
@@ -766,7 +766,7 @@ public class HostConnectionObserver
             hostState.lastConnectionStatusErrorCode = errorCode;
             hostState.lastConnectionStatusErrorDescription = description;
             for (final ConnectionStatusObserver observer : observers) {
-                observer.connectionStatusOnError(errorCode, description);
+                observer.onConnectionStatusError(errorCode, description);
             }
         }
     }
@@ -955,11 +955,11 @@ public class HostConnectionObserver
      * @param observer Observers
      */
     private void notifyConnectionError(final int errorCode, final String description, PlayerEventsObserver observer) {
-        observer.playerOnConnectionError(errorCode, description);
+        observer.onPlayerConnectionError(errorCode, description);
     }
 
     /**
-     * Nothing is playing, notify observers calling playerOnStop
+     * Nothing is playing, notify observers calling onPlayerStop
      * Only notifies them if the result is different from the last one
      * @param observers List of observers
      */
@@ -984,7 +984,7 @@ public class HostConnectionObserver
      * @param observer Observer
      */
     private void notifyNothingIsPlaying(PlayerEventsObserver observer) {
-        observer.playerOnStop();
+        observer.onPlayerStop();
     }
 
     private boolean getPropertiesResultChanged(PlayerType.PropertyValue getPropertiesResult) {
@@ -1064,10 +1064,10 @@ public class HostConnectionObserver
                                           PlayerEventsObserver observer) {
         if (getPropertiesResult.speed == 0) {
             // Paused
-            observer.playerOnPause(getActivePlayersResult, getPropertiesResult, getItemResult);
+            observer.onPlayerPause(getActivePlayersResult, getPropertiesResult, getItemResult);
         } else {
             // Playing
-            observer.playerOnPlay(getActivePlayersResult, getPropertiesResult, getItemResult);
+            observer.onPlayerPlay(getActivePlayersResult, getPropertiesResult, getItemResult);
         }
     }
 
@@ -1089,7 +1089,7 @@ public class HostConnectionObserver
                 notifySomethingIsPlaying(hostState.lastGetActivePlayerResult, hostState.lastGetPropertiesResult, hostState.lastGetItemResult, observer);
                 break;
             case PlayerEventsObserver.PLAYER_NO_RESULT:
-                observer.playerNoResultsYet();
+                observer.onPlayerNoResultsYet();
                 break;
         }
     }
@@ -1103,7 +1103,7 @@ public class HostConnectionObserver
         if (hostState.volumeLevel == -1) {
             getApplicationProperties();
         } else {
-            observer.applicationOnVolumeChanged(hostState.volumeLevel, hostState.volumeMuted);
+            observer.onApplicationVolumeChanged(hostState.volumeLevel, hostState.volumeMuted);
         }
     }
 
@@ -1114,7 +1114,7 @@ public class HostConnectionObserver
      */
     private void replyWithLastResult(PlaylistEventsObserver observer) {
         if (hostState.lastGetPlaylistResults != null && !hostState.lastGetPlaylistResults.isEmpty())
-            observer.playlistsAvailable(hostState.lastGetPlaylistResults);
+            observer.onPlaylistsAvailable(hostState.lastGetPlaylistResults);
         else
             checkPlaylist();
     }
@@ -1126,13 +1126,13 @@ public class HostConnectionObserver
     private void replyWithLastResult(ConnectionStatusObserver observer) {
         switch (hostState.lastConnectionStatusResult) {
             case ConnectionStatusObserver.CONNECTION_ERROR:
-                observer.connectionStatusOnError(hostState.lastConnectionStatusErrorCode, hostState.lastConnectionStatusErrorDescription);
+                observer.onConnectionStatusError(hostState.lastConnectionStatusErrorCode, hostState.lastConnectionStatusErrorDescription);
                 break;
             case ConnectionStatusObserver.CONNECTION_SUCCESS:
-                observer.connectionStatusOnSuccess();
+                observer.onConnectionStatusSuccess();
                 break;
             case PlayerEventsObserver.PLAYER_NO_RESULT:
-                observer.connectionStatusNoResultsYet();
+                observer.onConnectionStatusNoResultsYet();
                 break;
         }
     }

--- a/app/src/main/java/org/xbmc/kore/service/MediaSessionService.java
+++ b/app/src/main/java/org/xbmc/kore/service/MediaSessionService.java
@@ -261,13 +261,13 @@ public class MediaSessionService extends Service
 
     /* Ignore this */
     @Override
-    public void playerOnPropertyChanged(org.xbmc.kore.jsonrpc.notification.Player.NotificationsData notificationsData) {}
+    public void onPlayerPropertyChanged(org.xbmc.kore.jsonrpc.notification.Player.NotificationsData notificationsData) {}
 
     /**
      * HostConnectionObserver.PlayerEventsObserver interface callbacks
      */
     @Override
-    public void playerOnPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
+    public void onPlayerPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                              PlayerType.PropertyValue getPropertiesResult,
                              ListType.ItemsAll getItemResult) {
         notifyPlaying(getActivePlayerResult, getPropertiesResult, getItemResult);
@@ -277,7 +277,7 @@ public class MediaSessionService extends Service
     }
 
     @Override
-    public void playerOnPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
+    public void onPlayerPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                               PlayerType.PropertyValue getPropertiesResult,
                               ListType.ItemsAll getItemResult) {
         notifyPlaying(getActivePlayerResult, getPropertiesResult, getItemResult);
@@ -288,7 +288,7 @@ public class MediaSessionService extends Service
 
     private final Handler stopHandler = new Handler(Looper.myLooper());
     @Override
-    public void playerOnStop() {
+    public void onPlayerStop() {
         notifyNothingPlaying();
 
         // Stop service if nothing starts in a couple of seconds
@@ -299,26 +299,26 @@ public class MediaSessionService extends Service
     }
 
     @Override
-    public void playerNoResultsYet() {
+    public void onPlayerNoResultsYet() {
         notifyNothingPlaying();
     }
 
     @Override
-    public void playerOnConnectionError(int errorCode, String description) {
+    public void onPlayerConnectionError(int errorCode, String description) {
         stop("Connection Error: " + description);
     }
 
     @Override
-    public void systemOnQuit() {
+    public void onSystemQuit() {
         stop("System quit");
     }
 
     // Ignore
     @Override
-    public void inputOnInputRequested(String title, String type, String value) {}
+    public void onInputRequested(String title, String type, String value) {}
 
     @Override
-    public void observerOnStopObserving() {
+    public void onObserverStopObserving() {
         stop("Stop observing");
     }
 

--- a/app/src/main/java/org/xbmc/kore/ui/AbstractCursorListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractCursorListFragment.java
@@ -412,12 +412,14 @@ public abstract class AbstractCursorListFragment
 	 */
 	@Override
 	public void onConnectionStatusError(int errorCode, String description) {
+		if (binding == null) return; // If receiving this after onDestroy, ignore
 		lastConnectionStatusResult = CONNECTION_ERROR;
 		binding.swipeRefreshLayout.setEnabled(false);
 	}
 
 	@Override
 	public void onConnectionStatusSuccess() {
+		if (binding == null) return; // If receiving this after onDestroy, ignore
 		// Only update views if transitioning from error state.
 		// If transitioning from Sucess or No results the enabled UI is already being shown
 		if (lastConnectionStatusResult == CONNECTION_ERROR) {

--- a/app/src/main/java/org/xbmc/kore/ui/AbstractCursorListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractCursorListFragment.java
@@ -411,13 +411,13 @@ public abstract class AbstractCursorListFragment
 	 * Override parent methods to only disable Swipe Refresh, as the list can be shown without a connection
 	 */
 	@Override
-	public void connectionStatusOnError(int errorCode, String description) {
+	public void onConnectionStatusError(int errorCode, String description) {
 		lastConnectionStatusResult = CONNECTION_ERROR;
 		binding.swipeRefreshLayout.setEnabled(false);
 	}
 
 	@Override
-	public void connectionStatusOnSuccess() {
+	public void onConnectionStatusSuccess() {
 		// Only update views if transitioning from error state.
 		// If transitioning from Sucess or No results the enabled UI is already being shown
 		if (lastConnectionStatusResult == CONNECTION_ERROR) {

--- a/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
@@ -281,7 +281,7 @@ abstract public class AbstractInfoFragment
      * Hide/Disable UI elements that don't make sense without a connection
      */
     @Override
-    public void connectionStatusOnError(int errorCode, String description) {
+    public void onConnectionStatusError(int errorCode, String description) {
         LogUtils.LOGD(TAG, "Connection Status Error, disabling buttons");
         lastConnectionStatusResult = CONNECTION_ERROR;
         binding.fabPlay.setEnabled(false);
@@ -295,7 +295,7 @@ abstract public class AbstractInfoFragment
      * Show/Enable UI elements relevant when there's a connection
      */
     @Override
-    public void connectionStatusOnSuccess() {
+    public void onConnectionStatusSuccess() {
         // Only update views if transitioning from error state.
         // If transitioning from Sucess or No results the enabled UI is already being shown
         if (lastConnectionStatusResult == CONNECTION_ERROR) {
@@ -312,7 +312,7 @@ abstract public class AbstractInfoFragment
     }
 
     @Override
-    public void connectionStatusNoResultsYet() {
+    public void onConnectionStatusNoResultsYet() {
         // Do nothing, by default the enabled UI is shown while there are no results
         lastConnectionStatusResult = CONNECTION_NO_RESULT;
     }

--- a/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
@@ -282,6 +282,8 @@ abstract public class AbstractInfoFragment
      */
     @Override
     public void onConnectionStatusError(int errorCode, String description) {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
+
         LogUtils.LOGD(TAG, "Connection Status Error, disabling buttons");
         lastConnectionStatusResult = CONNECTION_ERROR;
         binding.fabPlay.setEnabled(false);
@@ -296,6 +298,8 @@ abstract public class AbstractInfoFragment
      */
     @Override
     public void onConnectionStatusSuccess() {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
+
         // Only update views if transitioning from error state.
         // If transitioning from Sucess or No results the enabled UI is already being shown
         if (lastConnectionStatusResult == CONNECTION_ERROR) {

--- a/app/src/main/java/org/xbmc/kore/ui/AbstractListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractListFragment.java
@@ -177,7 +177,7 @@ public abstract class AbstractListFragment
 	 * connection. Override in subclasses if this isn't the intended behaviour
 	 */
 	@Override
-	public void connectionStatusOnError(int errorCode, String description) {
+	public void onConnectionStatusError(int errorCode, String description) {
 		lastConnectionStatusResult = CONNECTION_ERROR;
 		binding.swipeRefreshLayout.setEnabled(false);
 		binding.list.setVisibility(View.GONE);
@@ -191,7 +191,7 @@ public abstract class AbstractListFragment
 	 * In subclasses make sure you populate the list
 	 */
 	@Override
-	public void connectionStatusOnSuccess() {
+	public void onConnectionStatusSuccess() {
 		// Only update views if transitioning from error state.
 		// If transitioning from Sucess or No results the enabled UI is already being shown
 		if (lastConnectionStatusResult == CONNECTION_ERROR) {
@@ -203,7 +203,7 @@ public abstract class AbstractListFragment
 	}
 
 	@Override
-	public void connectionStatusNoResultsYet() {
+	public void onConnectionStatusNoResultsYet() {
 		// Do nothing, by default the enabled UI is shown while there are no results
 		lastConnectionStatusResult = CONNECTION_NO_RESULT;
 	}

--- a/app/src/main/java/org/xbmc/kore/ui/AbstractListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractListFragment.java
@@ -178,6 +178,8 @@ public abstract class AbstractListFragment
 	 */
 	@Override
 	public void onConnectionStatusError(int errorCode, String description) {
+		if (binding == null) return; // If receiving this after onDestroy, ignore
+
 		lastConnectionStatusResult = CONNECTION_ERROR;
 		binding.swipeRefreshLayout.setEnabled(false);
 		binding.list.setVisibility(View.GONE);
@@ -192,6 +194,8 @@ public abstract class AbstractListFragment
 	 */
 	@Override
 	public void onConnectionStatusSuccess() {
+		if (binding == null) return; // If receiving this after onDestroy, ignore
+
 		// Only update views if transitioning from error state.
 		// If transitioning from Sucess or No results the enabled UI is already being shown
 		if (lastConnectionStatusResult == CONNECTION_ERROR) {

--- a/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
@@ -246,19 +246,19 @@ public abstract class BaseMediaActivity
     }
 
     @Override
-    public void applicationOnVolumeChanged(int volume, boolean muted) {
+    public void onApplicationVolumeChanged(int volume, boolean muted) {
         binding.nowPlayingPanel.setVolumeState(volume, muted);
     }
 
     @Override
-    public void playerOnPropertyChanged(org.xbmc.kore.jsonrpc.notification.Player.NotificationsData notificationsData) {
+    public void onPlayerPropertyChanged(org.xbmc.kore.jsonrpc.notification.Player.NotificationsData notificationsData) {
         binding.nowPlayingPanel.setRepeatShuffleState(notificationsData.property.repeatMode,
                                                       notificationsData.property.shuffled,
                                                       notificationsData.property.partymode);
     }
 
     @Override
-    public void playerOnPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
+    public void onPlayerPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                              PlayerType.PropertyValue getPropertiesResult,
                              ListType.ItemsAll getItemResult) {
         updateNowPlayingPanel(getActivePlayerResult, getPropertiesResult, getItemResult);
@@ -267,37 +267,37 @@ public abstract class BaseMediaActivity
     }
 
     @Override
-    public void playerOnPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult, PlayerType.PropertyValue getPropertiesResult, ListType.ItemsAll getItemResult) {
+    public void onPlayerPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult, PlayerType.PropertyValue getPropertiesResult, ListType.ItemsAll getItemResult) {
         updateNowPlayingPanel(getActivePlayerResult, getPropertiesResult, getItemResult);
     }
 
     @Override
-    public void playerOnStop() {
+    public void onPlayerStop() {
         // Delay hiding the panel to prevent hiding it when playing the next item in a playlist
         callbackHandler.removeCallbacks(hidePanelRunnable);
         callbackHandler.postDelayed(hidePanelRunnable, 1000);
     }
 
     @Override
-    public void playerOnConnectionError(int errorCode, String description) {
+    public void onPlayerConnectionError(int errorCode, String description) {
         binding.nowPlayingPanel.setPanelState(SlidingUpPanelLayout.PanelState.HIDDEN);
     }
 
     @Override
-    public void playerNoResultsYet() {}
+    public void onPlayerNoResultsYet() {}
 
     @Override
-    public void observerOnStopObserving() {
+    public void onObserverStopObserving() {
         binding.nowPlayingPanel.setPanelState(SlidingUpPanelLayout.PanelState.HIDDEN);
     }
 
     @Override
-    public void systemOnQuit() {
+    public void onSystemQuit() {
         binding.nowPlayingPanel.setPanelState(SlidingUpPanelLayout.PanelState.HIDDEN);
     }
 
     @Override
-    public void inputOnInputRequested(String title, String type, String value) {}
+    public void onInputRequested(String title, String type, String value) {}
 
     private void updateNowPlayingPanel(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                                        PlayerType.PropertyValue getPropertiesResult,

--- a/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
@@ -247,11 +247,13 @@ public abstract class BaseMediaActivity
 
     @Override
     public void onApplicationVolumeChanged(int volume, boolean muted) {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         binding.nowPlayingPanel.setVolumeState(volume, muted);
     }
 
     @Override
     public void onPlayerPropertyChanged(org.xbmc.kore.jsonrpc.notification.Player.NotificationsData notificationsData) {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         binding.nowPlayingPanel.setRepeatShuffleState(notificationsData.property.repeatMode,
                                                       notificationsData.property.shuffled,
                                                       notificationsData.property.partymode);
@@ -261,6 +263,7 @@ public abstract class BaseMediaActivity
     public void onPlayerPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                              PlayerType.PropertyValue getPropertiesResult,
                              ListType.ItemsAll getItemResult) {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         updateNowPlayingPanel(getActivePlayerResult, getPropertiesResult, getItemResult);
         // Start the MediaSession service
         MediaSessionService.startIfNotRunning(this);
@@ -268,6 +271,7 @@ public abstract class BaseMediaActivity
 
     @Override
     public void onPlayerPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult, PlayerType.PropertyValue getPropertiesResult, ListType.ItemsAll getItemResult) {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         updateNowPlayingPanel(getActivePlayerResult, getPropertiesResult, getItemResult);
     }
 
@@ -280,6 +284,7 @@ public abstract class BaseMediaActivity
 
     @Override
     public void onPlayerConnectionError(int errorCode, String description) {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         binding.nowPlayingPanel.setPanelState(SlidingUpPanelLayout.PanelState.HIDDEN);
     }
 
@@ -288,11 +293,13 @@ public abstract class BaseMediaActivity
 
     @Override
     public void onObserverStopObserving() {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         binding.nowPlayingPanel.setPanelState(SlidingUpPanelLayout.PanelState.HIDDEN);
     }
 
     @Override
     public void onSystemQuit() {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         binding.nowPlayingPanel.setPanelState(SlidingUpPanelLayout.PanelState.HIDDEN);
     }
 

--- a/app/src/main/java/org/xbmc/kore/ui/generic/VolumeControllerDialogFragmentListener.java
+++ b/app/src/main/java/org/xbmc/kore/ui/generic/VolumeControllerDialogFragmentListener.java
@@ -141,7 +141,7 @@ public class VolumeControllerDialogFragmentListener extends AppCompatDialogFragm
     }
 
     @Override
-    public void applicationOnVolumeChanged(int volume, boolean muted) {
+    public void onApplicationVolumeChanged(int volume, boolean muted) {
         binding.vcdVolumeLevelIndicator.setVolume(muted, volume);
 
         binding.vcdVolumeMutedIndicator.setVisibility(muted ? View.VISIBLE : View.GONE);

--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListFragment.java
@@ -117,9 +117,9 @@ public class AddonListFragment extends AbstractListFragment {
      * Show the addons
      */
     @Override
-    public void connectionStatusOnSuccess() {
+    public void onConnectionStatusSuccess() {
         boolean refresh = (lastConnectionStatusResult != CONNECTION_SUCCESS);
-        super.connectionStatusOnSuccess();
+        super.onConnectionStatusSuccess();
         if (refresh) onRefresh();
     }
 

--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonsActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonsActivity.java
@@ -142,7 +142,7 @@ public class AddonsActivity extends BaseMediaActivity
     }
 
     @Override
-    public void inputOnInputRequested(String title, String type, String value) {
+    public void onInputRequested(String title, String type, String value) {
         final SendTextDialogFragment dialog =
                 SendTextDialogFragment.newInstance(title);
         dialog.show(getSupportFragmentManager(), null);

--- a/app/src/main/java/org/xbmc/kore/ui/sections/favourites/FavouritesListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/favourites/FavouritesListFragment.java
@@ -36,7 +36,6 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import org.xbmc.kore.R;
 import org.xbmc.kore.host.HostConnectionObserver;
-import org.xbmc.kore.host.HostInfo;
 import org.xbmc.kore.host.HostManager;
 import org.xbmc.kore.jsonrpc.ApiCallback;
 import org.xbmc.kore.jsonrpc.ApiList;
@@ -114,9 +113,9 @@ public class FavouritesListFragment
      * Show the favourites
      */
     @Override
-    public void connectionStatusOnSuccess() {
+    public void onConnectionStatusSuccess() {
         boolean refresh = (lastConnectionStatusResult != CONNECTION_SUCCESS);
-        super.connectionStatusOnSuccess();
+        super.onConnectionStatusSuccess();
         if (refresh) onRefresh();
     }
 

--- a/app/src/main/java/org/xbmc/kore/ui/sections/localfile/LocalMediaFileListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/localfile/LocalMediaFileListFragment.java
@@ -146,13 +146,13 @@ public class LocalMediaFileListFragment extends AbstractListFragment {
      * This fragment doesn't need a Kodi connection to show results
      */
     @Override
-    public void connectionStatusOnError(int errorCode, String description) {}
+    public void onConnectionStatusError(int errorCode, String description) {}
 
     @Override
-    public void connectionStatusOnSuccess() {}
+    public void onConnectionStatusSuccess() {}
 
     @Override
-    public void connectionStatusNoResultsYet() {}
+    public void onConnectionStatusNoResultsYet() {}
 
     private void checkReadStoragePermission() {
         boolean hasStoragePermission =

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
@@ -117,25 +117,25 @@ public class NowPlayingFragment extends Fragment
     }
 
     @Override
-    public void playerOnPropertyChanged(Player.NotificationsData notificationsData) {
+    public void onPlayerPropertyChanged(Player.NotificationsData notificationsData) {
     }
 
     /**
      * HostConnectionObserver.PlayerEventsObserver interface callbacks
      */
-    public void playerOnPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
+    public void onPlayerPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                              PlayerType.PropertyValue getPropertiesResult,
                              ListType.ItemsAll getItemResult) {
         setNowPlayingInfo(getActivePlayerResult, getPropertiesResult, getItemResult);
     }
 
-    public void playerOnPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
+    public void onPlayerPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                               PlayerType.PropertyValue getPropertiesResult,
                               ListType.ItemsAll getItemResult) {
         setNowPlayingInfo(getActivePlayerResult, getPropertiesResult, getItemResult);
     }
 
-    public void playerOnStop() {
+    public void onPlayerStop() {
         stopNowPlayingInfo();
         switchToPanel(R.id.info_panel);
         HostInfo hostInfo = hostManager.getHostInfo();
@@ -143,7 +143,7 @@ public class NowPlayingFragment extends Fragment
         binding.includeInfoPanel.infoMessage.setText(String.format(getString(R.string.connected_to), hostInfo.getName()));
     }
 
-    public void playerOnConnectionError(int errorCode, String description) {
+    public void onPlayerConnectionError(int errorCode, String description) {
         stopNowPlayingInfo();
         switchToPanel(R.id.info_panel);
         HostInfo hostInfo = hostManager.getHostInfo();
@@ -157,7 +157,7 @@ public class NowPlayingFragment extends Fragment
         }
     }
 
-    public void playerNoResultsYet() {
+    public void onPlayerNoResultsYet() {
         // Initialize info panel
         switchToPanel(R.id.info_panel);
         HostInfo hostInfo = hostManager.getHostInfo();
@@ -169,13 +169,13 @@ public class NowPlayingFragment extends Fragment
         binding.includeInfoPanel.infoMessage.setText(null);
     }
 
-    public void systemOnQuit() {
-        playerNoResultsYet();
+    public void onSystemQuit() {
+        onPlayerNoResultsYet();
     }
 
     // Ignore this
-    public void inputOnInputRequested(String title, String type, String value) {}
-    public void observerOnStopObserving() {}
+    public void onInputRequested(String title, String type, String value) {}
+    public void onObserverStopObserving() {}
 
     /**
      * Sets whats playing information

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
@@ -117,8 +117,7 @@ public class NowPlayingFragment extends Fragment
     }
 
     @Override
-    public void onPlayerPropertyChanged(Player.NotificationsData notificationsData) {
-    }
+    public void onPlayerPropertyChanged(Player.NotificationsData notificationsData) { }
 
     /**
      * HostConnectionObserver.PlayerEventsObserver interface callbacks
@@ -126,16 +125,19 @@ public class NowPlayingFragment extends Fragment
     public void onPlayerPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                              PlayerType.PropertyValue getPropertiesResult,
                              ListType.ItemsAll getItemResult) {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         setNowPlayingInfo(getActivePlayerResult, getPropertiesResult, getItemResult);
     }
 
     public void onPlayerPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                               PlayerType.PropertyValue getPropertiesResult,
                               ListType.ItemsAll getItemResult) {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         setNowPlayingInfo(getActivePlayerResult, getPropertiesResult, getItemResult);
     }
 
     public void onPlayerStop() {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         stopNowPlayingInfo();
         switchToPanel(R.id.info_panel);
         HostInfo hostInfo = hostManager.getHostInfo();
@@ -144,6 +146,7 @@ public class NowPlayingFragment extends Fragment
     }
 
     public void onPlayerConnectionError(int errorCode, String description) {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         stopNowPlayingInfo();
         switchToPanel(R.id.info_panel);
         HostInfo hostInfo = hostManager.getHostInfo();
@@ -158,6 +161,7 @@ public class NowPlayingFragment extends Fragment
     }
 
     public void onPlayerNoResultsYet() {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         // Initialize info panel
         switchToPanel(R.id.info_panel);
         HostInfo hostInfo = hostManager.getHostInfo();

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/PlaylistFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/PlaylistFragment.java
@@ -240,6 +240,7 @@ public class PlaylistFragment extends Fragment
 
     @Override
     public void onPlayerPropertyChanged(org.xbmc.kore.jsonrpc.notification.Player.NotificationsData notificationsData) {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         if (notificationsData.property.shuffled != null)
             refreshPlaylist(new GetPlaylist(lastGetActivePlayerResult.type));
     }
@@ -251,6 +252,7 @@ public class PlaylistFragment extends Fragment
     public void onPlayerPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                              PlayerType.PropertyValue getPropertiesResult,
                              ListType.ItemsAll getItemResult) {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         playerState = PLAYER_STATE.PLAYING;
 
         lastGetItemResult = getItemResult;
@@ -276,6 +278,7 @@ public class PlaylistFragment extends Fragment
     public void onPlayerPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                               PlayerType.PropertyValue getPropertiesResult,
                               ListType.ItemsAll getItemResult) {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         playerState = PLAYER_STATE.PAUSED;
 
         lastGetItemResult = getItemResult;
@@ -290,6 +293,7 @@ public class PlaylistFragment extends Fragment
 
     @Override
     public void onPlayerStop() {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         playerState = PLAYER_STATE.STOPPED;
 
         if (lastGetActivePlayerResult != null)
@@ -302,6 +306,7 @@ public class PlaylistFragment extends Fragment
 
     @Override
     public void onPlayerConnectionError(int errorCode, String description) {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         playerState = PLAYER_STATE.CONNECTION_ERROR;
 
         HostInfo hostInfo = hostManager.getHostInfo();
@@ -318,6 +323,7 @@ public class PlaylistFragment extends Fragment
 
     @Override
     public void onPlayerNoResultsYet() {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         playerState = PLAYER_STATE.NO_RESULTS_YET;
 
         // Initialize info panel
@@ -339,11 +345,13 @@ public class PlaylistFragment extends Fragment
     // Ignore this
     @Override
     public void onInputRequested(String title, String type, String value) {}
+
     @Override
     public void onObserverStopObserving() {}
 
     @Override
     public void onPlaylistClear(int playlistId) {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         Iterator<String> it = playlists.keySet().iterator();
         while (it.hasNext()) {
             String key = it.next();
@@ -359,6 +367,7 @@ public class PlaylistFragment extends Fragment
 
     @Override
     public void onPlaylistsAvailable(ArrayList<GetPlaylist.GetPlaylistResult> playlists) {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         updatePlaylists(playlists);
 
         if ((playerState == PLAYER_STATE.PLAYING) &&

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/PlaylistFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/PlaylistFragment.java
@@ -196,7 +196,7 @@ public class PlaylistFragment extends Fragment
         if (itemId == R.id.action_clear_playlist) {
             PlaylistHolder playlistHolder = playlists.get(binding.playlistsBar.getSelectedPlaylistType());
             if (playlistHolder != null) {
-                playlistOnClear(playlistHolder.getPlaylistId());
+                onPlaylistClear(playlistHolder.getPlaylistId());
                 Playlist.Clear action = new Playlist.Clear(playlistHolder.getPlaylistId());
                 action.execute(hostManager.getConnection(), defaultStringActionCallback, callbackHandler);
             }
@@ -228,7 +228,7 @@ public class PlaylistFragment extends Fragment
                     public void onError(int errorCode, String description) {
                         refreshingPlaylist = false;
 
-                        playerOnConnectionError(errorCode, description);
+                        onPlayerConnectionError(errorCode, description);
                     }
                 }, callbackHandler);
     }
@@ -239,7 +239,7 @@ public class PlaylistFragment extends Fragment
     private final ApiCallback<String> defaultStringActionCallback = ApiMethod.getDefaultActionCallback();
 
     @Override
-    public void playerOnPropertyChanged(org.xbmc.kore.jsonrpc.notification.Player.NotificationsData notificationsData) {
+    public void onPlayerPropertyChanged(org.xbmc.kore.jsonrpc.notification.Player.NotificationsData notificationsData) {
         if (notificationsData.property.shuffled != null)
             refreshPlaylist(new GetPlaylist(lastGetActivePlayerResult.type));
     }
@@ -248,7 +248,7 @@ public class PlaylistFragment extends Fragment
      * HostConnectionObserver.PlayerEventsObserver interface callbacks
      */
     @Override
-    public void playerOnPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
+    public void onPlayerPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                              PlayerType.PropertyValue getPropertiesResult,
                              ListType.ItemsAll getItemResult) {
         playerState = PLAYER_STATE.PLAYING;
@@ -273,7 +273,7 @@ public class PlaylistFragment extends Fragment
     }
 
     @Override
-    public void playerOnPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
+    public void onPlayerPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                               PlayerType.PropertyValue getPropertiesResult,
                               ListType.ItemsAll getItemResult) {
         playerState = PLAYER_STATE.PAUSED;
@@ -289,7 +289,7 @@ public class PlaylistFragment extends Fragment
     }
 
     @Override
-    public void playerOnStop() {
+    public void onPlayerStop() {
         playerState = PLAYER_STATE.STOPPED;
 
         if (lastGetActivePlayerResult != null)
@@ -301,7 +301,7 @@ public class PlaylistFragment extends Fragment
     }
 
     @Override
-    public void playerOnConnectionError(int errorCode, String description) {
+    public void onPlayerConnectionError(int errorCode, String description) {
         playerState = PLAYER_STATE.CONNECTION_ERROR;
 
         HostInfo hostInfo = hostManager.getHostInfo();
@@ -317,7 +317,7 @@ public class PlaylistFragment extends Fragment
     }
 
     @Override
-    public void playerNoResultsYet() {
+    public void onPlayerNoResultsYet() {
         playerState = PLAYER_STATE.NO_RESULTS_YET;
 
         // Initialize info panel
@@ -332,18 +332,18 @@ public class PlaylistFragment extends Fragment
     }
 
     @Override
-    public void systemOnQuit() {
-        playerNoResultsYet();
+    public void onSystemQuit() {
+        onPlayerNoResultsYet();
     }
 
     // Ignore this
     @Override
-    public void inputOnInputRequested(String title, String type, String value) {}
+    public void onInputRequested(String title, String type, String value) {}
     @Override
-    public void observerOnStopObserving() {}
+    public void onObserverStopObserving() {}
 
     @Override
-    public void playlistOnClear(int playlistId) {
+    public void onPlaylistClear(int playlistId) {
         Iterator<String> it = playlists.keySet().iterator();
         while (it.hasNext()) {
             String key = it.next();
@@ -358,12 +358,12 @@ public class PlaylistFragment extends Fragment
     }
 
     @Override
-    public void playlistsAvailable(ArrayList<GetPlaylist.GetPlaylistResult> playlists) {
+    public void onPlaylistsAvailable(ArrayList<GetPlaylist.GetPlaylistResult> playlists) {
         updatePlaylists(playlists);
 
         if ((playerState == PLAYER_STATE.PLAYING) &&
             (hostManager.getConnection().getProtocol() == HostConnection.PROTOCOL_TCP))
-            // if item is currently playing displaying is already handled by playerOnPlay callback
+            // if item is currently playing displaying is already handled by onPlayerPlay callback
             return;
 
         // BUG: When playing movies playlist stops, audio tab gets selected when it contains a playlist.
@@ -376,8 +376,8 @@ public class PlaylistFragment extends Fragment
     }
 
     @Override
-    public void playlistOnError(int errorCode, String description) {
-        playerOnConnectionError(errorCode, description);
+    public void onPlaylistError(int errorCode, String description) {
+        onPlayerConnectionError(errorCode, description);
     }
 
     private void updatePlaylists(ArrayList<GetPlaylist.GetPlaylistResult> playlists) {

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
@@ -357,40 +357,37 @@ public class RemoteActivity extends BaseActivity
     private String lastImageUrl = null;
 
     @Override
-    public void onPlayerPropertyChanged(org.xbmc.kore.jsonrpc.notification.Player.NotificationsData notificationsData) {
-
-    }
+    public void onPlayerPropertyChanged(org.xbmc.kore.jsonrpc.notification.Player.NotificationsData notificationsData) {}
 
     public void onPlayerPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                              PlayerType.PropertyValue getPropertiesResult,
                              ListType.ItemsAll getItemResult) {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         String imageUrl = (TextUtils.isEmpty(getItemResult.fanart)) ?
-                getItemResult.thumbnail : getItemResult.fanart;
+                          getItemResult.thumbnail : getItemResult.fanart;
         if ((imageUrl != null) && !imageUrl.equals(lastImageUrl)) {
             setImageViewBackground(imageUrl);
         }
         lastImageUrl = imageUrl;
-
         MediaSessionService.startIfNotRunning(this);
     }
 
     public void onPlayerPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                               PlayerType.PropertyValue getPropertiesResult,
                               ListType.ItemsAll getItemResult) {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         onPlayerPlay(getActivePlayerResult, getPropertiesResult, getItemResult);
     }
 
     public void onPlayerStop() {
-        LogUtils.LOGD(TAG, "Player stopping");
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         if (lastImageUrl != null) {
             setImageViewBackground(null);
         }
         lastImageUrl = null;
     }
 
-    public void onPlayerNoResultsYet() {
-        // Do nothing
-    }
+    public void onPlayerNoResultsYet() { }
 
     public void onPlayerConnectionError(int errorCode, String description) {
         onPlayerStop();
@@ -402,6 +399,7 @@ public class RemoteActivity extends BaseActivity
     }
 
     public void onInputRequested(String title, String type, String value) {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         SendTextDialogFragment dialog =
                 SendTextDialogFragment.newInstance(title);
         dialog.show(getSupportFragmentManager(), null);

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
@@ -357,11 +357,11 @@ public class RemoteActivity extends BaseActivity
     private String lastImageUrl = null;
 
     @Override
-    public void playerOnPropertyChanged(org.xbmc.kore.jsonrpc.notification.Player.NotificationsData notificationsData) {
+    public void onPlayerPropertyChanged(org.xbmc.kore.jsonrpc.notification.Player.NotificationsData notificationsData) {
 
     }
 
-    public void playerOnPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
+    public void onPlayerPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                              PlayerType.PropertyValue getPropertiesResult,
                              ListType.ItemsAll getItemResult) {
         String imageUrl = (TextUtils.isEmpty(getItemResult.fanart)) ?
@@ -374,13 +374,13 @@ public class RemoteActivity extends BaseActivity
         MediaSessionService.startIfNotRunning(this);
     }
 
-    public void playerOnPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
+    public void onPlayerPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                               PlayerType.PropertyValue getPropertiesResult,
                               ListType.ItemsAll getItemResult) {
-        playerOnPlay(getActivePlayerResult, getPropertiesResult, getItemResult);
+        onPlayerPlay(getActivePlayerResult, getPropertiesResult, getItemResult);
     }
 
-    public void playerOnStop() {
+    public void onPlayerStop() {
         LogUtils.LOGD(TAG, "Player stopping");
         if (lastImageUrl != null) {
             setImageViewBackground(null);
@@ -388,26 +388,26 @@ public class RemoteActivity extends BaseActivity
         lastImageUrl = null;
     }
 
-    public void playerNoResultsYet() {
+    public void onPlayerNoResultsYet() {
         // Do nothing
     }
 
-    public void playerOnConnectionError(int errorCode, String description) {
-        playerOnStop();
+    public void onPlayerConnectionError(int errorCode, String description) {
+        onPlayerStop();
     }
 
-    public void systemOnQuit() {
+    public void onSystemQuit() {
         Toast.makeText(this, R.string.xbmc_quit, Toast.LENGTH_SHORT).show();
-        playerOnStop();
+        onPlayerStop();
     }
 
-    public void inputOnInputRequested(String title, String type, String value) {
+    public void onInputRequested(String title, String type, String value) {
         SendTextDialogFragment dialog =
                 SendTextDialogFragment.newInstance(title);
         dialog.show(getSupportFragmentManager(), null);
     }
 
-    public void observerOnStopObserving() {}
+    public void onObserverStopObserving() {}
 
     /**
      * Now playing fragment listener

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteFragment.java
@@ -220,7 +220,7 @@ public class RemoteFragment extends Fragment
     }
 
     @Override
-    public void playerOnPropertyChanged(org.xbmc.kore.jsonrpc.notification.Player.NotificationsData notificationsData) {
+    public void onPlayerPropertyChanged(org.xbmc.kore.jsonrpc.notification.Player.NotificationsData notificationsData) {
         binding.mediaActionsBar.setRepeatShuffleState(notificationsData.property.repeatMode,
                                                       notificationsData.property.shuffled,
                                                       notificationsData.property.partymode);
@@ -229,19 +229,19 @@ public class RemoteFragment extends Fragment
     /**
      * HostConnectionObserver.PlayerEventsObserver interface callbacks
      */
-    public void playerOnPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
+    public void onPlayerPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                              PlayerType.PropertyValue getPropertiesResult,
                              ListType.ItemsAll getItemResult) {
         setNowPlayingInfo(getActivePlayerResult, getPropertiesResult, getItemResult);
     }
 
-    public void playerOnPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
+    public void onPlayerPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                               PlayerType.PropertyValue getPropertiesResult,
                               ListType.ItemsAll getItemResult) {
         setNowPlayingInfo(getActivePlayerResult, getPropertiesResult, getItemResult);
     }
 
-    public void playerOnStop() {
+    public void onPlayerStop() {
         stopNowPlayingInfo();
         switchToPanel(R.id.info_panel);
         HostInfo hostInfo = hostManager.getHostInfo();
@@ -249,7 +249,7 @@ public class RemoteFragment extends Fragment
         binding.includeInfoPanel.infoMessage.setText(String.format(getString(R.string.connected_to), hostInfo.getName()));
     }
 
-    public void playerOnConnectionError(int errorCode, String description) {
+    public void onPlayerConnectionError(int errorCode, String description) {
         stopNowPlayingInfo();
         switchToPanel(R.id.info_panel);
         HostInfo hostInfo = hostManager.getHostInfo();
@@ -263,7 +263,7 @@ public class RemoteFragment extends Fragment
         }
     }
 
-    public void playerNoResultsYet() {
+    public void onPlayerNoResultsYet() {
         // Initialize info panel
         switchToPanel(R.id.info_panel);
         HostInfo hostInfo = hostManager.getHostInfo();
@@ -275,19 +275,19 @@ public class RemoteFragment extends Fragment
         binding.includeInfoPanel.infoMessage.setText(null);
     }
 
-    public void systemOnQuit() {
-        playerNoResultsYet();
+    public void onSystemQuit() {
+        onPlayerNoResultsYet();
     }
 
     @Override
-    public void applicationOnVolumeChanged(int volume, boolean muted) {
+    public void onApplicationVolumeChanged(int volume, boolean muted) {
         binding.mediaActionsBar.setVolumeState(volume, muted);
     }
 
 
     // Ignore this
-    public void inputOnInputRequested(String title, String type, String value) {}
-    public void observerOnStopObserving() {}
+    public void onInputRequested(String title, String type, String value) {}
+    public void onObserverStopObserving() {}
 
     /**
      * Sets whats playing information

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteFragment.java
@@ -221,6 +221,7 @@ public class RemoteFragment extends Fragment
 
     @Override
     public void onPlayerPropertyChanged(org.xbmc.kore.jsonrpc.notification.Player.NotificationsData notificationsData) {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         binding.mediaActionsBar.setRepeatShuffleState(notificationsData.property.repeatMode,
                                                       notificationsData.property.shuffled,
                                                       notificationsData.property.partymode);
@@ -232,16 +233,19 @@ public class RemoteFragment extends Fragment
     public void onPlayerPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                              PlayerType.PropertyValue getPropertiesResult,
                              ListType.ItemsAll getItemResult) {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         setNowPlayingInfo(getActivePlayerResult, getPropertiesResult, getItemResult);
     }
 
     public void onPlayerPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                               PlayerType.PropertyValue getPropertiesResult,
                               ListType.ItemsAll getItemResult) {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         setNowPlayingInfo(getActivePlayerResult, getPropertiesResult, getItemResult);
     }
 
     public void onPlayerStop() {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         stopNowPlayingInfo();
         switchToPanel(R.id.info_panel);
         HostInfo hostInfo = hostManager.getHostInfo();
@@ -250,6 +254,7 @@ public class RemoteFragment extends Fragment
     }
 
     public void onPlayerConnectionError(int errorCode, String description) {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         stopNowPlayingInfo();
         switchToPanel(R.id.info_panel);
         HostInfo hostInfo = hostManager.getHostInfo();
@@ -264,6 +269,7 @@ public class RemoteFragment extends Fragment
     }
 
     public void onPlayerNoResultsYet() {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         // Initialize info panel
         switchToPanel(R.id.info_panel);
         HostInfo hostInfo = hostManager.getHostInfo();
@@ -281,6 +287,7 @@ public class RemoteFragment extends Fragment
 
     @Override
     public void onApplicationVolumeChanged(int volume, boolean muted) {
+        if (binding == null) return; // If receiving this after onDestroy, ignore
         binding.mediaActionsBar.setVolumeState(volume, muted);
     }
 

--- a/app/src/main/java/org/xbmc/kore/utils/RemoteVolumeProviderCompat.java
+++ b/app/src/main/java/org/xbmc/kore/utils/RemoteVolumeProviderCompat.java
@@ -54,7 +54,7 @@ public class RemoteVolumeProviderCompat extends VolumeProviderCompat implements 
     }
 
     @Override
-    public void applicationOnVolumeChanged(int volume, boolean muted) {
+    public void onApplicationVolumeChanged(int volume, boolean muted) {
         setCurrentVolume(volume);
     }
 }


### PR DESCRIPTION
Rename HostConnectionObserver interface methods
To avoid null pointer exceptions, make sure that on callbacks from Kodi only access Views if they're available
