### PR TITLE
Refresh lists after entering details

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListFragment.java
@@ -74,9 +74,13 @@ public class AddonListFragment extends AbstractListFragment {
 
     private static boolean hideDisabledAddons;
 
+    private boolean forceRefreshAddons = false;
+
     @Override
     protected GridRecyclerView.OnItemClickListener createOnItemClickListener() {
         return (view, position) -> {
+            // If we get back here after showing an addon, force a refresh, as its enabled state might have changed
+            forceRefreshAddons = true;
             // Get the movie id from the tag
             ViewHolder tag = (ViewHolder) view.getTag();
             // Notify the activity
@@ -121,7 +125,8 @@ public class AddonListFragment extends AbstractListFragment {
     public void onConnectionStatusSuccess() {
         boolean refresh = (lastConnectionStatusResult != CONNECTION_SUCCESS);
         super.onConnectionStatusSuccess();
-        if (refresh) onRefresh();
+        if (refresh || forceRefreshAddons) onRefresh();
+        forceRefreshAddons = false;
     }
 
     @Override

--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/AlbumListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/AlbumListFragment.java
@@ -21,7 +21,6 @@ import android.content.res.Resources;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
-import androidx.preference.PreferenceManager;
 import android.provider.BaseColumns;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -37,6 +36,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.loader.content.CursorLoader;
+import androidx.preference.PreferenceManager;
 
 import org.xbmc.kore.R;
 import org.xbmc.kore.Settings;
@@ -163,25 +163,25 @@ public class AlbumListFragment extends AbstractCursorListFragment {
             preferences.edit()
                        .putInt(Settings.KEY_PREF_ALBUMS_SORT_ORDER, Settings.SORT_BY_ALBUM)
                        .apply();
-            refreshList();
+            restartLoader();
         } else if (itemId == R.id.action_sort_by_artist) {
             item.setChecked(!item.isChecked());
             preferences.edit()
                        .putInt(Settings.KEY_PREF_ALBUMS_SORT_ORDER, Settings.SORT_BY_ARTIST)
                        .apply();
-            refreshList();
+            restartLoader();
         } else if (itemId == R.id.action_sort_by_artist_year) {
             item.setChecked(!item.isChecked());
             preferences.edit()
                        .putInt(Settings.KEY_PREF_ALBUMS_SORT_ORDER, Settings.SORT_BY_ARTIST_YEAR)
                        .apply();
-            refreshList();
+            restartLoader();
         } else if (itemId == R.id.action_sort_by_year) {
             item.setChecked(!item.isChecked());
             preferences.edit()
                        .putInt(Settings.KEY_PREF_ALBUMS_SORT_ORDER, Settings.SORT_BY_YEAR)
                        .apply();
-            refreshList();
+            restartLoader();
         }
 
         return super.onOptionsItemSelected(item);

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/MovieListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/MovieListFragment.java
@@ -214,63 +214,63 @@ public class MovieListFragment extends AbstractCursorListFragment {
             preferences.edit()
                        .putBoolean(Settings.KEY_PREF_MOVIES_FILTER_HIDE_WATCHED, item.isChecked())
                        .apply();
-            refreshList();
+            restartLoader();
         } else if (itemId == R.id.action_show_watched_status) {
             item.setChecked(!item.isChecked());
             preferences.edit()
                        .putBoolean(Settings.KEY_PREF_MOVIES_SHOW_WATCHED_STATUS, item.isChecked())
                        .apply();
             showWatchedStatus = item.isChecked();
-            refreshList();
+            restartLoader();
         } else if (itemId == R.id.action_show_rating) {
             item.setChecked(!item.isChecked());
             preferences.edit()
                        .putBoolean(Settings.KEY_PREF_MOVIES_SHOW_RATING, item.isChecked())
                        .apply();
             showRating = item.isChecked();
-            refreshList();
+            restartLoader();
         } else if (itemId == R.id.action_ignore_prefixes) {
             item.setChecked(!item.isChecked());
             preferences.edit()
                        .putBoolean(Settings.KEY_PREF_MOVIES_IGNORE_PREFIXES, item.isChecked())
                        .apply();
-            refreshList();
+            restartLoader();
         } else if (itemId == R.id.action_sort_by_name) {
             item.setChecked(true);
             preferences.edit()
                        .putInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.SORT_BY_NAME)
                        .apply();
-            refreshList();
+            restartLoader();
         } else if (itemId == R.id.action_sort_by_year) {
             item.setChecked(true);
             preferences.edit()
                        .putInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.SORT_BY_YEAR)
                        .apply();
-            refreshList();
+            restartLoader();
         } else if (itemId == R.id.action_sort_by_rating) {
             item.setChecked(true);
             preferences.edit()
                        .putInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.SORT_BY_RATING)
                        .apply();
-            refreshList();
+            restartLoader();
         } else if (itemId == R.id.action_sort_by_date_added) {
             item.setChecked(true);
             preferences.edit()
                        .putInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.SORT_BY_DATE_ADDED)
                        .apply();
-            refreshList();
+            restartLoader();
         } else if (itemId == R.id.action_sort_by_last_played) {
             item.setChecked(true);
             preferences.edit()
                        .putInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.SORT_BY_LAST_PLAYED)
                        .apply();
