### PR TITLE
Remove setting the Download button state in the UI thread

### DIFF
--- a/app/src/main/java/org/xbmc/kore/eventclient/Packet.java
+++ b/app/src/main/java/org/xbmc/kore/eventclient/Packet.java
@@ -259,6 +259,7 @@ public abstract class Packet {
 			p.setPort(port);
 			s.send(p);
 		}
+		s.close();
 	}
 	
 	/**

--- a/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
@@ -578,7 +578,6 @@ abstract public class AbstractInfoFragment
             if (checkStoragePermission()) {
                 if (Settings.allowedDownloadNetworkTypes(getActivity()) != 0) {
                     listener.onClick(view);
-                    setToggleButtonState(binding.infoActionDownload, true);
                 } else {
                     UIUtils.showSnackbar(getView(), R.string.no_connection_type_selected);
                 }

--- a/app/src/main/java/org/xbmc/kore/ui/BaseActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/BaseActivity.java
@@ -17,6 +17,9 @@ package org.xbmc.kore.ui;
 
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.os.StrictMode;
+import android.text.TextUtils;
+
 import androidx.preference.PreferenceManager;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -32,10 +35,26 @@ public abstract class BaseActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+//        StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder()
+//                                           .detectDiskReads()
+//                                           .detectDiskWrites()
+//                                           .detectNetwork()   // or .detectAll() for all detectable problems
+//                                           .penaltyLog()
+//                                           .build());
+//        StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
+//                                       .detectLeakedSqlLiteObjects()
+//                                       .detectLeakedClosableObjects()
+//                                       .penaltyLog()
+//                                       .penaltyDeath()
+//                                       .build());
+
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
         setTheme(UIUtils.getThemeResourceId(prefs.getString(Settings.KEY_PREF_THEME, Settings.DEFAULT_PREF_THEME)));
+        String preferredLocale = prefs.getString(Settings.KEY_PREF_SELECTED_LANGUAGE, null);
+        if (!TextUtils.isEmpty(preferredLocale))
+            Utils.setLocale(this, preferredLocale);
+
         UIUtils.tintSystemBars(this);
-        Utils.setPreferredLocale(this);
         super.onCreate(savedInstanceState);
     }
 }

--- a/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/BaseMediaActivity.java
@@ -20,7 +20,6 @@ import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import android.os.StrictMode;
 import android.text.TextUtils;
 import android.view.KeyEvent;
 import android.view.Menu;
@@ -33,8 +32,6 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.preference.PreferenceManager;
-import androidx.transition.Transition;
-import androidx.transition.TransitionInflater;
 
 import com.sothree.slidinguppanel.SlidingUpPanelLayout;
 
@@ -89,18 +86,6 @@ public abstract class BaseMediaActivity
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-//        StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder()
-//                                           .detectDiskReads()
-//                                           .detectDiskWrites()
-//                                           .detectNetwork()   // or .detectAll() for all detectable problems
-//                                           .penaltyLog()
-//                                           .build());
-//        StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
-//                                       .detectLeakedSqlLiteObjects()
-//                                       .detectLeakedClosableObjects()
-//                                       .penaltyLog()
-//                                       .penaltyDeath()
-//                                       .build());
         super.onCreate(savedInstanceState);
 
         binding = ActivityGenericMediaBinding.inflate(getLayoutInflater());

--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/AlbumInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/AlbumInfoFragment.java
@@ -152,7 +152,7 @@ public class AlbumInfoFragment extends AbstractInfoFragment
 
                     FileDownloadHelper.SongInfo songInfo = new FileDownloadHelper.SongInfo
                             (dataHolder.getUnderTitle(), dataHolder.getTitle(), 0, 0, null, null);
-                    setDownloadButtonState(songInfo.downloadDirectoryExists());
+                    //setDownloadButtonState(songInfo.downloadDirectoryExists());
 
                     updateView(dataHolder);
                     break;

--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/ArtistInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/ArtistInfoFragment.java
@@ -140,7 +140,7 @@ public class ArtistInfoFragment extends AbstractInfoFragment
 
                     FileDownloadHelper.SongInfo songInfo = new FileDownloadHelper.SongInfo(
                             cursor.getString(DetailsQuery.ARTIST),null, -1, -1, null, null);
-                    setDownloadButtonState(songInfo.downloadDirectoryExists());
+                    //setDownloadButtonState(songInfo.downloadDirectoryExists());
 
                     String artist = cursor.getString(DetailsQuery.ARTIST);
 

--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/MusicVideoInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/MusicVideoInfoFragment.java
@@ -157,7 +157,7 @@ public class MusicVideoInfoFragment extends AbstractInfoFragment
 
                     FileDownloadHelper.MusicVideoInfo musicVideoDownloadInfo = new FileDownloadHelper.MusicVideoInfo(
                             dataHolder.getTitle(), cursor.getString(MusicVideoDetailsQuery.FILE));
-                    setDownloadButtonState(musicVideoDownloadInfo.downloadFileExists());
+                    //setDownloadButtonState(musicVideoDownloadInfo.downloadFileExists());
 
                     updateView(dataHolder);
                     break;

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/MovieInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/MovieInfoFragment.java
@@ -238,7 +238,7 @@ public class MovieInfoFragment extends AbstractInfoFragment
 
                     movieDownloadInfo = new FileDownloadHelper.MovieInfo(
                             dataHolder.getTitle(), cursor.getString(MovieDetailsQuery.FILE));
-                    setDownloadButtonState(movieDownloadInfo.downloadDirectoryExists());
+                    //setDownloadButtonState(movieDownloadInfo.downloadDirectoryExists());
                     setWatchedButtonState(cursor.getInt(MovieDetailsQuery.PLAYCOUNT) > 0);
                     updateView(dataHolder);
                     checkOutdatedMovieDetails(cursor);

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowEpisodeInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowEpisodeInfoFragment.java
@@ -210,7 +210,7 @@ public class TVShowEpisodeInfoFragment extends AbstractInfoFragment
                             episodeTitle,
                             cursor.getString(EpisodeDetailsQuery.FILE));
 
-                    setDownloadButtonState(fileDownloadHelper.downloadFileExists());
+                    //setDownloadButtonState(fileDownloadHelper.downloadFileExists());
 
                     setWatchedButtonState(cursor.getInt(EpisodeDetailsQuery.PLAYCOUNT) > 0);
 

--- a/app/src/main/java/org/xbmc/kore/utils/Utils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/Utils.java
@@ -121,15 +121,7 @@ public class Utils {
         return bitmap;
     }
 
-    public static void setPreferredLocale(Context context) {
-        String preferredLocale = PreferenceManager.getDefaultSharedPreferences(context)
-                                                  .getString(Settings.KEY_PREF_SELECTED_LANGUAGE, "");
-        if (! preferredLocale.isEmpty()) {
-            Utils.setLocale(context, preferredLocale);
-        }
-    }
-
-    private static void setLocale(Context context, String localeName) {
+    public static void setLocale(Context context, String localeName) {
         Locale locale = getLocale(localeName);
 
         Locale.setDefault(locale);


### PR DESCRIPTION
Strinct mode complains about a disk read IO that occurred because the download button state was being set by checking if a directory or file existed. This removes that check, as the button is an action, and not intended to show the state. It was also frequently wrong.