### PR TITLE
Replace Toast messages by Snackbars

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/AbstractCursorListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractCursorListFragment.java
@@ -29,7 +29,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -50,6 +49,7 @@ import org.xbmc.kore.service.library.SyncItem;
 import org.xbmc.kore.service.library.SyncUtils;
 import org.xbmc.kore.ui.viewgroups.GridRecyclerView;
 import org.xbmc.kore.utils.LogUtils;
+import org.xbmc.kore.utils.UIUtils;
 
 import de.greenrobot.event.EventBus;
 
@@ -211,6 +211,8 @@ public abstract class AbstractCursorListFragment
 	 * @param event Media Sync Event
 	 */
 	protected void onSyncProcessEnded(MediaSyncEvent event) {
+		if (!isResumed() || getView() == null) return;
+
         boolean silentSync = false;
         if (event.syncExtras != null) {
             silentSync = event.syncExtras.getBoolean(LibrarySyncService.SILENT_SYNC, false);
@@ -221,14 +223,13 @@ public abstract class AbstractCursorListFragment
 			if (event.status == MediaSyncEvent.STATUS_SUCCESS) {
 				refreshList();
                 if (!silentSync) {
-                    Toast.makeText(getActivity(), R.string.sync_successful, Toast.LENGTH_SHORT)
-                        .show();
+					UIUtils.showSnackbar(getView(), R.string.sync_successful);
                 }
             } else if (!silentSync) {
-			    String msg = (event.errorCode == ApiException.API_ERROR) ?
-					String.format(getString(R.string.error_while_syncing), event.errorMessage) :
-					getString(R.string.unable_to_connect_to_xbmc);
-				Toast.makeText(getActivity(), msg, Toast.LENGTH_SHORT).show();
+				String msg = (event.errorCode == ApiException.API_ERROR) ?
+							 String.format(getString(R.string.error_while_syncing), event.errorMessage) :
+							 getString(R.string.unable_to_connect_to_xbmc);
+				UIUtils.showSnackbar(getView(), msg);
 			}
 		}
 	}

--- a/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
@@ -37,7 +37,6 @@ import android.view.View;
 import android.view.ViewAnimationUtils;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
-import android.widget.Toast;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
@@ -105,8 +104,7 @@ abstract public class AbstractInfoFragment
                 if (isGranted) {
                     binding.infoActionDownload.performClick();
                 } else {
-                    Toast.makeText(getActivity(), R.string.write_storage_permission_denied, Toast.LENGTH_SHORT)
-                         .show();
+                    UIUtils.showSnackbar(getView(), R.string.write_storage_permission_denied);
                 }
             });
 
@@ -245,8 +243,7 @@ abstract public class AbstractInfoFragment
     @Override
     public void onRefresh () {
         if (getRefreshItem() == null) {
-            Toast.makeText(getActivity(), R.string.Refreshing_not_implemented_for_this_item,
-                           Toast.LENGTH_SHORT).show();
+            UIUtils.showSnackbar(getView(), R.string.Refreshing_not_implemented_for_this_item);
             binding.swipeRefreshLayout.setRefreshing(false);
             return;
         }
@@ -348,7 +345,7 @@ abstract public class AbstractInfoFragment
 
     protected void playItemOnKodi(PlaylistType.Item item) {
         if (item == null) {
-            Toast.makeText(getActivity(), R.string.no_item_available_to_play, Toast.LENGTH_SHORT).show();
+            UIUtils.showSnackbar(getView(), R.string.no_item_available_to_play);
             return;
         }
 
@@ -363,10 +360,8 @@ abstract public class AbstractInfoFragment
 
                     @Override
                     public void onError(int errorCode, String description) {
-                        if (!isAdded()) return;
-                        // Got an error, show toast
-                        Toast.makeText(getActivity(), R.string.unable_to_connect_to_xbmc, Toast.LENGTH_SHORT)
-                             .show();
+                        if (!isResumed()) return;
+                        UIUtils.showSnackbar(getView(), R.string.unable_to_connect_to_xbmc);
                     }
                 },
                 callbackHandler);
