### PR TITLE
Add collapsing toolbar, review Now Playing panel and play FAB

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -100,12 +100,20 @@ ext {
 dependencies {
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.preference:preference:1.2.0'
-    implementation 'androidx.appcompat:appcompat:1.4.2'
+    implementation 'androidx.appcompat:appcompat:1.5.0'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.core:core-google-shortcuts:1.0.1'
     implementation 'androidx.media:media:1.6.0'
     implementation "androidx.viewpager2:viewpager2:1.1.0-beta01"
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
+
+    implementation "androidx.fragment:fragment:1.5.2"
+    implementation "androidx.fragment:fragment-ktx:1.5.2"
+
+//    Dependency resolution
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
+    implementation "androidx.lifecycle:lifecycle-viewmodel:2.5.1"
 
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
@@ -113,7 +121,6 @@ dependencies {
     implementation 'org.greenrobot:eventbus:3.3.1'
     implementation 'org.jmdns:jmdns:3.5.7'
     implementation 'at.blogc:expandabletextview:1.0.5'
-    implementation 'com.sothree.slidinguppanel:library:3.4.0'
     implementation 'com.simplecityapps:recyclerview-fastscroll:2.0.1'
     implementation 'org.nanohttpd:nanohttpd:2.3.1'
 

--- a/app/src/androidTest/java/org/xbmc/kore/testhelpers/EspressoTestUtils.java
+++ b/app/src/androidTest/java/org/xbmc/kore/testhelpers/EspressoTestUtils.java
@@ -35,6 +35,7 @@ import com.sothree.slidinguppanel.SlidingUpPanelLayout;
 import org.hamcrest.Matcher;
 import org.xbmc.kore.R;
 import org.xbmc.kore.testhelpers.action.ViewActions;
+import org.xbmc.kore.ui.widgets.NowPlayingPanel;
 
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
@@ -360,11 +361,11 @@ public class EspressoTestUtils {
      *
      * @param panelState desired state of panel
      */
-    public static void waitForPanelState(final SlidingUpPanelLayout.PanelState panelState) {
+    public static void waitForPanelState(final int panelState) {
         onView(isRoot()).perform(ViewActions.waitForView(R.id.now_playing_panel, new ViewActions.CheckStatus() {
             @Override
             public boolean check(View v) {
-                return ((SlidingUpPanelLayout) v).getPanelState() == panelState;
+                return ((NowPlayingPanel)v).getPanelState() == panelState;
             }
         }, 10000));
     }

--- a/app/src/androidTest/java/org/xbmc/kore/tests/ui/music/SlideUpPanelTests.java
+++ b/app/src/androidTest/java/org/xbmc/kore/tests/ui/music/SlideUpPanelTests.java
@@ -26,7 +26,7 @@ import android.widget.TextView;
 import androidx.preference.PreferenceManager;
 import androidx.test.rule.ActivityTestRule;
 
-import com.sothree.slidinguppanel.SlidingUpPanelLayout;
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,6 +41,7 @@ import org.xbmc.kore.testutils.tcpserver.handlers.jsonrpc.response.methods.Playe
 import org.xbmc.kore.testutils.tcpserver.handlers.jsonrpc.response.methods.Playlist;
 import org.xbmc.kore.ui.sections.audio.MusicActivity;
 import org.xbmc.kore.ui.widgets.HighlightButton;
+import org.xbmc.kore.ui.widgets.NowPlayingPanel;
 import org.xbmc.kore.ui.widgets.RepeatModeButton;
 
 import java.util.concurrent.TimeoutException;
@@ -95,7 +96,7 @@ public class SlideUpPanelTests extends AbstractTestClass<MusicActivity> {
         getPlayerHandler().setPlaylists(getPlaylistHandler().getPlaylists());
         getPlayerHandler().startPlay(Playlist.playlistID.AUDIO, 0);
 
-        waitForPanelState(SlidingUpPanelLayout.PanelState.COLLAPSED);
+        waitForPanelState(BottomSheetBehavior.STATE_COLLAPSED);
     }
 
     /**
@@ -108,7 +109,7 @@ public class SlideUpPanelTests extends AbstractTestClass<MusicActivity> {
     @Test
     public void panelTitleTest() {
         Player.GetItem item = getPlayerHandler().getMediaItem();
-        onView(withId(R.id.npp_title)).check(matches(withText(item.getTitle())));
+        onView(withId(R.id.title)).check(matches(withText(item.getTitle())));
     }
 
     /**
@@ -120,9 +121,9 @@ public class SlideUpPanelTests extends AbstractTestClass<MusicActivity> {
      */
     @Test
     public void panelButtonsMusicTest() {
-        onView(withId(R.id.npp_next)).check(matches(isDisplayed()));
-        onView(withId(R.id.npp_previous)).check(matches(isDisplayed()));
-        onView(withId(R.id.npp_play)).check(matches(isDisplayed()));
+        onView(withId(R.id.next)).check(matches(isDisplayed()));
+        onView(withId(R.id.previous)).check(matches(isDisplayed()));
+        onView(withId(R.id.play)).check(matches(isDisplayed()));
     }
 
     /**
@@ -138,16 +139,16 @@ public class SlideUpPanelTests extends AbstractTestClass<MusicActivity> {
         Player.GetItem item = getPlayerHandler().getMediaItem();
         final String title = item.getTitle();
         onView(isRoot()).perform(ViewActions.waitForView(
-                R.id.npp_title, new ViewActions.CheckStatus() {
+                R.id.title, new ViewActions.CheckStatus() {
                     @Override
                     public boolean check(View v) {
                         return title.contentEquals(((TextView) v).getText());
                     }
                 }, 10000));
 
-        onView(withId(R.id.npp_next)).check(matches(not(isDisplayed())));
-        onView(withId(R.id.npp_previous)).check(matches(not(isDisplayed())));
-        onView(withId(R.id.npp_play)).check(matches(isDisplayed()));
+        onView(withId(R.id.next)).check(matches(not(isDisplayed())));
+        onView(withId(R.id.previous)).check(matches(not(isDisplayed())));
+        onView(withId(R.id.play)).check(matches(isDisplayed()));
     }
 
     /**
@@ -163,16 +164,16 @@ public class SlideUpPanelTests extends AbstractTestClass<MusicActivity> {
         Player.GetItem item = getPlayerHandler().getMediaItem();
         final String title = item.getTitle();
         onView(isRoot()).perform(ViewActions.waitForView(
-                R.id.npp_title, new ViewActions.CheckStatus() {
+                R.id.title, new ViewActions.CheckStatus() {
                     @Override
                     public boolean check(View v) {
                         return title.contentEquals(((TextView) v).getText());
                     }
                 }, 10000));
 
-        onView(withId(R.id.npp_next)).check(matches(isDisplayed()));
-        onView(withId(R.id.npp_previous)).check(matches(isDisplayed()));
-        onView(withId(R.id.npp_play)).check(matches(isDisplayed()));
+        onView(withId(R.id.next)).check(matches(isDisplayed()));
+        onView(withId(R.id.previous)).check(matches(isDisplayed()));
+        onView(withId(R.id.play)).check(matches(isDisplayed()));
     }
 
     /**
@@ -188,9 +189,9 @@ public class SlideUpPanelTests extends AbstractTestClass<MusicActivity> {
     public void panelButtonsShuffleTest() {
         expandPanel();
 
-        onView(withId(R.id.npp_shuffle)).perform(click());
+        onView(withId(R.id.shuffle)).perform(click());
 
-        onView(isRoot()).perform(ViewActions.waitForView(R.id.npp_shuffle, new ViewActions.CheckStatus() {
+        onView(isRoot()).perform(ViewActions.waitForView(R.id.shuffle, new ViewActions.CheckStatus() {
             @Override
             public boolean check(View v) {
                 return ((HighlightButton) v).isHighlighted();
@@ -216,7 +217,7 @@ public class SlideUpPanelTests extends AbstractTestClass<MusicActivity> {
         expandPanel();
 
         //Initial state should be OFF
-        onView(isRoot()).perform(ViewActions.waitForView(R.id.npp_repeat, new ViewActions.CheckStatus() {
+        onView(isRoot()).perform(ViewActions.waitForView(R.id.repeat, new ViewActions.CheckStatus() {
             @Override
             public boolean check(View v) {
                 return ((RepeatModeButton) v).getMode() == RepeatModeButton.MODE.OFF;
@@ -224,8 +225,8 @@ public class SlideUpPanelTests extends AbstractTestClass<MusicActivity> {
         }, 10000));
 
         // Test if repeat mode is set to ONE after first click
-        onView(withId(R.id.npp_repeat)).perform(click());
-        onView(isRoot()).perform(ViewActions.waitForView(R.id.npp_repeat, new ViewActions.CheckStatus() {
+        onView(withId(R.id.repeat)).perform(click());
+        onView(isRoot()).perform(ViewActions.waitForView(R.id.repeat, new ViewActions.CheckStatus() {
             @Override
             public boolean check(View v) {
                 return ((RepeatModeButton) v).getMode() == RepeatModeButton.MODE.ONE;
@@ -233,8 +234,8 @@ public class SlideUpPanelTests extends AbstractTestClass<MusicActivity> {
         }, 10000));
 
         // Test if repeat mode is set to ALL after second click
-        onView(withId(R.id.npp_repeat)).perform(click());
-        onView(isRoot()).perform(ViewActions.waitForView(R.id.npp_repeat, new ViewActions.CheckStatus() {
+        onView(withId(R.id.repeat)).perform(click());
+        onView(isRoot()).perform(ViewActions.waitForView(R.id.repeat, new ViewActions.CheckStatus() {
             @Override
             public boolean check(View v) {
                 return ((RepeatModeButton) v).getMode() == RepeatModeButton.MODE.ALL;
@@ -243,8 +244,8 @@ public class SlideUpPanelTests extends AbstractTestClass<MusicActivity> {
 
 
         // Test if repeat mode is set to OFF after third click
-        onView(withId(R.id.npp_repeat)).perform(click());
-        onView(isRoot()).perform(ViewActions.waitForView(R.id.npp_repeat, new ViewActions.CheckStatus() {
+        onView(withId(R.id.repeat)).perform(click());
+        onView(isRoot()).perform(ViewActions.waitForView(R.id.repeat, new ViewActions.CheckStatus() {
             @Override
             public boolean check(View v) {
                 return ((RepeatModeButton) v).getMode() == RepeatModeButton.MODE.OFF;
@@ -264,7 +265,7 @@ public class SlideUpPanelTests extends AbstractTestClass<MusicActivity> {
     public void keepCollapsedOnRotate() {
         rotateDevice(getActivity());
 
-        waitForPanelState(SlidingUpPanelLayout.PanelState.COLLAPSED);
+        waitForPanelState(BottomSheetBehavior.STATE_COLLAPSED;
     }
 
     /**
@@ -282,7 +283,7 @@ public class SlideUpPanelTests extends AbstractTestClass<MusicActivity> {
 
         rotateDevice(getActivity());
 
-        waitForPanelState(SlidingUpPanelLayout.PanelState.EXPANDED);
+        waitForPanelState(BottomSheetBehavior.STATE_EXPANDED);
     }
 
     /**
@@ -298,11 +299,11 @@ public class SlideUpPanelTests extends AbstractTestClass<MusicActivity> {
     @Test
     public void restoreRepeatButtonStateOnRotate() {
         expandPanel();
-        onView(withId(R.id.npp_repeat)).perform(click());
+        onView(withId(R.id.repeat)).perform(click());
 
         rotateDevice(getActivity());
 
-        onView(isRoot()).perform(ViewActions.waitForView(R.id.npp_repeat, new ViewActions.CheckStatus() {
+        onView(isRoot()).perform(ViewActions.waitForView(R.id.repeat, new ViewActions.CheckStatus() {
             @Override
             public boolean check(View v) {
                 return ((RepeatModeButton) v).getMode() == RepeatModeButton.MODE.ONE;
@@ -323,9 +324,9 @@ public class SlideUpPanelTests extends AbstractTestClass<MusicActivity> {
     public void setShuffleButtonState() {
         expandPanel();
 
-        onView(withId(R.id.npp_shuffle)).perform(click()); //Set state to shuffled
+        onView(withId(R.id.shuffle)).perform(click()); //Set state to shuffled
 
-        onView(withId(R.id.npp_shuffle)).check(matches(withHighlightState(true)));
+        onView(withId(R.id.shuffle)).check(matches(withHighlightState(true)));
     }
 
     /**
@@ -341,12 +342,12 @@ public class SlideUpPanelTests extends AbstractTestClass<MusicActivity> {
     @Test
     public void restoreShuffleButtonStateOnRotate() {
         expandPanel();
-        onView(withId(R.id.npp_shuffle)).perform(click()); //Set state to shuffled
+        onView(withId(R.id.shuffle)).perform(click()); //Set state to shuffled
 
         rotateDevice(getActivityTestRule().getActivity());
 
         //Using waitForView as we need to wait for the rotate to finish
-        onView(isRoot()).perform(ViewActions.waitForView(R.id.npp_shuffle, new ViewActions.CheckStatus() {
+        onView(isRoot()).perform(ViewActions.waitForView(R.id.shuffle, new ViewActions.CheckStatus() {
             @Override
             public boolean check(View v) {
                 return ((HighlightButton) v).isHighlighted();
@@ -445,7 +446,7 @@ public class SlideUpPanelTests extends AbstractTestClass<MusicActivity> {
         final int progress = 16;
         final String progressText = "0:16";
         expandPanel();
-        onView(withId(R.id.npp_play)).perform(click()); //Pause playback
+        onView(withId(R.id.play)).perform(click()); //Pause playback
 
         onView(withId(R.id.mpi_seek_bar)).perform(ViewActions.slideSeekBar(progress));
 
@@ -469,7 +470,7 @@ public class SlideUpPanelTests extends AbstractTestClass<MusicActivity> {
         final int progress = 16;
         final String progressText = "0:16";
         expandPanel();
-        onView(withId(R.id.npp_play)).perform(click()); //Pause playback
+        onView(withId(R.id.play)).perform(click()); //Pause playback
 
         onView(withId(R.id.mpi_seek_bar)).perform(ViewActions.slideSeekBar(progress));
         rotateDevice(getActivity());
@@ -496,7 +497,7 @@ public class SlideUpPanelTests extends AbstractTestClass<MusicActivity> {
     public void pauseSetProgressionPlay() {
         expandPanel();
 
-        onView(withId(R.id.npp_play)).perform(click()); //Pause playback
+        onView(withId(R.id.play)).perform(click()); //Pause playback
         onView(withId(R.id.mpi_seek_bar)).perform(ViewActions.slideSeekBar(16));
         getPlayerHandler().startPlay();
 
@@ -552,7 +553,7 @@ public class SlideUpPanelTests extends AbstractTestClass<MusicActivity> {
         Utils.openDrawer(getActivityTestRule());
         clickAdapterViewItem(2, R.id.navigation_drawer); //select movie activity
 
-        waitForPanelState(SlidingUpPanelLayout.PanelState.COLLAPSED);
+        waitForPanelState(BottomSheetBehavior.STATE_COLLAPSED);
         expandPanel();
 
         onView(isRoot()).perform(ViewActions.waitForView(R.id.mpi_seek_bar, new ViewActions.CheckStatus() {
@@ -574,7 +575,7 @@ public class SlideUpPanelTests extends AbstractTestClass<MusicActivity> {
      */
     @Test
     public void pausePlayback() {
-        onView(withId(R.id.npp_play)).perform(click());
+        onView(withId(R.id.play)).perform(click());
 
         assertSame(getPlayerHandler().getPlayState(), PlayerHandler.PLAY_STATE.PAUSED);
 
@@ -609,7 +610,7 @@ public class SlideUpPanelTests extends AbstractTestClass<MusicActivity> {
         edit.apply();
         pressBack();
 
-        waitForPanelState(SlidingUpPanelLayout.PanelState.HIDDEN);
+        waitForPanelState(BottomSheetBehavior.STATE_HIDDEN);
     }
 
     /**
@@ -639,19 +640,19 @@ public class SlideUpPanelTests extends AbstractTestClass<MusicActivity> {
         edit.apply();
         pressBack();
 
-        waitForPanelState(SlidingUpPanelLayout.PanelState.COLLAPSED);
+        waitForPanelState(BottomSheetBehavior.STATE_COLLAPSED);
     }
 
     private void expandPanel() {
         int tries = 10;
         while (tries-- > 0) {
             try {
-                onView(withId(R.id.npp_title)).perform(click());
+                onView(withId(R.id.title)).perform(click());
 
                 onView(isRoot()).perform(ViewActions.waitForView(R.id.now_playing_panel, new ViewActions.CheckStatus() {
                     @Override
                     public boolean check(View v) {
-                        return ((SlidingUpPanelLayout) v).getPanelState() == SlidingUpPanelLayout.PanelState.EXPANDED;
+                        return ((NowPlayingPanel) v).getPanelState() == BottomSheetBehavior.STATE_EXPANDED;
                     }
                 }, 1000));
 

--- a/app/src/main/java/org/xbmc/kore/ui/behaviors/HideOnVerticalScrollBehavior.java
+++ b/app/src/main/java/org/xbmc/kore/ui/behaviors/HideOnVerticalScrollBehavior.java
@@ -17,16 +17,15 @@
 package org.xbmc.kore.ui.behaviors;
 
 import android.content.Context;
+import android.util.AttributeSet;
+import android.util.DisplayMetrics;
+import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.view.ViewCompat;
-import android.util.AttributeSet;
-import android.view.View;
 
 public class HideOnVerticalScrollBehavior extends CoordinatorLayout.Behavior<View> {
-
-    private boolean hide;
 
     public HideOnVerticalScrollBehavior(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -43,11 +42,11 @@ public class HideOnVerticalScrollBehavior extends CoordinatorLayout.Behavior<Vie
     public void onNestedScroll(@NonNull CoordinatorLayout coordinatorLayout, @NonNull final View child, @NonNull View target, int dxConsumed, int dyConsumed, int dxUnconsumed, int dyUnconsumed, int type, @NonNull int[] consumed) {
         super.onNestedScroll(coordinatorLayout, child, target, dxConsumed, dyConsumed, dxUnconsumed, dyUnconsumed, type, consumed);
 
-        if (dyConsumed > 0 && !hide) {
-            hide = true;
-            ViewCompat.animate(child).translationY(child.getHeight());
-        } else if (dyConsumed < 0 && hide) {
-            hide = false;
+        boolean hidden = child.getTranslationY() != 0;
+        if (dyConsumed > 0 && !hidden) {
+            DisplayMetrics dm = child.getContext().getResources().getDisplayMetrics();
+            ViewCompat.animate(child).translationY(dm.heightPixels - child.getTop());
+        } else if (dyConsumed < 0 && hidden) {
             ViewCompat.animate(child).translationY(0);
         }
     }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonInfoFragment.java
@@ -25,8 +25,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.preference.PreferenceManager;
 
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
-
 import org.xbmc.kore.R;
 import org.xbmc.kore.Settings;
 import org.xbmc.kore.host.HostManager;
@@ -94,8 +92,8 @@ public class AddonInfoFragment extends AbstractInfoFragment {
     }
 
     @Override
-    protected boolean setupFAB(FloatingActionButton fab) {
-        fab.setOnClickListener(v -> {
+    protected View.OnClickListener getFABClickListener() {
+        return (v -> {
             Addons.ExecuteAddon action = new Addons.ExecuteAddon(addonId);
             action.execute(getHostManager().getConnection(), new ApiCallback<String>() {
                 @Override
@@ -111,7 +109,6 @@ public class AddonInfoFragment extends AbstractInfoFragment {
                 }
             }, callbackHandler);
         });
-        return true;
     }
 
     private void setupEnabledButton() {

--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListFragment.java
@@ -213,6 +213,7 @@ public class AddonListFragment extends AbstractListFragment {
                     }
 
                     adapter.notifyDataSetChanged();
+                    hideRefreshAnimation();
                     // Notify parent that list view is setup
                     notifyListSetupComplete();
                 }
@@ -221,6 +222,7 @@ public class AddonListFragment extends AbstractListFragment {
                 public void onError(int errorCode, String description) {
                     if (!isAdded()) return;
                     LogUtils.LOGD(TAG, "Error getting addons: " + description);
+                    hideRefreshAnimation();
                     showStatusMessage(null, getString(R.string.error_getting_addon_info, description));
                 }
             },

--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/AlbumInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/AlbumInfoFragment.java
@@ -31,14 +31,11 @@ import androidx.loader.app.LoaderManager;
 import androidx.loader.content.CursorLoader;
 import androidx.loader.content.Loader;
 
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
-
 import org.xbmc.kore.host.HostManager;
 import org.xbmc.kore.jsonrpc.type.PlaylistType;
 import org.xbmc.kore.provider.MediaContract;
 import org.xbmc.kore.ui.AbstractFragment;
 import org.xbmc.kore.ui.AbstractInfoFragment;
-import org.xbmc.kore.utils.FileDownloadHelper;
 import org.xbmc.kore.utils.LogUtils;
 import org.xbmc.kore.utils.MediaPlayerUtils;
 import org.xbmc.kore.utils.UIUtils;
@@ -93,13 +90,12 @@ public class AlbumInfoFragment extends AbstractInfoFragment
     }
 
     @Override
-    protected boolean setupFAB(FloatingActionButton fab) {
-        fab.setOnClickListener(v -> {
+    protected View.OnClickListener getFABClickListener() {
+        return (v -> {
             PlaylistType.Item item = new PlaylistType.Item();
             item.albumid = getDataHolder().getId();
             playItemOnKodi(item);
         });
-        return true;
     }
 
     /*
@@ -150,8 +146,8 @@ public class AlbumInfoFragment extends AbstractInfoFragment
                                            String.valueOf(year)) :
                                           genres);
 
-                    FileDownloadHelper.SongInfo songInfo = new FileDownloadHelper.SongInfo
-                            (dataHolder.getUnderTitle(), dataHolder.getTitle(), 0, 0, null, null);
+                    //FileDownloadHelper.SongInfo songInfo = new FileDownloadHelper.SongInfo
+                    //        (dataHolder.getUnderTitle(), dataHolder.getTitle(), 0, 0, null, null);
                     //setDownloadButtonState(songInfo.downloadDirectoryExists());
 
                     updateView(dataHolder);

--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/ArtistInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/ArtistInfoFragment.java
@@ -30,8 +30,6 @@ import androidx.loader.app.LoaderManager;
 import androidx.loader.content.CursorLoader;
 import androidx.loader.content.Loader;
 
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
-
 import org.xbmc.kore.jsonrpc.type.PlaylistType;
 import org.xbmc.kore.provider.MediaContract;
 import org.xbmc.kore.provider.MediaDatabase;
@@ -100,13 +98,12 @@ public class ArtistInfoFragment extends AbstractInfoFragment
     }
 
     @Override
-    protected boolean setupFAB(FloatingActionButton fab) {
-        fab.setOnClickListener(v -> {
+    protected View.OnClickListener getFABClickListener() {
+        return (v -> {
             PlaylistType.Item item = new PlaylistType.Item();
             item.artistid = getDataHolder().getId();
             playItemOnKodi(item);
         });
-        return true;
     }
 
     /*
@@ -138,8 +135,8 @@ public class ArtistInfoFragment extends AbstractInfoFragment
                 case LOADER_ARTIST:
                     cursor.moveToFirst();
 
-                    FileDownloadHelper.SongInfo songInfo = new FileDownloadHelper.SongInfo(
-                            cursor.getString(DetailsQuery.ARTIST),null, -1, -1, null, null);
+                    //FileDownloadHelper.SongInfo songInfo = new FileDownloadHelper.SongInfo(
+                    //        cursor.getString(DetailsQuery.ARTIST),null, -1, -1, null, null);
                     //setDownloadButtonState(songInfo.downloadDirectoryExists());
 
                     String artist = cursor.getString(DetailsQuery.ARTIST);

--- a/app/src/main/java/org/xbmc/kore/ui/sections/audio/MusicVideoInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/audio/MusicVideoInfoFragment.java
@@ -30,7 +30,6 @@ import androidx.loader.content.CursorLoader;
 import androidx.loader.content.Loader;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import org.xbmc.kore.R;
 import org.xbmc.kore.jsonrpc.event.MediaSyncEvent;
@@ -93,13 +92,12 @@ public class MusicVideoInfoFragment extends AbstractInfoFragment
     }
 
     @Override
-    protected boolean setupFAB(FloatingActionButton fab) {
-        fab.setOnClickListener(v -> {
+    protected View.OnClickListener getFABClickListener() {
+        return (v -> {
             PlaylistType.Item item = new PlaylistType.Item();
             item.musicvideoid = getDataHolder().getId();
             playItemOnKodi(item);
         });
-        return true;
     }
 
     @Override
@@ -155,8 +153,8 @@ public class MusicVideoInfoFragment extends AbstractInfoFragment
                     dataHolder.setDescription(cursor.getString(MusicVideoDetailsQuery.PLOT));
                     dataHolder.setSearchTerms(artist + " " + title);
 
-                    FileDownloadHelper.MusicVideoInfo musicVideoDownloadInfo = new FileDownloadHelper.MusicVideoInfo(
-                            dataHolder.getTitle(), cursor.getString(MusicVideoDetailsQuery.FILE));
+                    //FileDownloadHelper.MusicVideoInfo musicVideoDownloadInfo = new FileDownloadHelper.MusicVideoInfo(
+                    //        dataHolder.getTitle(), cursor.getString(MusicVideoDetailsQuery.FILE));
                     //setDownloadButtonState(musicVideoDownloadInfo.downloadFileExists());
 
                     updateView(dataHolder);

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/MovieInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/MovieInfoFragment.java
@@ -31,7 +31,6 @@ import androidx.loader.content.CursorLoader;
 import androidx.loader.content.Loader;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import org.xbmc.kore.R;
 import org.xbmc.kore.Settings;
@@ -157,13 +156,12 @@ public class MovieInfoFragment extends AbstractInfoFragment
     }
 
     @Override
-    protected boolean setupFAB(FloatingActionButton fab) {
-        fab.setOnClickListener(v -> {
+    protected View.OnClickListener getFABClickListener() {
+        return (v -> {
             PlaylistType.Item item = new PlaylistType.Item();
             item.movieid = getDataHolder().getId();
             playItemOnKodi(item);
         });
-        return true;
     }
 
     @Override

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowEpisodeInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowEpisodeInfoFragment.java
@@ -31,7 +31,6 @@ import androidx.loader.content.CursorLoader;
 import androidx.loader.content.Loader;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import org.xbmc.kore.R;
 import org.xbmc.kore.jsonrpc.ApiCallback;
@@ -131,13 +130,12 @@ public class TVShowEpisodeInfoFragment extends AbstractInfoFragment
     }
 
     @Override
-    protected boolean setupFAB(FloatingActionButton fab) {
-        fab.setOnClickListener(v -> {
+    protected View.OnClickListener getFABClickListener() {
+        return (v -> {
             PlaylistType.Item item = new PlaylistType.Item();
             item.episodeid = getDataHolder().getId();
             playItemOnKodi(item);
         });
-        return true;
     }
 
     @Override

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowInfoFragment.java
@@ -28,8 +28,6 @@ import androidx.loader.app.LoaderManager;
 import androidx.loader.content.CursorLoader;
 import androidx.loader.content.Loader;
 
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
-
 import org.xbmc.kore.R;
 import org.xbmc.kore.Settings;
 import org.xbmc.kore.jsonrpc.event.MediaSyncEvent;
@@ -88,8 +86,8 @@ public class TVShowInfoFragment extends AbstractInfoFragment
     }
 
     @Override
-    protected boolean setupFAB(FloatingActionButton fab) {
-        return false;
+    protected View.OnClickListener getFABClickListener() {
+        return null;
     }
 
     @Override

--- a/app/src/main/java/org/xbmc/kore/utils/UIUtils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/UIUtils.java
@@ -333,10 +333,11 @@ public class UIUtils {
      * @param activity Activity
      */
     public static void tintSystemBars(Activity activity) {
-        int color = SurfaceColors.SURFACE_2.getColor(activity);
+        int color;
+//        color = SurfaceColors.SURFACE_2.getColor(activity);
 //        if (Utils.isMOrLater())
 //            activity.getWindow().setStatusBarColor(color);
-        color = SurfaceColors.SURFACE_1.getColor(activity);
+        color = SurfaceColors.SURFACE_3.getColor(activity);
         if (Utils.isOreoMR1OrLater())
             activity.getWindow().setNavigationBarColor(color);
     }

--- a/app/src/main/res/drawable/ic_bottom_sheet_drag_handle.xml
+++ b/app/src/main/res/drawable/ic_bottom_sheet_drag_handle.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="3dp"
+    android:tint="#FFFFFF"
+    android:viewportWidth="24"
+    android:viewportHeight="3">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M 1.5 0 L 22.5 0 Q 24 0 24 1.5 L 24 1.5 Q 24 3 22.5 3 L 1.5 3 Q 0 3 0 1.5 L 0 1.5 Q 0 0 1.5 0 Z"
+        android:strokeWidth="1" />
+</vector>

--- a/app/src/main/res/layout/activity_generic_media.xml
+++ b/app/src/main/res/layout/activity_generic_media.xml
@@ -17,27 +17,65 @@
 
 <androidx.drawerlayout.widget.DrawerLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <LinearLayout
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">
 
-        <include layout="@layout/toolbar_default" />
+        <com.google.android.material.appbar.AppBarLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/top_app_bar_layout"
+            style="@style/Widget.Kore.Toolbar">
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/default_toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                app:layout_scrollFlags="scroll|enterAlways|snap"
+                style="@style/Widget.Kore.Toolbar" />
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/fragment_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab_play"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/fab_normal_margin"
+            android:layout_marginBottom="@dimen/fab_normal_margin"
+            android:layout_gravity="bottom|end"
+            android:visibility="gone"
+            android:contentDescription="@string/play"
+            app:layout_behavior=".ui.behaviors.HideOnVerticalScrollBehavior"
+            app:layout_dodgeInsetEdges="bottom"
+            app:fabSize="normal"
+            app:useCompatPadding="true"
+            style="?attr/floatingActionButtonPrimaryStyle"
+            app:srcCompat="@drawable/ic_round_play_arrow_24"/>
 
         <org.xbmc.kore.ui.widgets.NowPlayingPanel
-            xmlns:sothree="http://schemas.android.com/apk/res-auto"
             android:id="@+id/now_playing_panel"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
             android:gravity="bottom"
-            sothree:umanoShadowHeight="0dp"
-            sothree:umanoFadeColor="@android:color/transparent"
-            sothree:umanoInitialState="hidden"/>
-    </LinearLayout>
+            android:background="@drawable/background_round_top"
+            style="@style/Widget.Kore.BottomPanel"
+            app:behavior_hideable="true"
+            app:behavior_peekHeight="@dimen/now_playing_panel_heigth"
+            app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
+            app:layout_insetEdge="bottom"/>
+
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/navigation_drawer"

--- a/app/src/main/res/layout/fragment_default_view_pager.xml
+++ b/app/src/main/res/layout/fragment_default_view_pager.xml
@@ -27,9 +27,12 @@
         android:layout_height="wrap_content"
         app:tabMode="auto"
         app:tabIndicatorFullWidth="true"
-        android:background="?attr/colorSurface"
-        android:elevation="@dimen/kore_elevation_level2"
+        android:background="@android:color/transparent"
+        android:elevation="@dimen/kore_elevation_level0"
         app:tabTextAppearance="@style/TextAppearance.Kore.TabLayout" />
+    <!--        android:elevation="@dimen/kore_elevation_level2"-->
+    <!--        android:outlineAmbientShadowColor="@android:color/transparent"-->
+    <!--        android:outlineSpotShadowColor="@android:color/transparent"-->
 
     <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/pager"

--- a/app/src/main/res/layout/fragment_media_info.xml
+++ b/app/src/main/res/layout/fragment_media_info.xml
@@ -14,7 +14,7 @@
    limitations under the License.
 -->
 
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -23,7 +23,6 @@
         android:id="@+id/media_art"
         android:layout_width="match_parent"
         android:layout_height="@dimen/info_art_height"
-        android:layout_alignParentStart="true"
         android:layout_marginTop="@dimen/small_padding"
         android:layout_marginLeft="@dimen/info_panel_horiz_margin"
         android:layout_marginRight="@dimen/info_panel_horiz_margin"
@@ -274,22 +273,6 @@
         </androidx.core.widget.NestedScrollView>
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/fab_play"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/fab_normal_margin"
-        android:visibility="gone"
-        android:contentDescription="@string/play"
-        app:fabSize="normal"
-        app:useCompatPadding="true"
-        style="?attr/floatingActionButtonPrimaryStyle"
-        app:layout_anchor="@id/media_panel"
-        app:layout_anchorGravity="bottom|end"
-        app:layout_scrollFlags="scroll|enterAlways"
-        app:layout_behavior="org.xbmc.kore.ui.behaviors.HideOnVerticalScrollBehavior"
-        app:srcCompat="@drawable/ic_round_play_arrow_24"/>
-
     <!-- View that will be shown with the circularReveal when user presses the FAB -->
     <View
         android:id="@+id/exit_transition_view"
@@ -297,4 +280,4 @@
         android:layout_height="match_parent"
         android:background="?attr/colorPrimaryContainer"
         android:visibility="invisible" />
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+</FrameLayout>

--- a/app/src/main/res/layout/item_tvshow_episode.xml
+++ b/app/src/main/res/layout/item_tvshow_episode.xml
@@ -35,10 +35,11 @@
         style="@style/Widget.Kore.TextView.MediaList.Title"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/small_padding"
         app:layout_constraintEnd_toStartOf="@id/list_context_menu"
         app:layout_constraintStart_toEndOf="@id/art"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/details"
+        app:layout_constraintVertical_chainStyle="packed" />
 
     <TextView
         android:id="@+id/details"
@@ -47,17 +48,18 @@
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toStartOf="@id/list_context_menu"
         app:layout_constraintStart_toStartOf="@id/title"
-        app:layout_constraintTop_toBottomOf="@id/title" />
+        app:layout_constraintTop_toBottomOf="@id/title"
+        app:layout_constraintBottom_toTopOf="@id/duration"/>
 
     <TextView
         android:id="@+id/duration"
         style="@style/Widget.Kore.TextView.MediaList.Info"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/small_padding"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/list_context_menu"
-        app:layout_constraintStart_toStartOf="@id/title" />
+        app:layout_constraintStart_toStartOf="@id/title"
+        app:layout_constraintTop_toBottomOf="@id/details"
+        app:layout_constraintBottom_toBottomOf="parent"/>
 
     <ImageView
         android:id="@+id/list_context_menu"

--- a/app/src/main/res/layout/now_playing_panel.xml
+++ b/app/src/main/res/layout/now_playing_panel.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
    Copyright 2017 Martijn Brekhof. All rights reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,111 +13,116 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-<merge
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/fragment_container"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
-
-    <LinearLayout
-        android:id="@+id/panel_container"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/collapsed_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        style="@style/Widget.Kore.BottomPanel"
-        android:background="@drawable/background_round_top">
+        android:orientation="horizontal">
 
-        <LinearLayout
-            android:id="@+id/collapsed_view"
-            android:layout_width="match_parent"
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/poster"
+            android:layout_width="@dimen/now_playing_panel_art_width"
+            android:layout_height="@dimen/now_playing_panel_art_heigth"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            android:contentDescription="@string/poster"
+            android:scaleType="centerCrop"
+            app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.Kore.Image.NowPlayingArt" />
+
+        <ImageView
+            android:id="@+id/drag_handle"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="4dp"
+            android:src="@drawable/ic_bottom_sheet_drag_handle"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="?attr/colorOnSurfaceVariant"
+            android:alpha="0.4" />
 
-            <com.google.android.material.imageview.ShapeableImageView
-                android:id="@+id/poster"
-                android:layout_width="@dimen/now_playing_panel_art_width"
-                android:layout_height="@dimen/now_playing_panel_art_heigth"
-                android:scaleType="centerCrop"
-                android:contentDescription="@string/poster"
-                app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.Kore.Image.NowPlayingArt"/>
+        <TextView
+            android:id="@+id/title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toEndOf="@id/poster"
+            app:layout_constraintEnd_toStartOf="@id/volume_muted_indicator"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/details"
+            app:layout_constraintVertical_chainStyle="packed"
+            android:layout_marginStart="@dimen/small_padding"
+            android:layout_marginEnd="@dimen/small_padding"
+            android:gravity="center_horizontal"
+            android:ellipsize="marquee"
+            android:fadingEdge="horizontal"
+            android:singleLine="true"
+            android:textAppearance="@style/TextAppearance.Kore.NowPlaying.Title" />
 
-            <LinearLayout
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:layout_gravity="center_vertical"
-                android:layout_weight="1">
+        <TextView
+            android:id="@+id/details"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="@id/title"
+            app:layout_constraintEnd_toEndOf="@id/title"
+            app:layout_constraintTop_toBottomOf="@id/title"
+            app:layout_constraintBottom_toBottomOf="parent"
+            android:layout_marginStart="@dimen/small_padding"
+            android:layout_marginEnd="@dimen/small_padding"
+            android:gravity="center_horizontal"
+            android:ellipsize="marquee"
+            android:fadingEdge="horizontal"
+            android:singleLine="true"
+            android:textAppearance="@style/TextAppearance.Kore.NowPlaying.Details" />
 
-                <TextView
-                    android:id="@+id/title"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:paddingLeft="@dimen/small_padding"
-                    android:paddingRight="@dimen/small_padding"
-                    android:textAppearance="@style/TextAppearance.Kore.NowPlaying.Title"
-                    android:singleLine="true"
-                    android:ellipsize="marquee"
-                    android:fadingEdge="horizontal"
-                    android:gravity="center_vertical"/>
+        <org.xbmc.kore.ui.widgets.HighlightButton
+            android:id="@+id/volume_muted_indicator"
+            style="@style/Widget.Kore.Button.Borderless"
+            android:layout_width="@dimen/default_icon_size"
+            android:layout_height="@dimen/default_icon_size"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/play"
+            android:contentDescription="@string/volume_mute"
+            android:src="@drawable/ic_round_volume_off_24"
+            android:visibility="gone" />
 
-                <TextView
-                    android:id="@+id/details"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:paddingLeft="@dimen/small_padding"
-                    android:paddingRight="@dimen/small_padding"
-                    android:textAppearance="@style/TextAppearance.Kore.NowPlaying.Details"
-                    android:singleLine="true"
-                    android:ellipsize="marquee"
-                    android:fadingEdge="horizontal"
-                    android:gravity="center_vertical"/>
-            </LinearLayout>
+        <ImageButton
+            android:id="@+id/play"
+            style="@style/Widget.Kore.Button.Borderless"
+            android:layout_width="@dimen/default_icon_size"
+            android:layout_height="@dimen/default_icon_size"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:contentDescription="@string/play"
+            android:src="@drawable/ic_round_play_arrow_24" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
-            <org.xbmc.kore.ui.widgets.HighlightButton
-                android:id="@+id/volume_muted_indicator"
-                android:layout_width="@dimen/default_icon_size"
-                android:layout_height="@dimen/default_icon_size"
-                android:layout_gravity="center_vertical"
-                style="@style/Widget.Kore.Button.Borderless"
-                android:src="@drawable/ic_round_volume_off_24"
-                android:contentDescription="@string/volume_mute"
-                android:visibility="gone"/>
+    <!-- Progress bar -->
+    <org.xbmc.kore.ui.widgets.MediaProgressIndicator
+        android:id="@+id/progress_info"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/buttonbar_height"
+        android:orientation="horizontal"
+        android:paddingLeft="@dimen/default_padding"
+        android:paddingRight="@dimen/default_padding" />
 
-            <ImageButton
-                android:id="@+id/play"
-                android:layout_width="@dimen/default_icon_size"
-                android:layout_height="@dimen/default_icon_size"
-                android:layout_gravity="center_vertical"
-                style="@style/Widget.Kore.Button.Borderless"
-                android:src="@drawable/ic_round_play_arrow_24"
-                android:contentDescription="@string/play" />
-        </LinearLayout>
+    <!-- Media playback control buttons -->
+    <org.xbmc.kore.ui.widgets.MediaPlaybackBar
+        android:id="@+id/media_playback_bar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/buttonbar_height"
+        android:orientation="horizontal"
+        app:view_mode="full" />
 
-        <!-- Progress bar -->
-        <org.xbmc.kore.ui.widgets.MediaProgressIndicator
-            android:id="@+id/progress_info"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/buttonbar_height"
-            android:paddingRight="@dimen/default_padding"
-            android:paddingLeft="@dimen/default_padding"
-            android:orientation="horizontal"/>
-
-        <!-- Media playback control buttons -->
-        <org.xbmc.kore.ui.widgets.MediaPlaybackBar
-            android:id="@+id/media_playback_bar"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/buttonbar_height"
-            android:orientation="horizontal"
-            app:view_mode="full" />
-
-        <!-- Media action buttons -->
-        <org.xbmc.kore.ui.widgets.MediaActionsBar
-            android:id="@+id/media_actions_bar"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/buttonbar_height"
-            android:orientation="horizontal" />
-    </LinearLayout>
+    <!-- Media action buttons -->
+    <org.xbmc.kore.ui.widgets.MediaActionsBar
+        android:id="@+id/media_actions_bar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/buttonbar_height"
+        android:orientation="horizontal" />
 </merge>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -56,11 +56,20 @@
 	<dimen name="navigation_drawer_item_height">48dp</dimen>
     <dimen name="navigation_drawer_item_hosts_height">168dp</dimen>
 
+    <!-- Image sizes on Kodi
+    banner: 1000 x 185
+    clearart: 1000 x 562
+    clearlogo: 800 x 310
+    fanart: 1920 x 1080 (1.778)
+    poster: 505 x 720 (1.452)
+    thumb: 720 x 405 || 720 x 306
+    -->
+
     <dimen name="remote_poster_width">98dp</dimen>
-    <dimen name="remote_poster_height">140dp</dimen>
+    <dimen name="remote_poster_height">142dp</dimen>
 
     <dimen name="info_poster_width">112dp</dimen>
-    <dimen name="info_poster_height">160dp</dimen>
+    <dimen name="info_poster_height">162dp</dimen>
     <dimen name="info_poster_width_square">112dp</dimen>
     <dimen name="info_poster_height_square">112dp</dimen>
 
@@ -116,11 +125,11 @@
 
     <dimen name="epg_time_width">56dp</dimen>
 
-    <dimen name="now_playing_panel_art_heigth">64dp</dimen>
-    <dimen name="now_playing_panel_art_width">52dp</dimen>
+    <dimen name="now_playing_panel_heigth">80dp</dimen>
+    <dimen name="now_playing_panel_art_heigth">80dp</dimen>
+    <dimen name="now_playing_panel_art_width">56dp</dimen>
 
-    <dimen name="fab_normal_margin">8dp</dimen>
-    <dimen name="fab_mini_margin">16dp</dimen>
+    <dimen name="fab_normal_margin">16dp</dimen>
 
     <!-- Elevation for views, copied from Material 3 -->
     <dimen name="kore_elevation_level0">0dp</dimen>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -128,10 +128,10 @@
         <item name="android:background">@drawable/background_round_alpha</item>
     </style>
 
-    <style name="Widget.Kore.BottomPanel" parent="Widget.Kore">
+    <style name="Widget.Kore.BottomPanel" parent="Widget.Material3.BottomSheet">
         <item name="android:background">?attr/colorSurface</item>
 <!--        <item name="android:backgroundTint">?attr/colorSurfaceVariant</item>-->
-        <item name="android:elevation">@dimen/kore_elevation_level1</item>
+        <item name="android:elevation">@dimen/kore_elevation_level3</item>
     </style>
 
     <style name="Widget.Kore.RatingBar" parent="Widget.Kore">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -19,8 +19,6 @@
     <style name="Theme.Kore.Default.Dynamic" parent="Theme.Kore.Default.Light"/>
 
     <style name="Theme.Kore.Default.Dark" parent="Theme.Material3.Dark.NoActionBar">
-        <item name="android:windowActivityTransitions">true</item>
-
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">?attr/colorSurface</item>
 
@@ -76,7 +74,6 @@
 
     <!-- Base Light theme, allowing for customization based on the Android version -->
     <style name="Theme.Kore.Default.LightBase" parent="Theme.Material3.Light.NoActionBar">
-        <item name="android:windowActivityTransitions">true</item>
     </style>
 
     <style name="Theme.Kore.Default.Light" parent="Theme.Kore.Default.LightBase">


### PR DESCRIPTION
The initial goal of this was: 1) to hide the toolbar in media screens when scrolled, according to Android motion design and 2) to review the Now Playing panel, as it had some issues that needed addressing, namely 1) it was using a library that is old and no longer maintained and 2) it required that the list and media info `fragments` were inside the Now Playing panel layout, so that it could control those fragments when the panel was shown/hidden. This made it non-obvious the structure of the layout when looking at the base layout (`activity_generic_media`) and some issues as detailed bellow. These 2 goals were interwined, as to add a collapsing toolbar it needs to:
- Add a `CoordinatorLayout` to the root of `activity_generic_media` to control the toolbar
- Add a `AppBarLayout` enclosing the toolbar
- Make the dependent scroll view a child of the `CoordinatorLayout`, immediatly after the toolbar. This was an issue, as the dependent scroll view (the list or the nested scroll view of the info screens) was nested inside the Now Playing panel, which caused numerous issues when trying to collapse the toolbar.

So to solve this the following changes were done:
- Remove the `SlidingUpPanel` library, replacing it with the default Android mechanism for bottom sheets, which relies on just adding a `BottomSheetBehaviour` to an appropriate view. Now the `NowPlayingPanel` is a view, inheriting from LinearLayout, which doesn't contain the list/info fragment. A dependent fragment can be set on the panel, so that when it goes from the hidden to the collapsed state, it changes the dependent view bottom margins, so that it's still possible to scroll till the end of that view with the panel visible.
- Add the `CoordinatorLayout`, the `AppBarLayout` and move the list/info `FragmentContainerView` to the `activity_generic_media` so that 1) the collapsing toolbar worked, 2) the structure of the screen was obvious and 3) the panel worked

But now we had 2 `CoordinatorLayout` (one inside the other to control the FAB), which caused other issues, namely flickering. Furthermore, the FAB stopped working correctly because the collapsing toolbar changed the dimensions of the fragment that contained the fab, and the fab moved when scrolling the collapsing toolbar.

To solve this, the FAB had to be moved to the `activity_generic_media`, which solves the UI problems, but creates a conceptual issue, as the FAB is conceptually owned and should be controlled by the child info fragment. So this solution breaks some encapsulation, having the fab at the activity, but letting the fragment control it, but it was the only way to make the UI work correctly with the collapsing toolbar, hideable panel and moveable FAB.