### PR TITLE
Tweak theme preferences and add a new "System Colours" option

### DIFF
--- a/app/src/main/java/org/xbmc/kore/Settings.java
+++ b/app/src/main/java/org/xbmc/kore/Settings.java
@@ -59,8 +59,12 @@ public class Settings {
      */
 
     // Theme
-    public static final String KEY_PREF_THEME = "pref_theme";
-    public static final String DEFAULT_PREF_THEME = "0";
+    public static final String KEY_PREF_THEME_COLOR = "pref_theme_color";
+    public static final String DEFAULT_PREF_THEME_COLOR = "kore";
+    public static final String VALUE_PREF_THEME_COLOR_SYSTEM_COLORS = "system_colors";
+
+    public static final String KEY_PREF_THEME_VARIANT = "pref_theme_variant";
+    public static final String DEFAULT_PREF_THEME_VARIANT = "auto";
 
     // Switch to remote
     public static final String KEY_PREF_SWITCH_TO_REMOTE_AFTER_MEDIA_START = "pref_switch_to_remote_after_media_start";
@@ -212,4 +216,32 @@ public class Settings {
     }
     public static final String DEFAULT_PREF_NAME_BOOKMARKED_ADDON = "Content";
 
+    /**
+     * Returns a theme resource Id given the value stored in Shared Preferences
+     * @param prefThemeColor Shared Preferences colour for the theme
+     * @param prefThemeVariant Shared Preferences variant for the theme
+     * @return Android resource id of the theme
+     */
+    public static int getThemeResourceId(String prefThemeColor, String prefThemeVariant) {
+        switch (prefThemeColor) {
+            case "sun":
+                switch (prefThemeVariant) {
+                    case "light":
+                        return R.style.Theme_Kore_Sun_Light;
+                    case "dark":
+                        return R.style.Theme_Kore_Sun_Dark;
+                    default:
+                        return R.style.Theme_Kore_Sun_Auto;
+                }
+            default:  // "kore" and "system_colors" share this
+                switch (prefThemeVariant) {
+                    case "light":
+                        return R.style.Theme_Kore_Default_Light;
+                    case "dark":
+                        return R.style.Theme_Kore_Default_Dark;
+                    default:
+                        return R.style.Theme_Kore_Default_Auto;
+                }
+        }
+    }
 }

--- a/app/src/main/java/org/xbmc/kore/ui/BaseActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/BaseActivity.java
@@ -17,12 +17,12 @@ package org.xbmc.kore.ui;
 
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.os.StrictMode;
 import android.text.TextUtils;
 
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.preference.PreferenceManager;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.google.android.material.color.DynamicColors;
 
 import org.xbmc.kore.Settings;
 import org.xbmc.kore.utils.UIUtils;
@@ -49,7 +49,14 @@ public abstract class BaseActivity extends AppCompatActivity {
 //                                       .build());
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-        setTheme(UIUtils.getThemeResourceId(prefs.getString(Settings.KEY_PREF_THEME, Settings.DEFAULT_PREF_THEME)));
+
+        String themeColor = prefs.getString(Settings.KEY_PREF_THEME_COLOR, Settings.DEFAULT_PREF_THEME_COLOR),
+                themeVariant = prefs.getString(Settings.KEY_PREF_THEME_VARIANT, Settings.DEFAULT_PREF_THEME_VARIANT);
+        setTheme(Settings.getThemeResourceId(themeColor, themeVariant));
+        if (Utils.isSOrLater() && themeColor.equals(Settings.VALUE_PREF_THEME_COLOR_SYSTEM_COLORS)) {
+            DynamicColors.applyToActivityIfAvailable(this);
+        }
+
         String preferredLocale = prefs.getString(Settings.KEY_PREF_SELECTED_LANGUAGE, null);
         if (!TextUtils.isEmpty(preferredLocale))
             Utils.setLocale(this, preferredLocale);

--- a/app/src/main/java/org/xbmc/kore/ui/sections/settings/SettingsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/settings/SettingsFragment.java
@@ -120,16 +120,6 @@ public class SettingsFragment extends PreferenceFragmentCompat
         }
 
         setupPreferences();
-
-        ListPreference languagePref = findPreference(Settings.KEY_PREF_LANGUAGE);
-        if (languagePref != null) {
-            Locale currentLocale = getCurrentLocale();
-            languagePref.setSummary(currentLocale.getDisplayLanguage(currentLocale));
-            languagePref.setOnPreferenceClickListener(preference -> {
-                setupLanguagePreference((ListPreference) preference);
-                return true;
-            });
-        }
     }
 
     @Override