@@ -545,7 +540,7 @@ abstract public class AbstractInfoFragment
                     listener.onClick(view);
                     setToggleButtonState(binding.infoActionDownload, true);
                 } else {
-                    Toast.makeText(getActivity(), R.string.no_connection_type_selected, Toast.LENGTH_SHORT).show();
+                    UIUtils.showSnackbar(getView(), R.string.no_connection_type_selected);
                 }
             }
         });

--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonInfoFragment.java
@@ -20,7 +20,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.view.View;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -38,6 +37,7 @@ import org.xbmc.kore.ui.AbstractAdditionalInfoFragment;
 import org.xbmc.kore.ui.AbstractInfoFragment;
 import org.xbmc.kore.ui.generic.RefreshItem;
 import org.xbmc.kore.utils.LogUtils;
+import org.xbmc.kore.utils.UIUtils;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -104,10 +104,9 @@ public class AddonInfoFragment extends AbstractInfoFragment {
 
                 @Override
                 public void onError(int errorCode, String description) {
-                    if (!isAdded()) return;
+                    if (!isResumed()) return;
                     // Got an error, show toast
-                    Toast.makeText(getActivity(), R.string.unable_to_connect_to_xbmc, Toast.LENGTH_SHORT)
-                         .show();
+                    UIUtils.showSnackbar(getView(), R.string.unable_to_connect_to_xbmc);
                 }
             }, callbackHandler);
         });
@@ -122,20 +121,17 @@ public class AddonInfoFragment extends AbstractInfoFragment {
             action.execute(getHostManager().getConnection(), new ApiCallback<String>() {
                 @Override
                 public void onSuccess(String result) {
-                    if (!isAdded()) return;
+                    if (!isResumed()) return;
                     int messageResId = (!isEnabled) ? R.string.addon_enabled : R.string.addon_disabled;
-                    Toast.makeText(requireContext(), messageResId, Toast.LENGTH_SHORT).show();
+                    UIUtils.showSnackbar(getView(), messageResId);
                     setEnableButtonState(!isEnabled);
                     setFabState(!isEnabled);
                 }
 
                 @Override
                 public void onError(int errorCode, String description) {
-                    if (!isAdded()) return;
-                    Toast.makeText(requireContext(),
-                                   String.format(getString(R.string.general_error_executing_action), description),
-                                   Toast.LENGTH_SHORT)
-                         .show();
+                    if (!isResumed()) return;
+                    UIUtils.showSnackbar(getView(), String.format(getString(R.string.general_error_executing_action), description));
                 }
             }, callbackHandler);
         });
@@ -149,17 +145,15 @@ public class AddonInfoFragment extends AbstractInfoFragment {
         action.execute(getHostManager().getConnection(), new ApiCallback<AddonType.Details>() {
             @Override
             public void onSuccess(AddonType.Details result) {
-                if (!isAdded()) return;
+                if (!isResumed()) return;
                 setEnableButtonState(result.enabled);
                 setFabState(result.enabled);
             }
 
             @Override
             public void onError(int errorCode, String description) {
-                if (!isAdded()) return;
-                Toast.makeText(getActivity(),
-                               String.format(getString(R.string.error_getting_addon_info), description),
-                               Toast.LENGTH_SHORT).show();
+                if (!isResumed()) return;
+                UIUtils.showSnackbar(getView(), String.format(getString(R.string.error_getting_addon_info), description));
             }
         }, callbackHandler);
     }
@@ -182,7 +176,7 @@ public class AddonInfoFragment extends AbstractInfoFragment {
                  .putStringSet(Settings.getBookmarkedAddonsPrefKey(hostId), bookmarks)
                  .putString(Settings.getNameBookmarkedAddonsPrefKey(hostId) + path, name)
                  .apply();
-            Toast.makeText(getActivity(), !isBookmarked ? R.string.addon_pinned : R.string.addon_unpinned, Toast.LENGTH_SHORT).show();
+            UIUtils.showSnackbar(getView(), !isBookmarked ? R.string.addon_pinned : R.string.addon_unpinned);
             setPinButtonState(!isBookmarked);
         });
 

