### PR TITLE
Improve fragment transactions

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/AbstractFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractFragment.java
@@ -25,16 +25,6 @@ public class AbstractFragment extends Fragment {
 
     private DataHolder dataHolder;
 
-    public void setDataHolder(DataHolder dataHolder) {
-        this.dataHolder = dataHolder;
-        Bundle bundle = getArguments();
-        if (bundle == null) {
-            setArguments(dataHolder.getBundle());
-        } else {
-            bundle.putAll(dataHolder.getBundle());
-        }
-    }
-
     public DataHolder getDataHolder() {
         return dataHolder;
     }
@@ -42,12 +32,7 @@ public class AbstractFragment extends Fragment {
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        if( this.dataHolder == null ) {
-            this.dataHolder = new DataHolder(-1);
-        }
-
-        this.dataHolder.setBundle(getArguments());
+        this.dataHolder = new DataHolder(getArguments());
     }
 
     public static class DataHolder {

--- a/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
@@ -111,8 +111,7 @@ abstract public class AbstractInfoFragment
             });
 
     /**
-     * Use {@link #setDataHolder(DataHolder)}
-     * to provide the required info after creating a new instance of this Fragment
+     * Set args with {@link DataHolder} to provide the required info after creating a new instance of this Fragment
      */
     public AbstractInfoFragment() {
         super();

--- a/app/src/main/java/org/xbmc/kore/ui/AbstractTabsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractTabsFragment.java
@@ -49,8 +49,7 @@ abstract public class AbstractTabsFragment
     private SharedPreferences preferences;
 
     /**
-     * Use {@link #setDataHolder(AbstractInfoFragment.DataHolder)} to provide the required info
-     * after creating a new instance of this Fragment
+     * Set args with {@link #(AbstractInfoFragment.DataHolder)} to provide the required info
      */
     public AbstractTabsFragment() {
         super();

--- a/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
@@ -131,6 +131,7 @@ public abstract class BaseMediaActivity
             getSupportFragmentManager()
                     .beginTransaction()
                     .add(R.id.fragment_container, fragment, fragmentTitle)
+                    .setReorderingAllowed(true)
                     .commit();
         }
 
@@ -234,6 +235,7 @@ public abstract class BaseMediaActivity
     }
 
     protected void showFragment(AbstractFragment fragment, ImageView sharedImageView, AbstractFragment.DataHolder dataHolder) {
+        fragment.setArguments(dataHolder.getBundle());
         FragmentTransaction fragTrans = getSupportFragmentManager().beginTransaction();
 
         // Set up transitions
@@ -242,6 +244,7 @@ public abstract class BaseMediaActivity
 
         fragTrans.replace(R.id.fragment_container, fragment, getActionBarTitle())
                  .addToBackStack(null)
+                 .setReorderingAllowed(true)
                  .commit();
     }
 

--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonsActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonsActivity.java
@@ -130,10 +130,8 @@ public class AddonsActivity extends BaseMediaActivity
         // Replace list fragment
         final AbstractFragment addonDetailsFragment =
                 bundle.getBoolean(AddonInfoFragment.BUNDLE_KEY_BROWSABLE)
-            ? new AddonDetailsFragment()
-            : new AddonInfoFragment()
-            ;
-        addonDetailsFragment.setDataHolder(vh.dataHolder);
+                ? new AddonDetailsFragment()
+                : new AddonInfoFragment();
         vh.dataHolder.setSquarePoster(true);
         vh.dataHolder.setPosterTransitionName(vh.artView.getTransitionName());
         showFragment(addonDetailsFragment, vh.artView, vh.dataHolder);

--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/MusicActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/MusicActivity.java
@@ -176,11 +176,8 @@ public class MusicActivity extends BaseMediaActivity
 
         // Replace list fragment
         final ArtistInfoFragment artistInfoFragment = new ArtistInfoFragment();
-        artistInfoFragment.setDataHolder(dataHolder);
         dataHolder.setSquarePoster(true);
-
         showFragment(artistInfoFragment, sharedImageView, dataHolder);
-
         updateActionBar(selectedArtistName, true);
     }
 
@@ -191,10 +188,7 @@ public class MusicActivity extends BaseMediaActivity
         // Replace list fragment
         final AbstractInfoFragment albumInfoFragment = new AlbumInfoFragment();
         dataHolder.setSquarePoster(true);
-        albumInfoFragment.setDataHolder(dataHolder);
-
         showFragment(albumInfoFragment, sharedImageView, dataHolder);
-
         updateActionBar(selectedAlbumTitle, true);
     }
 
