### PR TITLE
Tweak Kore icon and add monochrome icon for Android 13+

### DIFF
--- a/app/src/main/res/color/ic_launcher_shadow.xml
+++ b/app/src/main/res/color/ic_launcher_shadow.xml
@@ -1,5 +1,5 @@
 <gradient xmlns:android="http://schemas.android.com/apk/res/android"
-    android:centerX="67.5" android:centerY="67.5" android:gradientRadius="76.37" android:type="radial">
+    android:centerX="54" android:centerY="54" android:gradientRadius="61" android:type="radial">
     <item android:color="#15000000" android:offset="0.0" />
     <item android:color="#10000000" android:offset="0.32" />
     <item android:color="#05000000" android:offset="0.62" />

--- a/app/src/main/res/drawable/ic_launcher_foreground_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground_monochrome.xml
@@ -4,14 +4,6 @@
     android:viewportWidth="108"
     android:viewportHeight="108">
     <path
-        android:fillAlpha="1"
-        android:pathData="M99.42,76.51 L89.99,85.94 52.58,48.53 62.01,39.1Z"
-        android:fillColor="@color/ic_launcher_shadow" />
-    <path
-        android:fillAlpha="1"
-        android:pathData="M85.9,90.02 L76.47,99.46 39.06,62.04 48.49,52.61Z"
-        android:fillColor="@color/ic_launcher_shadow"/>
-    <path
         android:pathData="m71.91,58.15c-2.72,2.73 -4.23,4.12 -4.56,4.19 -0.29,0.06 -0.69,0 -0.98,-0.15 -0.27,-0.14 -2.22,-1.99 -4.32,-4.1 -3.82,-3.84 -3.82,-3.85 -3.82,-4.62 0,-0.77 0.01,-0.78 3.82,-4.62 2.1,-2.11 4.05,-3.96 4.32,-4.1 0.3,-0.15 0.7,-0.22 0.98,-0.15 0.32,0.07 1.84,1.46 4.56,4.19 3.71,3.73 4.07,4.14 4.07,4.69 0,0.54 -0.36,0.96 -4.07,4.69z"
         android:fillColor="#ffffff"/>
     <path

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,7 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+
+    <!-- For monochrome icons in Android 13+ -->
+    <monochrome android:drawable="@drawable/ic_launcher_foreground_monochrome"/>
 </adaptive-icon>


### PR DESCRIPTION
The main app icon was using a wrong viewport width/height of 135x135 instead of 108x108, which caused it to appear small in some situations. This fixes that. It also adds the icon in monochrome so that in Android 13+ it can be themed by the system.