--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListFragment.java
@@ -21,8 +21,6 @@ import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.Handler;
-import androidx.preference.PreferenceManager;
-
 import android.os.Looper;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -32,10 +30,10 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.preference.PreferenceManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import org.xbmc.kore.R;
@@ -132,8 +130,7 @@ public class AddonListFragment extends AbstractListFragment {
             callGetAddonsAndSetup();
         } else {
             hideRefreshAnimation();
-            Toast.makeText(getActivity(), R.string.no_xbmc_configured, Toast.LENGTH_SHORT)
-                 .show();
+            UIUtils.showSnackbar(getView(), R.string.no_xbmc_configured);
         }
     }
 

--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/AlbumSongsListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/AlbumSongsListFragment.java
@@ -33,7 +33,6 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.PopupMenu;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -124,9 +123,8 @@ public class AlbumSongsListFragment extends AbstractAdditionalInfoFragment
 
     @Override
     public void onLoadFinished(@NonNull Loader<Cursor> loader, Cursor data) {
-        if (! data.moveToFirst()) {
-            Toast.makeText(getActivity(), R.string.no_songs_found_refresh,
-                           Toast.LENGTH_SHORT).show();
+        if (!data.moveToFirst()) {
+            UIUtils.showSnackbar(getView(), R.string.no_songs_found_refresh);
             return;
         }
         displaySongs(data);

--- a/app/src/main/java/org/xbmc/kore/ui/sections/favourites/FavouritesListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/favourites/FavouritesListFragment.java
@@ -26,7 +26,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -75,7 +74,8 @@ public class FavouritesListFragment
 
             @Override
             public void onError(int errorCode, String description) {
-                Toast.makeText(getActivity(), description, Toast.LENGTH_SHORT).show();
+                if (!isResumed()) return;
+                UIUtils.showSnackbar(getView(), description);
             }
         };
         return (view, position) -> {
@@ -98,8 +98,7 @@ public class FavouritesListFragment
                 playlistItem.file = detailsFavourite.path;
                 MediaPlayerUtils.play(FavouritesListFragment.this, playlistItem);
             } else {
-                Toast.makeText(getActivity(), R.string.unable_to_play_favourite_item, Toast.LENGTH_SHORT)
-                     .show();
+                UIUtils.showSnackbar(getView(), R.string.unable_to_play_favourite_item);
             }
         };
     }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/file/MediaFileListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/file/MediaFileListFragment.java
@@ -31,7 +31,6 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.PopupMenu;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -330,10 +329,8 @@ public class MediaFileListFragment extends AbstractListFragment {
 
             @Override
             public void onError(int errorCode, String description) {
-                if (!isAdded()) return;
-                Toast.makeText(getActivity(),
-                               String.format(getString(R.string.error_play_media_file), description),
-                               Toast.LENGTH_SHORT).show();
+                if (!isResumed()) return;
+                UIUtils.showSnackbar(getView(), String.format(getString(R.string.error_play_media_file), description));
             }
         }, callbackHandler);
     }
@@ -356,10 +353,8 @@ public class MediaFileListFragment extends AbstractListFragment {
 
                     @Override
                     public void onError(int errorCode, String description) {
-                        if (!isAdded()) return;
-                        Toast.makeText(getActivity(),
-                                       String.format(getString(R.string.error_queue_media_file), description),
-                                       Toast.LENGTH_SHORT).show();
+                        if (!isResumed()) return;
+                        UIUtils.showSnackbar(getView(), String.format(getString(R.string.error_queue_media_file), description));
                         callbackHandler.post(queueMediaQueueFileLocations);
                     }
                 }, callbackHandler);