-            refreshList();
+            restartLoader();
         } else if (itemId == R.id.action_sort_by_length) {
             item.setChecked(true);
             preferences.edit()
                        .putInt(Settings.KEY_PREF_MOVIES_SORT_ORDER, Settings.SORT_BY_LENGTH)
                        .apply();
-            refreshList();
+            restartLoader();
         }
 
         return super.onOptionsItemSelected(item);

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowEpisodeListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowEpisodeListFragment.java
@@ -190,7 +190,7 @@ public class TVShowEpisodeListFragment extends AbstractCursorListFragment {
             preferences.edit()
                        .putBoolean(Settings.KEY_PREF_TVSHOW_EPISODES_FILTER_HIDE_WATCHED, item.isChecked())
                        .apply();
-            refreshList();
+            restartLoader();
         }
 
         return super.onOptionsItemSelected(item);

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowListFragment.java
@@ -210,50 +210,50 @@ public class TVShowListFragment extends AbstractCursorListFragment {
             preferences.edit()
                        .putBoolean(Settings.KEY_PREF_TVSHOWS_FILTER_HIDE_WATCHED, item.isChecked())
                        .apply();
-            refreshList();
+            restartLoader();
         } else if (itemId == R.id.action_show_watched_status) {
             item.setChecked(!item.isChecked());
             preferences.edit()
                        .putBoolean(Settings.KEY_PREF_TVSHOWS_SHOW_WATCHED_STATUS, item.isChecked())
                        .apply();
             showWatchedStatus = item.isChecked();
-            refreshList();
+            restartLoader();
         } else if (itemId == R.id.action_ignore_prefixes) {
             item.setChecked(!item.isChecked());
             preferences.edit()
                        .putBoolean(Settings.KEY_PREF_TVSHOWS_IGNORE_PREFIXES, item.isChecked())
                        .apply();
-            refreshList();
+            restartLoader();
         } else if (itemId == R.id.action_sort_by_name) {
             item.setChecked(true);
             preferences.edit()
                        .putInt(Settings.KEY_PREF_TVSHOWS_SORT_ORDER, Settings.SORT_BY_NAME)
                        .apply();
-            refreshList();
+            restartLoader();
         } else if (itemId == R.id.action_sort_by_year) {
             item.setChecked(true);
             preferences.edit()
                        .putInt(Settings.KEY_PREF_TVSHOWS_SORT_ORDER, Settings.SORT_BY_YEAR)
                        .apply();
-            refreshList();
+            restartLoader();
         } else if (itemId == R.id.action_sort_by_rating) {
             item.setChecked(true);
             preferences.edit()
                        .putInt(Settings.KEY_PREF_TVSHOWS_SORT_ORDER, Settings.SORT_BY_RATING)
                        .apply();
-            refreshList();
+            restartLoader();
         } else if (itemId == R.id.action_sort_by_date_added) {
             item.setChecked(true);
             preferences.edit()
                        .putInt(Settings.KEY_PREF_TVSHOWS_SORT_ORDER, Settings.SORT_BY_DATE_ADDED)
                        .apply();
-            refreshList();
+            restartLoader();
         } else if (itemId == R.id.action_sort_by_last_played) {
             item.setChecked(true);
             preferences.edit()
                        .putInt(Settings.KEY_PREF_TVSHOWS_SORT_ORDER, Settings.SORT_BY_LAST_PLAYED)
                        .apply();
-            refreshList();
+            restartLoader();
         }
 
         return super.onOptionsItemSelected(item);


### PR DESCRIPTION
When viewing the details of an item, the user can make changes to it (enable, set watched) that were not being reflected on the corresponding list, because it was not being reloaded.
This fixes that for cursor lists and the addons list