@@ -155,8 +145,10 @@ public class SettingsFragment extends PreferenceFragmentCompat
         setupPreferences();
         Context ctx = requireContext();
 
-        if (key.equals(Settings.KEY_PREF_THEME) || key.equals(Settings.getNavDrawerItemsPrefKey(hostId))
-            || key.equals((Settings.getRemoteBarItemsPrefKey(hostId)))) {
+        if (key.equals(Settings.KEY_PREF_THEME_COLOR) ||
+            key.equals(Settings.KEY_PREF_THEME_VARIANT) ||
+            key.equals(Settings.getNavDrawerItemsPrefKey(hostId)) ||
+            key.equals((Settings.getRemoteBarItemsPrefKey(hostId)))) {
             // restart to apply new theme (actually build an entirely new task stack)
             TaskStackBuilder.create(ctx)
                             .addNextIntent(new Intent(ctx, RemoteActivity.class))
@@ -192,10 +184,34 @@ public class SettingsFragment extends PreferenceFragmentCompat
      * Sets up the preferences state and summaries
      */
     private void setupPreferences() {
-        // Theme preferences
-        ListPreference themePref = findPreference(Settings.KEY_PREF_THEME);
-        if (themePref != null) themePref.setSummary(themePref.getEntry());
         Context context = requireContext();
+
+        // Theme preferences
+        ListPreference themeColorPref = findPreference(Settings.KEY_PREF_THEME_COLOR);
+        if (themeColorPref != null) {
+            // Depending on the Android version we need to show different entries and values
+            if (Utils.isSOrLater()) {
+                themeColorPref.setEntries(R.array.theme_colors_array);
+                themeColorPref.setEntryValues(R.array.theme_colors_values_array);
+            } else {
+                themeColorPref.setEntries(R.array.theme_colors_array_pre_S);
+                themeColorPref.setEntryValues(R.array.theme_colors_values_array_pre_S);
+            }
+            themeColorPref.setSummary(themeColorPref.getEntry());
+        }
+        ListPreference themeVariantPref = findPreference(Settings.KEY_PREF_THEME_VARIANT);
+        if (themeVariantPref != null) themeVariantPref.setSummary(themeVariantPref.getEntry());
+
+        // Language preference
+        ListPreference languagePref = findPreference(Settings.KEY_PREF_LANGUAGE);
+        if (languagePref != null) {
+            Locale currentLocale = getCurrentLocale();
+            languagePref.setSummary(currentLocale.getDisplayLanguage(currentLocale));
+            languagePref.setOnPreferenceClickListener(preference -> {
+                setupLanguagePreference((ListPreference) preference);
+                return true;
+            });
+        }
 
         // About preference
         String nameAndVersion = context.getString(R.string.app_name);

--- a/app/src/main/java/org/xbmc/kore/utils/UIUtils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/UIUtils.java
@@ -390,29 +390,6 @@ public class UIUtils {
         return (alpha << 24) | (color & 0x00ffffff);
     }
 
-    /**
-     * Returns a theme resource Id given the value stored in Shared Preferences
-     * @param prefThemeValue Shared Preferences value for the theme
-     * @return Android resource id of the theme
-     */
-    public static int getThemeResourceId(String prefThemeValue) {
-        switch (Integer.parseInt(prefThemeValue)) {
-            case 1:
-                return R.style.Theme_Kore_Default_Light;
-            case 2:
-                return R.style.Theme_Kore_Default_Dark;
-            case 3:
-                return R.style.Theme_Kore_Sun_Dynamic;
-            case 4:
-                return R.style.Theme_Kore_Sun_Light;
-            case 5:
-                return R.style.Theme_Kore_Sun_Dark;
-            case 0:
-            default:
-                return R.style.Theme_Kore_Default_Dynamic;
-        }
-    }
-
     public static void handleVibration(Context context) {
         if(context == null) return;
 

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.Kore.Default.Dynamic" parent="Theme.Kore.Default.Dark"/>
-    <style name="Theme.Kore.Sun.Dynamic" parent="Theme.Kore.Sun.Dark"/>
+    <style name="Theme.Kore.Default.Auto" parent="Theme.Kore.Default.Dark"/>
+    <style name="Theme.Kore.Sun.Auto" parent="Theme.Kore.Sun.Dark"/>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -43,6 +43,40 @@
         <item>5</item>
     </string-array>
 
+    <!-- Theme colors -->
+    <string-array name="theme_colors_array">
+        <item>@string/theme_color_kore</item>
+        <item>@string/theme_color_sun</item>
+        <item>@string/theme_color_system_colors</item>
+    </string-array>
+    <string-array translatable="false" name="theme_colors_values_array">
+        <item>kore</item>
+        <item>sun</item>
+        <item>system_colors</item>
+    </string-array>
+
+    <!-- For pre Android S (31) remove the System Colors option as its not applicable -->
+    <string-array name="theme_colors_array_pre_S">
+        <item>@string/theme_color_kore</item>
+        <item>@string/theme_color_sun</item>
+    </string-array>
+    <string-array translatable="false" name="theme_colors_values_array_pre_S">
+        <item>kore</item>
+        <item>sun</item>
+    </string-array>
+
+    <!-- Theme variants -->
+    <string-array name="theme_variants_array">
+        <item>@string/theme_variant_auto</item>
+        <item>@string/theme_variant_light</item>
+        <item>@string/theme_variant_dark</item>
+    </string-array>
+    <string-array translatable="false" name="theme_variants_values_array">
+        <item>auto</item>
+        <item>light</item>
+        <item>dark</item>
+    </string-array>
+
     <!-- Remote Bar items -->
     <string-array name="entries_remote_bar_items">
         <item>@string/home</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -371,6 +371,17 @@
     <string name="theme_sunrise">Sunrise</string>
     <string name="theme_sunset">Sunset</string>
 
+    <!-- New theme strings -->
+    <string name="theme_color">Colour Scheme</string>
+    <string name="theme_color_system_colors">System Colours</string>
+    <string name="theme_color_kore">Kore</string>
+    <string name="theme_color_sun">Sun</string>
+
+    <string name="theme_variant">Variant</string>
+    <string name="theme_variant_auto">System Default</string>
+    <string name="theme_variant_light">Light</string>
+    <string name="theme_variant_dark">Dark</string>
+
     <string name="switch_to_remote">Show on media start</string>
     <string name="keep_remote_above_lockscreen">Show over lockscreen</string>
     <string name="pref_keep_screen_on">Stay awake</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -16,7 +16,7 @@
 -->
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <style name="Theme.Kore.Default.Dynamic" parent="Theme.Kore.Default.Light"/>
+    <style name="Theme.Kore.Default.Auto" parent="Theme.Kore.Default.Light"/>
 
     <style name="Theme.Kore.Default.Dark" parent="Theme.Material3.Dark.NoActionBar">
         <item name="android:statusBarColor">@android:color/transparent</item>
@@ -126,7 +126,7 @@
         <item name="kodiStatusUnavailable">?attr/colorError</item>
     </style>
 
-    <style name="Theme.Kore.Sun.Dynamic" parent="Theme.Kore.Sun.Light"/>
+    <style name="Theme.Kore.Sun.Auto" parent="Theme.Kore.Sun.Light"/>
 
     <!-- Sunrise theme. -->
     <style name="Theme.Kore.Sun.Light" parent="Theme.Kore.Default.Light">

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -52,14 +52,24 @@
 
     </PreferenceCategory>
 
-    <PreferenceCategory android:title="@string/application">
+    <PreferenceCategory android:title="@string/theme">
         <ListPreference
-            android:key="pref_theme"
-            android:title="@string/theme"
-            android:entries="@array/themes_array"
-            android:entryValues="@array/themes_values_array"
-            android:defaultValue="9"/>
+            android:key="pref_theme_color"
+            android:title="@string/theme_color"
+            android:entries="@array/theme_colors_array"
+            android:entryValues="@array/theme_colors_values_array"
+            android:defaultValue="0"/>
 
+        <ListPreference
+            android:key="pref_theme_variant"
+            android:title="@string/theme_variant"
+            android:entries="@array/theme_variants_array"
+            android:entryValues="@array/theme_variants_values_array"
+            android:defaultValue="0"/>
+
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/application">
         <ListPreference
             android:key="pref_language"
             android:title="@string/language"/>


### PR DESCRIPTION
"System Colours" works on Android 12+ using the the user's wallpaper to extract colors to colorize the app. This also tweaks the settings screen to make it more intuitive selecting theme, which is composed of the color scheme and variant (light, dark).