@@ -404,10 +399,8 @@ public class MediaFileListFragment extends AbstractListFragment {
 
             @Override
             public void onError(int errorCode, String description) {
-                if (!isAdded()) return;
-                Toast.makeText(getActivity(),
-                               String.format(getString(R.string.error_queue_media_file), description),
-                               Toast.LENGTH_SHORT).show();
+                if (!isResumed()) return;
+                UIUtils.showSnackbar(getView(), String.format(getString(R.string.error_queue_media_file), description));
             }
         }, callbackHandler);
     }
@@ -434,10 +427,8 @@ public class MediaFileListFragment extends AbstractListFragment {
 
                         @Override
                         public void onError(int errorCode, String description) {
-                            if (!isAdded()) return;
-                            Toast.makeText(getActivity(),
-                                           String.format(getString(R.string.error_play_media_file), description),
-                                           Toast.LENGTH_SHORT).show();
+                            if (!isResumed()) return;
+                            UIUtils.showSnackbar(getView(), String.format(getString(R.string.error_play_media_file), description));
                         }
                     }, callbackHandler);
                 }
@@ -445,10 +436,8 @@ public class MediaFileListFragment extends AbstractListFragment {
 
             @Override
             public void onError(int errorCode, String description) {
-                if (!isAdded()) return;
-                Toast.makeText(getActivity(),
-                               String.format(getString(R.string.error_get_active_player), description),
-                               Toast.LENGTH_SHORT).show();
+                if (!isResumed()) return;
+                UIUtils.showSnackbar(getView(), String.format(getString(R.string.error_get_active_player), description));
             }
         }, callbackHandler);
 

--- a/app/src/main/java/org/xbmc/kore/ui/sections/hosts/AddHostFragmentZeroconf.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/hosts/AddHostFragmentZeroconf.java
@@ -31,7 +31,6 @@ import android.widget.ArrayAdapter;
 import android.widget.GridView;
 import android.widget.ImageView;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -41,10 +40,11 @@ import com.google.android.material.color.MaterialColors;
 
 import org.xbmc.kore.R;
 import org.xbmc.kore.databinding.FragmentAddHostZeroconfBinding;
-import org.xbmc.kore.host.HostInfo;
 import org.xbmc.kore.host.HostConnection;
+import org.xbmc.kore.host.HostInfo;
 import org.xbmc.kore.utils.LogUtils;
 import org.xbmc.kore.utils.NetUtils;
