### PR TITLE
Fix Addon and Kodi files navigation

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonDetailsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonDetailsFragment.java
@@ -36,9 +36,8 @@ public class AddonDetailsFragment extends AbstractTabsFragment {
         String name = dataHolder.getTitle();
         String path = details.getString(AddonInfoFragment.BUNDLE_KEY_ADDONID);
 
-        MediaFileListFragment.FileLocation rootPath = new MediaFileListFragment.FileLocation(name, "plugin://" + path, true);
-        rootPath.setRootDir(true);
-        details.putParcelable(MediaFileListFragment.CURRENT_LOCATION, rootPath);
+        details.putParcelable(MediaFileListFragment.CURRENT_LOCATION,
+                              new MediaFileListFragment.FileLocation(name, "plugin://" + path, true, null, true));
         details.putBoolean(MediaFileListFragment.DELAY_LOAD, true);
         return details;
     }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListContainerFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListContainerFragment.java
@@ -71,7 +71,8 @@ public class AddonListContainerFragment extends AbstractTabsFragment {
             Bundle args = (Bundle) arguments.clone();
             String name = prefs.getString(Settings.getNameBookmarkedAddonsPrefKey(hostId) + path, Settings.DEFAULT_PREF_NAME_BOOKMARKED_ADDON);
             args.putParcelable(MediaFileListFragment.CURRENT_LOCATION,
-                                    new MediaFileListFragment.FileLocation(name, "plugin://" + path, true));
+                               new MediaFileListFragment.FileLocation(name, "plugin://" + path, true, null, true));
+            args.putBoolean(MediaFileListFragment.DELAY_LOAD, true);
             args.putString(MediaFileListFragment.MEDIA_TYPE, Files.Media.FILES);
             tabsAdapter.addTab(MediaFileListFragment.class, args, name, ++baseFragmentId);
         }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/file/FileListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/file/FileListFragment.java
@@ -70,13 +70,8 @@ public class FileListFragment
     @Override
     public boolean onBackPressed() {
         // Tell current fragment to move up one directory, if possible
-        MediaFileListFragment curPage = (MediaFileListFragment)getCurrentSelectedFragment();
-        if (curPage != null && !curPage.atRootDirectory()) {
-            curPage.navigateToParentDir();
-            return true;
-        }
-        // Not handled, let the activity handle it
-        return false;
+        MediaFileListFragment frag = (MediaFileListFragment)getCurrentSelectedFragment();
+        return (frag != null) && frag.navigateToParentDir();
     }
 
     @Override

--- a/app/src/main/java/org/xbmc/kore/ui/sections/localfile/LocalFileListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/localfile/LocalFileListFragment.java
@@ -91,13 +91,8 @@ public class LocalFileListFragment extends AbstractTabsFragment
     @Override
     public boolean onBackPressed() {
         // Tell current fragment to move up one directory, if possible
-        LocalMediaFileListFragment curPage = (LocalMediaFileListFragment)getCurrentSelectedFragment();
-        if (curPage != null) {
-            curPage.navigateToParentDir();
-            return true;
-        }
-        // Not handled, let the activity handle it
-        return false;
+        LocalMediaFileListFragment frag = (LocalMediaFileListFragment)getCurrentSelectedFragment();
+        return (frag != null) && frag.navigateToParentDir();
     }
 
     @Override

--- a/app/src/main/java/org/xbmc/kore/ui/sections/localfile/LocalMediaFileListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/localfile/LocalMediaFileListFragment.java
@@ -185,12 +185,17 @@ public class LocalMediaFileListFragment extends AbstractListFragment {
         }
     }
 
-    public void navigateToParentDir() {
-        if (isRootDirectory(currentDirLocation)) return;
+    /**
+     * Tries to navigate to the parent directory, returning whether it is possible
+     * @return Whether it is possible to navigate
+     */
+    public boolean navigateToParentDir() {
+        if (isRootDirectory(currentDirLocation)) return false;
 
         // Emulate a click on ..
         LocalFileLocation selection = ((MediaPictureListAdapter) getAdapter()).getItem(0);
         if (selection != null) handleFileSelect(selection);
+        return true;
     }
 
     public boolean isRootDirectory(LocalFileLocation dir) {


### PR DESCRIPTION
Navigation on addons was broken, given that relationships between parent/child directories wasn relying on the same rules as in a filesystem, which is not valid in addons.
This correctly sets the relationship, saving it in the FileLocation structure, and using it to do the navigation.
It also simplifies the code, given that it is no longer necessary to keep the root contents available, and it is easier to check if we're at root level.