### PR TITLE
Remove checks if binding is null on callbacks

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
@@ -278,8 +278,6 @@ abstract public class AbstractInfoFragment
      */
     @Override
     public void onConnectionStatusError(int errorCode, String description) {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
-
         LogUtils.LOGD(TAG, "Connection Status Error, disabling buttons");
         lastConnectionStatusResult = CONNECTION_ERROR;
         binding.fabPlay.setEnabled(false);
@@ -294,8 +292,6 @@ abstract public class AbstractInfoFragment
      */
     @Override
     public void onConnectionStatusSuccess() {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
-
         // Only update views if transitioning from error state.
         // If transitioning from Sucess or No results the enabled UI is already being shown
         if (lastConnectionStatusResult == CONNECTION_ERROR) {

--- a/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
@@ -250,13 +250,11 @@ public abstract class BaseMediaActivity
 
     @Override
     public void onApplicationVolumeChanged(int volume, boolean muted) {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         binding.nowPlayingPanel.setVolumeState(volume, muted);
     }
 
     @Override
     public void onPlayerPropertyChanged(org.xbmc.kore.jsonrpc.notification.Player.NotificationsData notificationsData) {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         binding.nowPlayingPanel.setRepeatShuffleState(notificationsData.property.repeatMode,
                                                       notificationsData.property.shuffled,
                                                       notificationsData.property.partymode);
@@ -266,7 +264,6 @@ public abstract class BaseMediaActivity
     public void onPlayerPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                              PlayerType.PropertyValue getPropertiesResult,
                              ListType.ItemsAll getItemResult) {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         updateNowPlayingPanel(getActivePlayerResult, getPropertiesResult, getItemResult);
         // Start the MediaSession service
         MediaSessionService.startIfNotRunning(this);
@@ -274,7 +271,6 @@ public abstract class BaseMediaActivity
 
     @Override
     public void onPlayerPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult, PlayerType.PropertyValue getPropertiesResult, ListType.ItemsAll getItemResult) {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         updateNowPlayingPanel(getActivePlayerResult, getPropertiesResult, getItemResult);
     }
 
@@ -287,7 +283,6 @@ public abstract class BaseMediaActivity
 
     @Override
     public void onPlayerConnectionError(int errorCode, String description) {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         binding.nowPlayingPanel.setPanelState(SlidingUpPanelLayout.PanelState.HIDDEN);
     }
 
@@ -296,13 +291,11 @@ public abstract class BaseMediaActivity
 
     @Override
     public void onObserverStopObserving() {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         binding.nowPlayingPanel.setPanelState(SlidingUpPanelLayout.PanelState.HIDDEN);
     }
 
     @Override
     public void onSystemQuit() {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         binding.nowPlayingPanel.setPanelState(SlidingUpPanelLayout.PanelState.HIDDEN);
     }
 

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/NowPlayingFragment.java
@@ -125,19 +125,16 @@ public class NowPlayingFragment extends Fragment
     public void onPlayerPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                              PlayerType.PropertyValue getPropertiesResult,
                              ListType.ItemsAll getItemResult) {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         setNowPlayingInfo(getActivePlayerResult, getPropertiesResult, getItemResult);
     }
 
     public void onPlayerPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                               PlayerType.PropertyValue getPropertiesResult,
                               ListType.ItemsAll getItemResult) {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         setNowPlayingInfo(getActivePlayerResult, getPropertiesResult, getItemResult);
     }
 
     public void onPlayerStop() {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         stopNowPlayingInfo();
         switchToPanel(R.id.info_panel);
         HostInfo hostInfo = hostManager.getHostInfo();
@@ -146,7 +143,6 @@ public class NowPlayingFragment extends Fragment
     }
 
     public void onPlayerConnectionError(int errorCode, String description) {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         stopNowPlayingInfo();
         switchToPanel(R.id.info_panel);
         HostInfo hostInfo = hostManager.getHostInfo();
@@ -160,7 +156,6 @@ public class NowPlayingFragment extends Fragment
     }
 
     public void onPlayerNoResultsYet() {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         // Initialize info panel
         switchToPanel(R.id.info_panel);
         HostInfo hostInfo = hostManager.getHostInfo();

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/PlaylistFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/PlaylistFragment.java
@@ -239,7 +239,6 @@ public class PlaylistFragment extends Fragment
 
     @Override
     public void onPlayerPropertyChanged(org.xbmc.kore.jsonrpc.notification.Player.NotificationsData notificationsData) {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         if (notificationsData.property.shuffled != null)
             refreshPlaylist(new GetPlaylist(lastGetActivePlayerResult.type));
     }
@@ -251,7 +250,6 @@ public class PlaylistFragment extends Fragment
     public void onPlayerPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                              PlayerType.PropertyValue getPropertiesResult,
                              ListType.ItemsAll getItemResult) {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         playerState = PLAYER_STATE.PLAYING;
 
         lastGetItemResult = getItemResult;
@@ -277,7 +275,6 @@ public class PlaylistFragment extends Fragment
     public void onPlayerPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                               PlayerType.PropertyValue getPropertiesResult,
                               ListType.ItemsAll getItemResult) {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         playerState = PLAYER_STATE.PAUSED;
 
         lastGetItemResult = getItemResult;
@@ -292,7 +289,6 @@ public class PlaylistFragment extends Fragment
 
     @Override
     public void onPlayerStop() {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         playerState = PLAYER_STATE.STOPPED;
 
         if (lastGetActivePlayerResult != null)
@@ -305,7 +301,6 @@ public class PlaylistFragment extends Fragment
 
     @Override
     public void onPlayerConnectionError(int errorCode, String description) {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         playerState = PLAYER_STATE.CONNECTION_ERROR;
 
         HostInfo hostInfo = hostManager.getHostInfo();
@@ -322,7 +317,6 @@ public class PlaylistFragment extends Fragment
 
     @Override
     public void onPlayerNoResultsYet() {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         playerState = PLAYER_STATE.NO_RESULTS_YET;
 
         // Initialize info panel
@@ -350,7 +344,6 @@ public class PlaylistFragment extends Fragment
 
     @Override
     public void onPlaylistClear(int playlistId) {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         Iterator<String> it = playlists.keySet().iterator();
         while (it.hasNext()) {
             String key = it.next();
@@ -366,7 +359,6 @@ public class PlaylistFragment extends Fragment
 
     @Override
     public void onPlaylistsAvailable(ArrayList<GetPlaylist.GetPlaylistResult> playlists) {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         updatePlaylists(playlists);
 
         if ((playerState == PLAYER_STATE.PLAYING) &&

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteActivity.java
@@ -362,7 +362,6 @@ public class RemoteActivity
     public void onPlayerPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                              PlayerType.PropertyValue getPropertiesResult,
                              ListType.ItemsAll getItemResult) {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         String imageUrl = (TextUtils.isEmpty(getItemResult.fanart)) ?
                           getItemResult.thumbnail : getItemResult.fanart;
         if ((imageUrl != null) && !imageUrl.equals(lastImageUrl)) {
@@ -375,12 +374,10 @@ public class RemoteActivity
     public void onPlayerPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                               PlayerType.PropertyValue getPropertiesResult,
                               ListType.ItemsAll getItemResult) {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         onPlayerPlay(getActivePlayerResult, getPropertiesResult, getItemResult);
     }
 
     public void onPlayerStop() {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         if (lastImageUrl != null) {
             setImageViewBackground(null);
         }
@@ -399,7 +396,6 @@ public class RemoteActivity
     }
 
     public void onInputRequested(String title, String type, String value) {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         SendTextDialogFragment dialog =
                 SendTextDialogFragment.newInstance(title);
         dialog.show(getSupportFragmentManager(), null);

--- a/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/remote/RemoteFragment.java
@@ -221,7 +221,6 @@ public class RemoteFragment extends Fragment
 
     @Override
     public void onPlayerPropertyChanged(org.xbmc.kore.jsonrpc.notification.Player.NotificationsData notificationsData) {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         binding.mediaActionsBar.setRepeatShuffleState(notificationsData.property.repeatMode,
                                                       notificationsData.property.shuffled,
                                                       notificationsData.property.partymode);
@@ -233,19 +232,16 @@ public class RemoteFragment extends Fragment
     public void onPlayerPlay(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                              PlayerType.PropertyValue getPropertiesResult,
                              ListType.ItemsAll getItemResult) {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         setNowPlayingInfo(getActivePlayerResult, getPropertiesResult, getItemResult);
     }
 
     public void onPlayerPause(PlayerType.GetActivePlayersReturnType getActivePlayerResult,
                               PlayerType.PropertyValue getPropertiesResult,
                               ListType.ItemsAll getItemResult) {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         setNowPlayingInfo(getActivePlayerResult, getPropertiesResult, getItemResult);
     }
 
     public void onPlayerStop() {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         stopNowPlayingInfo();
         switchToPanel(R.id.info_panel);
         HostInfo hostInfo = hostManager.getHostInfo();
@@ -254,7 +250,6 @@ public class RemoteFragment extends Fragment
     }
 
     public void onPlayerConnectionError(int errorCode, String description) {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         stopNowPlayingInfo();
         switchToPanel(R.id.info_panel);
         HostInfo hostInfo = hostManager.getHostInfo();
@@ -269,7 +264,6 @@ public class RemoteFragment extends Fragment
     }
 
     public void onPlayerNoResultsYet() {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         // Initialize info panel
         switchToPanel(R.id.info_panel);
         HostInfo hostInfo = hostManager.getHostInfo();
@@ -287,7 +281,6 @@ public class RemoteFragment extends Fragment
 
     @Override
     public void onApplicationVolumeChanged(int volume, boolean muted) {
-        if (binding == null) return; // If receiving this after onDestroy, ignore
         binding.mediaActionsBar.setVolumeState(volume, muted);
     }
 

--- a/app/src/main/java/org/xbmc/kore/utils/MediaPlayerUtils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/MediaPlayerUtils.java
@@ -19,12 +19,10 @@ package org.xbmc.kore.utils;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Handler;
-import androidx.preference.PreferenceManager;
-
 import android.os.Looper;
-import android.widget.Toast;
 
 import androidx.fragment.app.Fragment;
+import androidx.preference.PreferenceManager;
 
 import org.xbmc.kore.R;
 import org.xbmc.kore.Settings;
@@ -55,7 +53,7 @@ public class MediaPlayerUtils {
         action.execute(hostManager.getConnection(), new ApiCallback<String>() {
             @Override
             public void onSuccess(String result) {
-                if (!fragment.isAdded()) return;
+                if (!fragment.isResumed()) return;
                 boolean switchToRemote = PreferenceManager
                         .getDefaultSharedPreferences(context)
                         .getBoolean(Settings.KEY_PREF_SWITCH_TO_REMOTE_AFTER_MEDIA_START,
@@ -64,18 +62,14 @@ public class MediaPlayerUtils {
                     Intent launchIntent = new Intent(context, RemoteActivity.class);
                     context.startActivity(launchIntent);
                 } else {
-                    Toast.makeText(context, R.string.now_playing, Toast.LENGTH_SHORT)
-                         .show();
+                    UIUtils.showSnackbar(fragment.getView(), R.string.now_playing);
                 }
             }
 
             @Override
             public void onError(int errorCode, String description) {
-                if (!fragment.isAdded()) return;
-                // Got an error, show toast
-                String errorMessage = context.getString(R.string.error_play_media_file, description);
-                Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT)
-                     .show();
+                if (!fragment.isResumed()) return;
+                UIUtils.showSnackbar(fragment.getView(), context.getString(R.string.error_play_media_file, description));
             }
         }, callbackHandler);
     }
@@ -98,7 +92,7 @@ public class MediaPlayerUtils {
         getPlaylists.execute(hostManager.getConnection(), new ApiCallback<ArrayList<PlaylistType.GetPlaylistsReturnType>>() {
             @Override
             public void onSuccess(ArrayList<PlaylistType.GetPlaylistsReturnType> result) {
-                if (!fragment.isAdded()) return;
+                if (!fragment.isResumed()) return;
                 // Ok, loop through the playlists, looking for the correct one
                 int playlistId = -1;
                 for (PlaylistType.GetPlaylistsReturnType playlist : result) {
@@ -113,33 +107,27 @@ public class MediaPlayerUtils {
                     action.execute(hostManager.getConnection(), new ApiCallback<String>() {
                         @Override
                         public void onSuccess(String result) {
-                            if (!fragment.isAdded()) return;
-                            Toast.makeText(context, R.string.item_added_to_playlist, Toast.LENGTH_SHORT)
-                                 .show();
+                            if (!fragment.isResumed()) return;
+                            UIUtils.showSnackbar(fragment.getView(), R.string.item_added_to_playlist);
                         }
 
                         @Override
                         public void onError(int errorCode, String description) {
-                            if (!fragment.isAdded()) return;
-                            // Got an error, show toast
+                            if (!fragment.isResumed()) return;
                             String errorMessage = context.getString(R.string.error_queue_media_file, description);
-                            Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT)
-                                 .show();
+                            UIUtils.showSnackbar(fragment.getView(), errorMessage);
                         }
                     }, callbackHandler);
                 } else {
-                    Toast.makeText(context, R.string.no_suitable_playlist, Toast.LENGTH_SHORT)
-                         .show();
+                    UIUtils.showSnackbar(fragment.getView(), R.string.no_suitable_playlist);
                 }
             }
 
             @Override
             public void onError(int errorCode, String description) {
-                if (!fragment.isAdded()) return;
-                // Got an error, show toast
+                if (!fragment.isResumed()) return;
                 String errorMessage = context.getString(R.string.error_queue_media_file, description);
-                Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT)
-                     .show();
+                UIUtils.showSnackbar(fragment.getView(), errorMessage);
             }
         }, callbackHandler);
     }


### PR DESCRIPTION
Reverts #868 as binding should not be null in callbacks, as callbacks are unregistered before onDestroy.
If it is, it's an error that we want to catch and fix