+import org.xbmc.kore.utils.UIUtils;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -238,8 +238,7 @@ public class AddHostFragmentZeroconf extends Fragment {
             String[] addresses = selectedServiceInfo.getHostAddresses();
             if (addresses.length == 0) {
                 // Couldn't get any address
-                Toast.makeText(getActivity(), R.string.wizard_zeroconf_cant_connect_no_host_address, Toast.LENGTH_LONG)
-                        .show();
+                UIUtils.showSnackbar(getView(), R.string.wizard_zeroconf_cant_connect_no_host_address);
                 return;
             }
             String hostName = selectedServiceInfo.getName();

--- a/app/src/main/java/org/xbmc/kore/ui/sections/hosts/HostFragmentManualConfiguration.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/hosts/HostFragmentManualConfiguration.java
@@ -24,24 +24,25 @@ import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.fragment.app.Fragment;
 
 import org.xbmc.kore.R;
 import org.xbmc.kore.databinding.FragmentAddHostManualConfigurationBinding;
 import org.xbmc.kore.eventclient.EventServerConnection;
+import org.xbmc.kore.host.HostConnection;
 import org.xbmc.kore.host.HostInfo;
 import org.xbmc.kore.jsonrpc.ApiCallback;
 import org.xbmc.kore.jsonrpc.ApiException;
-import org.xbmc.kore.host.HostConnection;
 import org.xbmc.kore.jsonrpc.method.Application;
 import org.xbmc.kore.jsonrpc.method.JSONRPC;
 import org.xbmc.kore.jsonrpc.type.ApplicationType;
 import org.xbmc.kore.utils.LogUtils;
 import org.xbmc.kore.utils.NetUtils;
+import org.xbmc.kore.utils.UIUtils;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -187,6 +188,11 @@ public class HostFragmentManualConfiguration extends Fragment {
         return port > 0 && port <= 65535;
     }
 
+    private void showMessage(@StringRes int messageResId) {
+        if (getView() == null) return;
+        UIUtils.showSnackbar(getView(), messageResId);
+    }
+
     /**
      * Tests a connection with the values set in the UI.
      * Checks whether the values are correctly set, and then tries to make
@@ -234,14 +240,14 @@ public class HostFragmentManualConfiguration extends Fragment {
 
         if (implicitPort != null) {
             if (!isValidPort(implicitPort)) {
-                Toast.makeText(requireContext(), R.string.wizard_invalid_http_port_specified, Toast.LENGTH_SHORT).show();
+                showMessage(R.string.wizard_invalid_http_port_specified);
                 binding.kodiHttpPort.requestFocus();
                 return;
             }
             kodiHttpPort = implicitPort;
         } else if (explicitPort != null) {
             if (!isValidPort(explicitPort)) {
-                Toast.makeText(requireContext(), R.string.wizard_invalid_http_port_specified, Toast.LENGTH_SHORT).show();
+                showMessage(R.string.wizard_invalid_http_port_specified);
                 binding.kodiHttpPort.requestFocus();
                 return;
             }
@@ -281,19 +287,19 @@ public class HostFragmentManualConfiguration extends Fragment {
 
         // Check Kodi name and address
         if (TextUtils.isEmpty(kodiName)) {
-            Toast.makeText(requireContext(), R.string.wizard_no_name_specified, Toast.LENGTH_SHORT).show();
+            showMessage(R.string.wizard_no_name_specified);
             binding.kodiName.requestFocus();
             return;
         } else if (TextUtils.isEmpty(kodiAddress)) {
-            Toast.makeText(requireContext(), R.string.wizard_no_address_specified, Toast.LENGTH_SHORT).show();
+            showMessage(R.string.wizard_no_address_specified);
             binding.kodiIpAddress.requestFocus();
             return;
         } else if (kodiTcpPort <= 0) {
-            Toast.makeText(requireContext(), R.string.wizard_invalid_tcp_port_specified, Toast.LENGTH_SHORT).show();
+            showMessage(R.string.wizard_invalid_tcp_port_specified);
             binding.kodiTcpPort.requestFocus();
             return;
         } else if (kodiEventServerPort <= 0) {
-            Toast.makeText(requireContext(), R.string.wizard_invalid_tcp_port_specified, Toast.LENGTH_SHORT).show();
+            showMessage(R.string.wizard_invalid_tcp_port_specified);
             binding.kodiEventServerPort.requestFocus();
             return;
         }
@@ -469,13 +475,11 @@ public class HostFragmentManualConfiguration extends Fragment {
                 } else {
                     messageResourceId = R.string.wizard_incorrect_authentication;
                 }
-                Toast.makeText(requireContext(), messageResourceId, Toast.LENGTH_SHORT).show();
+                showMessage(messageResourceId);
                 binding.kodiUsername.requestFocus();
                 break;
             default:
-                Toast.makeText(requireContext(),
-                        R.string.wizard_error_connecting,
-                        Toast.LENGTH_SHORT).show();
+                showMessage(R.string.wizard_error_connecting);
                 break;
         }
     }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/localfile/LocalMediaFileListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/localfile/LocalMediaFileListFragment.java
@@ -31,7 +31,6 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.PopupMenu;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
@@ -253,10 +252,8 @@ public class LocalMediaFileListFragment extends AbstractListFragment {
 
             @Override
             public void onError(int errorCode, String description) {
-                if (!isAdded()) return;
-                Toast.makeText(getActivity(),
-                        String.format(getString(R.string.error_play_local_file), description),
-                        Toast.LENGTH_SHORT).show();
+                if (!isResumed()) return;
+                UIUtils.showSnackbar(getView(), String.format(getString(R.string.error_play_local_file), description));
             }
         }, callbackHandler);
     }
@@ -281,10 +278,8 @@ public class LocalMediaFileListFragment extends AbstractListFragment {
 
             @Override
             public void onError(int errorCode, String description) {
-                if (!isAdded()) return;
-                Toast.makeText(getActivity(),
-                        String.format(getString(R.string.error_queue_media_file), description),
-                        Toast.LENGTH_SHORT).show();
+                if (!isResumed()) return;
+                UIUtils.showSnackbar(getView(), String.format(getString(R.string.error_queue_media_file), description));
             }
         }, callbackHandler);
     }
@@ -311,10 +306,8 @@ public class LocalMediaFileListFragment extends AbstractListFragment {
 
                         @Override
                         public void onError(int errorCode, String description) {
-                            if (!isAdded()) return;
-                            Toast.makeText(getActivity(),
-                                    String.format(getString(R.string.error_play_media_file), description),
-                                    Toast.LENGTH_SHORT).show();
+                            if (!isResumed()) return;
+                            UIUtils.showSnackbar(getView(), String.format(getString(R.string.error_play_media_file), description));
                         }
                     }, callbackHandler);
                 }
@@ -322,10 +315,8 @@ public class LocalMediaFileListFragment extends AbstractListFragment {
 
             @Override
             public void onError(int errorCode, String description) {
-                if (!isAdded()) return;
-                Toast.makeText(getActivity(),
-                        String.format(getString(R.string.error_get_active_player), description),
-                        Toast.LENGTH_SHORT).show();
+                if (!isResumed()) return;
+                UIUtils.showSnackbar(getView(), String.format(getString(R.string.error_get_active_player), description));
             }
         }, callbackHandler);
 

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/PlaylistFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/PlaylistFragment.java
@@ -31,7 +31,6 @@ import android.widget.BaseAdapter;
 import android.widget.ImageView;
 import android.widget.PopupMenu;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -594,8 +593,7 @@ public class PlaylistFragment extends Fragment
 
             if (lastGetItemResult != null &&
                 playlistItems.get(finalPosition).id == lastGetItemResult.id) {
-                Toast.makeText(getActivity(), R.string.cannot_move_playing_item, Toast.LENGTH_SHORT)
-                     .show();
+                UIUtils.showSnackbar(PlaylistFragment.this.getView(), R.string.cannot_move_playing_item);
                 rollbackSwappedItems(originalPosition, finalPosition);
                 notifyDataSetChanged();
                 return;
@@ -616,25 +614,23 @@ public class PlaylistFragment extends Fragment
 
                         @Override
                         public void onError(int errorCode, String description) {
+                            if (!isResumed()) return;
                             //Remove succeeded but insert failed, so we need to remove item from playlist at final position
                             playlistItems.remove(finalPosition);
                             notifyDataSetChanged();
-                            if (!isAdded()) return;
-                            // Got an error, show toast
-                            Toast.makeText(getActivity(), R.string.unable_to_move_item, Toast.LENGTH_SHORT)
-                                 .show();
+                            // Got an error, show message
+                            UIUtils.showSnackbar(PlaylistFragment.this.getView(), R.string.unable_to_move_item);
                         }
                     }, callbackHandler);
                 }
 
                 @Override
                 public void onError(int errorCode, String description) {
+                    if (!isResumed()) return;
                     rollbackSwappedItems(originalPosition, finalPosition);
                     notifyDataSetChanged();
-                    if (!isAdded()) return;
-                    // Got an error, show toast
-                    Toast.makeText(getActivity(), R.string.unable_to_move_item, Toast.LENGTH_SHORT)
-                         .show();
+                    // Got an error, show message
+                    UIUtils.showSnackbar(PlaylistFragment.this.getView(), R.string.unable_to_move_item);
                 }
             }, callbackHandler);
         }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
@@ -24,7 +24,6 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.ViewTreeObserver;
 import android.view.WindowManager;
-import android.widget.Toast;
 
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
@@ -395,7 +394,7 @@ public class RemoteActivity
     }
 
     public void onSystemQuit() {
-        Toast.makeText(this, R.string.xbmc_quit, Toast.LENGTH_SHORT).show();
+        UIUtils.showSnackbar(findViewById(android.R.id.content), R.string.xbmc_quit);
         onPlayerStop();
     }
 

--- a/app/src/main/java/org/xbmc/kore/ui/sections/settings/SettingsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/settings/SettingsFragment.java
@@ -26,7 +26,6 @@ import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
-import android.widget.Toast;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
@@ -44,6 +43,7 @@ import org.xbmc.kore.host.HostManager;
 import org.xbmc.kore.service.MediaSessionService;
 import org.xbmc.kore.ui.sections.remote.RemoteActivity;
 import org.xbmc.kore.utils.LogUtils;
+import org.xbmc.kore.utils.UIUtils;
 import org.xbmc.kore.utils.Utils;
 
 import java.lang.reflect.Method;
@@ -62,8 +62,8 @@ public class SettingsFragment extends PreferenceFragmentCompat
     private final ActivityResultLauncher<String> phonePermissionLauncher =
             registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
                 if (!isGranted) {
-                    Toast.makeText(requireContext(), R.string.read_phone_state_permission_denied, Toast.LENGTH_SHORT)
-                         .show();
+                    UIUtils.showSnackbar(getListView(),
+                                         R.string.read_phone_state_permission_denied);
                     TwoStatePreference pauseCallPreference = findPreference(Settings.KEY_PREF_PAUSE_DURING_CALLS);
                     if (pauseCallPreference != null) pauseCallPreference.setChecked(false);
                 }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRChannelEPGListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRChannelEPGListFragment.java
@@ -25,7 +25,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -132,8 +131,7 @@ public class PVRChannelEPGListFragment
             browseEPG();
         } else {
             hideRefreshAnimation();
-            Toast.makeText(requireContext(), R.string.no_xbmc_configured, Toast.LENGTH_SHORT)
-                 .show();
+            UIUtils.showSnackbar(getView(), R.string.no_xbmc_configured);
         }
     }
 

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRChannelsListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRChannelsListFragment.java
@@ -27,7 +27,6 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.PopupMenu;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -172,9 +171,7 @@ public class PVRChannelsListFragment
                 browseChannels(selectedChannelGroupId);
             }
         } else {
-            hideRefreshAnimation();
-            Toast.makeText(requireContext(), R.string.no_xbmc_configured, Toast.LENGTH_SHORT)
-                 .show();
+            UIUtils.showSnackbar(getView(), R.string.no_xbmc_configured);
         }
     }
 
@@ -282,10 +279,7 @@ public class PVRChannelsListFragment
                 ChannelViewHolder holder = (ChannelViewHolder) tag;
 
                 // Start the channel
-                Toast.makeText(requireContext(),
-                               String.format(getString(R.string.channel_switching), holder.channelName),
-                               Toast.LENGTH_SHORT)
-                     .show();
+                UIUtils.showSnackbar(getView(), String.format(getString(R.string.channel_switching), holder.channelName));
                 Player.Open action = new Player.Open(Player.Open.TYPE_CHANNEL, holder.channelId);
                 action.execute(hostManager.getConnection(), new ApiCallback<String>() {
                     @Override
@@ -293,14 +287,9 @@ public class PVRChannelsListFragment
 
                     @Override
                     public void onError(int errorCode, String description) {
-                        if (!isAdded()) return;
+                        if (!isResumed()) return;
                         LogUtils.LOGD(TAG, "Error starting channel: " + description);
-
-                        Toast.makeText(requireContext(),
-                                       String.format(getString(R.string.error_starting_channel), description),
-                                       Toast.LENGTH_SHORT)
-                             .show();
-
+                        UIUtils.showSnackbar(getView(), String.format(getString(R.string.error_starting_channel), description));
                     }
                 }, callbackHandler);
             }
@@ -467,14 +456,9 @@ public class PVRChannelsListFragment
 
                             @Override
                             public void onError(int errorCode, String description) {
-                                if (!isAdded()) return;
+                                if (!isResumed()) return;
                                 LogUtils.LOGD(TAG, "Error starting to record: " + description);
-
-                                Toast.makeText(requireContext(),
-                                               String.format(getString(R.string.error_starting_to_record), description),
-                                               Toast.LENGTH_SHORT)
-                                     .show();
-
+                                UIUtils.showSnackbar(getView(), String.format(getString(R.string.error_starting_to_record), description));
                             }
                         }, callbackHandler);
                         return true;

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRRecordingsListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRRecordingsListFragment.java
@@ -32,7 +32,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -79,10 +78,7 @@ public class PVRRecordingsListFragment
             RecordingViewHolder tag = (RecordingViewHolder) view.getTag();
 
             // Start the recording
-            Toast.makeText(requireContext(),
-                           String.format(getString(R.string.starting_recording), tag.title),
-                           Toast.LENGTH_SHORT)
-                 .show();
+            UIUtils.showSnackbar(getView(), String.format(getString(R.string.starting_recording), tag.title));
             Player.Open action = new Player.Open(Player.Open.TYPE_RECORDING, tag.recordingId);
             action.execute(hostManager.getConnection(), new ApiCallback<String>() {
                 @Override
@@ -90,14 +86,9 @@ public class PVRRecordingsListFragment
 
                 @Override
                 public void onError(int errorCode, String description) {
-                    if (!isAdded()) return;
+                    if (!isResumed()) return;
                     LogUtils.LOGD(TAG, "Error starting recording: " + description);
-
-                    Toast.makeText(requireContext(),
-                                   String.format(getString(R.string.error_starting_recording), description),
-                                   Toast.LENGTH_SHORT)
-                         .show();
-
+                    UIUtils.showSnackbar(getView(), String.format(getString(R.string.error_starting_recording), description));
                 }
             }, callbackHandler);
 
@@ -215,8 +206,7 @@ public class PVRRecordingsListFragment
             browseRecordings();
         } else {
             hideRefreshAnimation();
-            Toast.makeText(requireContext(), R.string.no_xbmc_configured, Toast.LENGTH_SHORT)
-                 .show();
+            UIUtils.showSnackbar(getView(), R.string.no_xbmc_configured);
         }
     }
 

--- a/app/src/main/java/org/xbmc/kore/utils/UIUtils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/UIUtils.java
@@ -44,11 +44,13 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
 import androidx.core.widget.TextViewCompat;
 import androidx.preference.PreferenceManager;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.elevation.SurfaceColors;
+import com.google.android.material.snackbar.Snackbar;
 
 import org.xbmc.kore.R;
 import org.xbmc.kore.Settings;
@@ -766,4 +768,27 @@ public class UIUtils {
             }
         };
     }
+
+    /**
+     * Show a generic snackbar with a short length
+     * @param view View to find parent of snackbar
+     * @param resId message
+     */
+    public static void showSnackbar(View view, @StringRes int resId) {
+        if (view == null) return;
+        Snackbar.make(view, resId, Snackbar.LENGTH_SHORT)
+                .show();
+    }
+
+    /**
+     * Show a generic snackbar with a short length
+     * @param view View to find parent of snackbar
+     * @param message message
+     */
+    public static void showSnackbar(View view, String message) {
+        if (view == null) return;
+        Snackbar.make(view, message, Snackbar.LENGTH_SHORT)
+                .show();
+    }
+
 }


### PR DESCRIPTION
According to modern Android guidelines, Snackbars should be used instead of Toasts for showing messages