@@ -211,6 +205,7 @@ public class MusicActivity extends BaseMediaActivity
                 .setCustomAnimations(R.anim.fragment_details_enter, 0, R.anim.fragment_list_popenter, 0)
                 .replace(R.id.fragment_container, albumListFragment)
                 .addToBackStack(null)
+                .setReorderingAllowed(true)
                 .commit();
 
         updateActionBar(selectedGenreTitle, true);
@@ -223,10 +218,7 @@ public class MusicActivity extends BaseMediaActivity
         // Replace list fragment
         final MusicVideoInfoFragment musicVideoInfoFragment = new MusicVideoInfoFragment();
         dataHolder.setSquarePoster(true);
-        musicVideoInfoFragment.setDataHolder(dataHolder);
-
         showFragment(musicVideoInfoFragment, sharedImageView, dataHolder);
-
         updateActionBar(selectedMusicVideoTitle, true);
     }
 }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/hosts/AddHostActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/hosts/AddHostActivity.java
@@ -55,6 +55,7 @@ public class AddHostActivity extends BaseActivity
             getSupportFragmentManager()
                     .beginTransaction()
                     .add(R.id.fragment_container, firstStep)
+                    .setReorderingAllowed(true)
                     .commit();
         }
 
@@ -163,6 +164,7 @@ public class AddHostActivity extends BaseActivity
         getSupportFragmentManager()
                 .beginTransaction()
                 .replace(R.id.fragment_container, fragment)
+                .setReorderingAllowed(true)
                 .commit();
     }
 }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/hosts/EditHostActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/hosts/EditHostActivity.java
@@ -90,6 +90,7 @@ public class EditHostActivity extends BaseActivity implements
             getSupportFragmentManager()
                     .beginTransaction()
                     .add(R.id.fragment_container, editFragment)
+                    .setReorderingAllowed(true)
                     .commit();
         }
         setupActionBar();

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
@@ -55,10 +55,11 @@ import org.xbmc.kore.utils.LogUtils;
 import org.xbmc.kore.utils.TabsAdapter;
 import org.xbmc.kore.utils.UIUtils;
 
-public class RemoteActivity extends BaseActivity
+public class RemoteActivity
+        extends BaseActivity
         implements HostConnectionObserver.PlayerEventsObserver,
-        NowPlayingFragment.NowPlayingListener,
-        SendTextDialogFragment.SendTextDialogListener {
+                   NowPlayingFragment.NowPlayingListener,
+                   SendTextDialogFragment.SendTextDialogListener {
     private static final String TAG = LogUtils.makeLogTag(RemoteActivity.class);
 
     private static final int NOWPLAYING_FRAGMENT_ID = 1;

--- a/app/src/main/java/org/xbmc/kore/ui/sections/settings/SettingsActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/settings/SettingsActivity.java
@@ -50,8 +50,9 @@ public class SettingsActivity extends BaseActivity {
         FragmentManager fm = getSupportFragmentManager();
         if (fm.findFragmentByTag("settings-fragment") == null) {
             fm.beginTransaction()
-                    .replace(R.id.fragment_container, new SettingsFragment(), "settings-fragment")
-                    .commit();
+              .replace(R.id.fragment_container, SettingsFragment.class, null, "settings-fragment")
+              .setReorderingAllowed(true)
+              .commit();
         }
     }
 

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/MoviesActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/MoviesActivity.java
@@ -109,10 +109,7 @@ public class MoviesActivity extends BaseMediaActivity
         selectedMovieId = vh.dataHolder.getId();
 
         final MovieInfoFragment movieInfoFragment = new MovieInfoFragment();
-        movieInfoFragment.setDataHolder(vh.dataHolder);
-
         showFragment(movieInfoFragment, vh.artView, vh.dataHolder);
-
         updateActionBar(selectedMovieTitle, true);
     }
 }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRActivity.java
@@ -168,6 +168,7 @@ public class PVRActivity extends BaseMediaActivity
 
         fragTrans.replace(R.id.fragment_container, pvrEPGFragment)
                  .addToBackStack(null)
+                 .setReorderingAllowed(true)
                  .commit();
         updateActionBar(getActionBarTitle(), true);
     }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowsActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowsActivity.java
@@ -15,6 +15,8 @@
  */
 package org.xbmc.kore.ui.sections.video;
 
+import static org.xbmc.kore.ui.sections.video.TVShowEpisodeInfoFragment.BUNDLE_KEY_TVSHOWID;
+
 import android.os.Bundle;
 import android.transition.TransitionInflater;
 import android.view.MenuItem;
