### PR TITLE
Improve jank on list/detail transitions 

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
@@ -160,26 +160,10 @@ abstract public class AbstractInfoFragment
         if (transitionName != null) {
             // If we are passed a transition name, setup up the shared element enter/return and this fragment
             // enter/return transition, and postpone them
-            int startDelay = getResources().getInteger(R.integer.fragment_enter_start_offset),
-                    enterDuration = getResources().getInteger(R.integer.fragment_enter_animation_duration),
-                    exitDuration = getResources().getInteger(R.integer.fragment_exit_animation_duration),
-                    seDuration = Math.max(startDelay + enterDuration, startDelay + exitDuration);
-
             TransitionInflater transitionInflater = TransitionInflater.from(requireContext());
-            Transition seTransition = transitionInflater.inflateTransition(R.transition.shared_element_image_enter);
-            setSharedElementEnterTransition(seTransition.setDuration(seDuration)
-                                                        .setStartDelay(0));
-            setSharedElementReturnTransition(seTransition.clone()
-                                                         .setDuration(seDuration)
-                                                         .setStartDelay(0));
+            setSharedElementEnterTransition(transitionInflater.inflateTransition(R.transition.shared_element_image_enter));
             binding.poster.setTransitionName(transitionName);
-
-            Transition fragmentTransition = transitionInflater.inflateTransition(R.transition.fragment_info_poster_enter);
-            setEnterTransition(fragmentTransition.setDuration(enterDuration)
-                                                 .setStartDelay(startDelay));
-            setReturnTransition(fragmentTransition.clone()
-                                                  .setDuration(exitDuration)
-                                                  .setStartDelay(0));
+            setEnterTransition(transitionInflater.inflateTransition(R.transition.fragment_info_poster_enter));
 
             postponeEnterTransition();
         }

--- a/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
@@ -20,6 +20,7 @@ import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.StrictMode;
 import android.text.TextUtils;
 import android.view.KeyEvent;
 import android.view.Menu;
@@ -88,6 +89,18 @@ public abstract class BaseMediaActivity
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+//        StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder()
+//                                           .detectDiskReads()
+//                                           .detectDiskWrites()
+//                                           .detectNetwork()   // or .detectAll() for all detectable problems
+//                                           .penaltyLog()
+//                                           .build());
+//        StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
+//                                       .detectLeakedSqlLiteObjects()
+//                                       .detectLeakedClosableObjects()
+//                                       .penaltyLog()
+//                                       .penaltyDeath()
+//                                       .build());
         super.onCreate(savedInstanceState);
 
         binding = ActivityGenericMediaBinding.inflate(getLayoutInflater());
@@ -249,18 +262,6 @@ public abstract class BaseMediaActivity
         FragmentManager fragmentManager = getSupportFragmentManager();
         Fragment currentFragment = fragmentManager.findFragmentById(R.id.fragment_container);
         if (currentFragment instanceof AbstractFragment) {
-            int startDelay = getResources().getInteger(R.integer.fragment_enter_start_offset),
-                    enterDuration = getResources().getInteger(R.integer.fragment_enter_animation_duration),
-                    exitDuration = getResources().getInteger(R.integer.fragment_exit_animation_duration);
-
-            Transition exitTransition = TransitionInflater.from(this)
-                                                          .inflateTransition(R.transition.fragment_list_exit);
-            exitTransition.excludeTarget(sharedImageView, true);
-            currentFragment.setExitTransition(exitTransition.setDuration(exitDuration)
-                                                            .setStartDelay(0));
-            currentFragment.setReenterTransition(exitTransition.clone()
-                                                               .setDuration(enterDuration)
-                                                               .setStartDelay(startDelay));
             // Postpone reenter transition to allow for shared element loading
             ((AbstractFragment) currentFragment).setPostponeReenterTransition(true);
         }