@@ -117,7 +119,6 @@ public class TVShowsActivity extends BaseMediaActivity
 
         // Replace list fragment
         final TVShowInfoFragment tvshowDetailsFragment = new TVShowInfoFragment();
-        tvshowDetailsFragment.setDataHolder(vh.dataHolder);
         showFragment(tvshowDetailsFragment, vh.artView, vh.dataHolder);
         updateActionBar(selectedTVShowTitle, true);
     }
@@ -138,6 +139,7 @@ public class TVShowsActivity extends BaseMediaActivity
                 .setCustomAnimations(R.anim.fragment_details_enter, 0, R.anim.fragment_list_popenter, 0)
                 .replace(R.id.fragment_container, fragment)
                 .addToBackStack(null)
+                .setReorderingAllowed(true)
                 .commit();
         selectedSeasonTitle = String.format(getString(R.string.season_number), seasonId);
         updateActionBar(selectedSeasonTitle, true);
@@ -152,9 +154,8 @@ public class TVShowsActivity extends BaseMediaActivity
 
         // Replace list fragment
         TVShowEpisodeInfoFragment fragment = new TVShowEpisodeInfoFragment();
-        fragment.setDataHolder(dh);
-        fragment.setTvshowId(tvshowId);
-        startFragment(fragment);
+        dh.getBundle().putInt(BUNDLE_KEY_TVSHOWID, tvshowId);
+        startFragment(fragment, dh);
         updateActionBar(selectedTVShowTitle, true);
     }
 
@@ -165,23 +166,24 @@ public class TVShowsActivity extends BaseMediaActivity
                                   TVShowEpisodeListFragment.ViewHolder viewHolder) {
         selectedEpisodeId = viewHolder.dataHolder.getId();
         TVShowEpisodeInfoFragment fragment = new TVShowEpisodeInfoFragment();
-        fragment.setDataHolder(viewHolder.dataHolder);
-        fragment.setTvshowId(tvshowId);
-        startFragment(fragment);
+        viewHolder.dataHolder.getBundle().putInt(BUNDLE_KEY_TVSHOWID, tvshowId);
+        startFragment(fragment, viewHolder.dataHolder);
         updateActionBar(selectedTVShowTitle, true);
     }
 
-    private void startFragment(AbstractFragment fragment) {
+    private void startFragment(AbstractFragment fragment, AbstractFragment.DataHolder dataHolder) {
+        fragment.setArguments(dataHolder.getBundle());
         // Replace list fragment
         FragmentTransaction fragTrans = getSupportFragmentManager().beginTransaction();
 
         // Set up transitions
-            fragment.setEnterTransition(TransitionInflater.from(this)
-                                                          .inflateTransition(R.transition.media_details));
+        fragment.setEnterTransition(TransitionInflater.from(this)
+                                                      .inflateTransition(R.transition.media_details));
         fragment.setReturnTransition(null);
 
         fragTrans.replace(R.id.fragment_container, fragment)
                  .addToBackStack(null)
+                 .setReorderingAllowed(true)
                  .commit();
     }
 

--- a/app/src/main/res/layout/activity_host_wizard.xml
+++ b/app/src/main/res/layout/activity_host_wizard.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
+<androidx.fragment.app.FragmentContainerView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
     android:id="@+id/fragment_container"
-    tools:ignore="MergeRootFrame">
-
-</FrameLayout>
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -22,7 +22,7 @@
 
     <include layout="@layout/toolbar_default"/>
 
-    <FrameLayout
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"/>

--- a/app/src/main/res/layout/fragment_tvshow_progress.xml
+++ b/app/src/main/res/layout/fragment_tvshow_progress.xml
@@ -71,7 +71,7 @@
         app:dividerInsetStart="@dimen/default_padding"
         app:dividerInsetEnd="@dimen/default_padding"/>
 
-    <FrameLayout
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/cast_fragment"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"/>

--- a/app/src/main/res/layout/now_playing_panel.xml
+++ b/app/src/main/res/layout/now_playing_panel.xml
@@ -18,7 +18,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <FrameLayout
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>


### PR DESCRIPTION
Improve fragment transactions according to current Android standards, namely:
- use `setReorderingAllowed(true)` if possible
- use `FragmentContainerView` to host fragments
This implied removing the method `setDataHolder` on fragments, and make them get all the information from their arguments (which they were already doing).
Still to do: Instantiate the fragments in `FragmentTransition.replace` via their `Class` instead of passing an explicit object. Not done now because it implies changing up the animations, which will be done later.