@@ -279,6 +280,7 @@ public abstract class BaseMediaActivity
      * @param args Arguments to the fragment
      */
     protected void showFragment(Class<? extends Fragment> fragment, Bundle args) {
+        args.putString(IMAGE_TRANS_NAME, null);
         FragmentManager fragmentManager = getSupportFragmentManager();
         Fragment currentFragment = fragmentManager.findFragmentById(R.id.fragment_container);
         if (currentFragment instanceof AbstractFragment) {

--- a/app/src/main/res/anim/activity_enter.xml
+++ b/app/src/main/res/anim/activity_enter.xml
@@ -15,8 +15,8 @@
    limitations under the License.
 -->
 <set xmlns:android="http://schemas.android.com/apk/res/android"
-    android:startOffset="@integer/activity_enter_start_offset"
-    android:duration="@integer/activity_enter_animation_duration"
+    android:startOffset="@integer/activity_enter_after_exit_start_offset"
+    android:duration="@integer/activity_enter_after_exit_animation_duration"
     android:shareInterpolator="true"
     android:interpolator="@anim/kore_decelerate_interpolator">
 

--- a/app/src/main/res/anim/fragment_enter.xml
+++ b/app/src/main/res/anim/fragment_enter.xml
@@ -15,8 +15,8 @@
    limitations under the License.
 -->
 <set xmlns:android="http://schemas.android.com/apk/res/android"
-    android:startOffset="@integer/fragment_enter_start_offset"
-    android:duration="@integer/fragment_enter_animation_duration"
+    android:startOffset="@integer/fragment_enter_after_exit_start_offset"
+    android:duration="@integer/fragment_enter_after_exit_animation_duration"
     android:shareInterpolator="true"
     android:interpolator="@anim/kore_decelerate_interpolator" >
 

--- a/app/src/main/res/anim/fragment_exit.xml
+++ b/app/src/main/res/anim/fragment_exit.xml
@@ -28,6 +28,6 @@
         android:pivotY="50%"
         android:fromXScale="1.0"
         android:fromYScale="1.0"
-        android:toXScale="0.92"
-        android:toYScale="0.92" />
+        android:toXScale="0.94"
+        android:toYScale="0.94" />
 </set>

--- a/app/src/main/res/anim/fragment_popenter.xml
+++ b/app/src/main/res/anim/fragment_popenter.xml
@@ -15,8 +15,8 @@
    limitations under the License.
 -->
 <set xmlns:android="http://schemas.android.com/apk/res/android"
-    android:startOffset="@integer/fragment_enter_start_offset"
-    android:duration="@integer/fragment_enter_animation_duration"
+    android:startOffset="@integer/fragment_popenter_start_offset"
+    android:duration="@integer/fragment_popenter_animation_duration"
     android:shareInterpolator="true"
     android:interpolator="@anim/kore_decelerate_interpolator">
 
@@ -27,8 +27,8 @@
     <scale
         android:pivotX="50%"
         android:pivotY="50%"
-        android:fromXScale="0.92"
-        android:fromYScale="0.92"
+        android:fromXScale="0.94"
+        android:fromYScale="0.94"
         android:toXScale="1.0"
         android:toYScale="1.0" />
 

--- a/app/src/main/res/anim/fragment_popexit.xml
+++ b/app/src/main/res/anim/fragment_popexit.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <set xmlns:android="http://schemas.android.com/apk/res/android"
-    android:duration="@integer/fragment_exit_animation_duration"
+    android:duration="@integer/fragment_popexit_animation_duration"
     android:shareInterpolator="true"
     android:interpolator="@anim/kore_accelerate_interpolator">
 

--- a/app/src/main/res/transition/fragment_info_poster_enter.xml
+++ b/app/src/main/res/transition/fragment_info_poster_enter.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <transitionSet xmlns:android="http://schemas.android.com/apk/res/android"
     android:transitionOrdering="together"
-    android:interpolator="@anim/kore_decelerate_interpolator">
+    android:interpolator="@anim/kore_decelerate_interpolator"
+    android:duration="@integer/fragment_enter_animation_duration">
 
     <fade>
         <targets>

--- a/app/src/main/res/transition/shared_element_image_enter.xml
+++ b/app/src/main/res/transition/shared_element_image_enter.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <transitionSet xmlns:android="http://schemas.android.com/apk/res/android"
     android:transitionOrdering="together"
-    android:interpolator="@anim/kore_decelerate_interpolator" >
+    android:interpolator="@anim/kore_decelerate_interpolator"
+    android:duration="@integer/fragment_enter_animation_duration">
 
     <changeTransform/>
     <changeBounds/>

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -16,12 +16,18 @@
 -->
 <resources>
     <integer name="fragment_exit_animation_duration">100</integer>
-    <integer name="fragment_enter_start_offset">100</integer>
-    <integer name="fragment_enter_animation_duration">150</integer>
+    <integer name="fragment_enter_after_exit_start_offset">50</integer>
+    <integer name="fragment_enter_after_exit_animation_duration">200</integer>
+    <integer name="fragment_enter_animation_duration">250</integer>
 
-    <integer name="activity_enter_animation_duration">100</integer>
-    <integer name="activity_enter_start_offset">100</integer>
+    <integer name="fragment_popexit_animation_duration">200</integer>
+    <integer name="fragment_popenter_animation_duration">100</integer>
+    <integer name="fragment_popenter_start_offset">150</integer>
+
+
     <integer name="activity_exit_animation_duration">150</integer>
+    <integer name="activity_enter_after_exit_start_offset">100</integer>
+    <integer name="activity_enter_after_exit_animation_duration">150</integer>
 
     <integer name="button_touch_animation_duration">50</integer>
 


### PR DESCRIPTION
Transitions had a lot of jank that somehow was caused by setting the exit/reenter transition on the leaving fragment (the list). Removing that transition eliminates the jank, with little visual effects.
Also simplified the shared element and entering fragment transitions, as, not existing a previous exit transition, there's no need to specify a delay on these transitions.
