### PR TITLE
Restrict the use on hardware volume keys to when Kore is on the foreground

### DIFF
--- a/app/src/main/java/org/xbmc/kore/Settings.java
+++ b/app/src/main/java/org/xbmc/kore/Settings.java
@@ -150,8 +150,11 @@ public class Settings {
     public static final boolean DEFAULT_PREF_ADDONS_FILTER_HIDE_DISABLED = false;
 
     // Use hardware volume keys to control volume
-    public static final String KEY_PREF_USE_HARDWARE_VOLUME_KEYS = "pref_use_hardware_volume_keys";
-    public static final boolean DEFAULT_PREF_USE_HARDWARE_VOLUME_KEYS = true;
+    public static final String USE_HW_VOL_KEYS_NEVER = "never", USE_HW_VOL_KEYS_ALWAYS = "always",
+            USE_HW_VOL_KEYS_WHEN_IN_FOREGROUND = "when_in_foreground";
+
+    public static final String KEY_PREF_USE_HW_VOL_KEYS = "pref_use_hw_vol_keys";
+    public static final String DEFAULT_PREF_USE_HW_VOL_KEYS = USE_HW_VOL_KEYS_NEVER;
 
     // Vibrate on remote button press
     public static final String KEY_PREF_VIBRATE_REMOTE_BUTTONS = "pref_vibrate_remote_buttons";

--- a/app/src/main/java/org/xbmc/kore/service/MediaSessionService.java
+++ b/app/src/main/java/org/xbmc/kore/service/MediaSessionService.java
@@ -51,7 +51,7 @@ import org.xbmc.kore.utils.Utils;
  * This service creates and updates a {@link android.support.v4.media.session.MediaSessionCompat} and a
  * {@link android.app.Notification} while playback is playing on Kodi.
  *
- * It should be started as soon as playback is detected (tipically by an activity that receives callbacks
+ * It should be started as soon as playback is detected (typically by an activity that receives callbacks
  * from {@link HostConnectionObserver}).
  * The service keeps running in the foreground while something is playing, and stops itself as soon as playback
  * stops or a connection error is detected.
@@ -186,7 +186,7 @@ public class MediaSessionService extends Service
         // a notification, we need to set a {@link PendingIntent} with a Media Button event, and the way to do it is by
         // calling buildMediaButtonPendingIntent on MediaButtonReceiver. This will return a Pending Intent with the
         // given action, that directly calls the {@link MediaButtonReceiver} broadcast receiver (hence the need for
-        // declaring androidx.media.session.MediaButtonReceiver on the Manifest), not routing throug MediaSession.
+        // declaring androidx.media.session.MediaButtonReceiver on the Manifest), not routing through MediaSession.
         // That broadcast receiver tries to find a service on the Application that handles Intent.ACTION_MEDIA_BUTTON,
         // which is this service (hence the intent filter on the Manifest), and starts it, passing the intent.
         // Here we need to forward it to the callbacks defined on the {@link MediaSessionCompat}, which can be done
@@ -212,7 +212,7 @@ public class MediaSessionService extends Service
         }
 
 
-        // Check whether we should react to phone state changes and wether we have permissions to do so
+        // Check whether we should react to phone state changes and weather we have permissions to do so
         boolean shouldPause = PreferenceManager
                 .getDefaultSharedPreferences(this)
                 .getBoolean(Settings.KEY_PREF_PAUSE_DURING_CALLS, Settings.DEFAULT_PREF_PAUSE_DURING_CALLS);
@@ -468,7 +468,7 @@ public class MediaSessionService extends Service
         // Using targets is a lot more efficient than letting Picasso load it directly into the notification imageview,
         // which causes a lot of flickering
         //
-        // 2. The target needs to be static, because Picasso only keeps a weak reference to it, so we need to keed a
+        // 2. The target needs to be static, because Picasso only keeps a weak reference to it, so we need to keep a
         // strong reference and reset it to null when we're done. We also need to check if it is not null in case a
         // previous request hasn't finished yet.
         //
@@ -529,9 +529,10 @@ public class MediaSessionService extends Service
     }
 
     private boolean hardwareVolumeKeysEnabled() {
-        return PreferenceManager.getDefaultSharedPreferences(this)
-                .getBoolean(Settings.KEY_PREF_USE_HARDWARE_VOLUME_KEYS,
-                        Settings.DEFAULT_PREF_USE_HARDWARE_VOLUME_KEYS);
+        String useHWVolKeysPreferences = PreferenceManager.getDefaultSharedPreferences(this)
+                                                          .getString(Settings.KEY_PREF_USE_HW_VOL_KEYS,
+                                                                     Settings.DEFAULT_PREF_USE_HW_VOL_KEYS);
+        return useHWVolKeysPreferences.equals(Settings.USE_HW_VOL_KEYS_ALWAYS);
     }
 
     /**
@@ -541,7 +542,7 @@ public class MediaSessionService extends Service
      */
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        if (Settings.KEY_PREF_USE_HARDWARE_VOLUME_KEYS.equals(key)) {
+        if (Settings.KEY_PREF_USE_HW_VOL_KEYS.equals(key)) {
             if (hardwareVolumeKeysEnabled()) {
                 remoteVolumePC = new RemoteVolumeProviderCompat(hostConnection);
                 mediaSession.setPlaybackToRemote(remoteVolumePC);

--- a/app/src/main/java/org/xbmc/kore/ui/generic/VolumeControllerDialogFragmentListener.java
+++ b/app/src/main/java/org/xbmc/kore/ui/generic/VolumeControllerDialogFragmentListener.java
@@ -166,10 +166,11 @@ public class VolumeControllerDialogFragmentListener extends AppCompatDialogFragm
     }
 
     public static boolean handleVolumeKeyEvent(Context context, KeyEvent event) {
-        boolean shouldInterceptKey =
-                PreferenceManager.getDefaultSharedPreferences(context)
-                        .getBoolean(Settings.KEY_PREF_USE_HARDWARE_VOLUME_KEYS,
-                                Settings.DEFAULT_PREF_USE_HARDWARE_VOLUME_KEYS);
+        String useHWVolKeysPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+                                                          .getString(Settings.KEY_PREF_USE_HW_VOL_KEYS,
+                                                                     Settings.DEFAULT_PREF_USE_HW_VOL_KEYS);
+        boolean shouldInterceptKey = useHWVolKeysPreferences.equals(Settings.USE_HW_VOL_KEYS_ALWAYS) ||
+                                     useHWVolKeysPreferences.equals(Settings.USE_HW_VOL_KEYS_WHEN_IN_FOREGROUND);
 
         if (shouldInterceptKey) {
             int action = event.getAction();

--- a/app/src/main/java/org/xbmc/kore/ui/sections/settings/SettingsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/settings/SettingsFragment.java
@@ -213,6 +213,12 @@ public class SettingsFragment extends PreferenceFragmentCompat
             });
         }
 
+        // Use hardware volume keys
+        ListPreference useHWVolKeysPref = findPreference(Settings.KEY_PREF_USE_HW_VOL_KEYS);
+        if (useHWVolKeysPref != null) {
+            useHWVolKeysPref.setSummary(useHWVolKeysPref.getEntry());
+        }
+
         // About preference
         String nameAndVersion = context.getString(R.string.app_name);
         try {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -162,4 +162,16 @@
         <item>5</item>
     </string-array>
 
+    <!-- Constants for the Use hardware volume keys setting in preferences -->
+    <string-array name="use_hw_vol_keys_array">
+        <item>@string/use_hardware_volume_keys_never</item>
+        <item>@string/use_hardware_volume_keys_always</item>
+        <item>@string/use_hardware_volume_keys_when_in_foreground</item>
+    </string-array>
+    <string-array translatable="false" name="use_hw_vol_keys_array_values_array">
+        <item>never</item>
+        <item>always</item>
+        <item>when_in_foreground</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -391,7 +391,6 @@
     <string name="show_now_playing_panel">Show now playing panel</string>
     <string name="show_now_playing_panel_summary">Display a panel at the bottom of the screen when media is playing</string>
     <string name="pause_during_calls">Pause during phone call</string>
-    <string name="use_hardware_volume_keys">Use device volume keys</string>
     <string name="vibrate_on_remote">Vibrate on touch</string>
     <string name="always_sendtokodi_addon">Prefer SendToKodi addon</string>
     <string name="remote_bar_items">Bottom bar shortcuts</string>
@@ -459,5 +458,11 @@
     <string name="any_network">Any</string>
 
     <string name="web_search">Web Search</string>
+
+    <!-- Strings for the Use hardware volume keys setting -->
+    <string name="use_hardware_volume_keys">Use device volume keys</string>
+    <string name="use_hardware_volume_keys_never">Never</string>
+    <string name="use_hardware_volume_keys_always">Always</string>
+    <string name="use_hardware_volume_keys_when_in_foreground">When Kore is in the foreground</string>
 
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -28,10 +28,12 @@
             android:title="@string/keep_remote_above_lockscreen"
             android:defaultValue="false"/>
 
-        <SwitchPreferenceCompat
-            android:key="pref_use_hardware_volume_keys"
+        <ListPreference
+            android:key="pref_use_hw_vol_keys"
             android:title="@string/use_hardware_volume_keys"
-            android:defaultValue="true"/>
+            android:entries="@array/use_hw_vol_keys_array"
+            android:entryValues="@array/use_hw_vol_keys_array_values_array"
+            android:defaultValue="never"/>
 
         <SwitchPreferenceCompat
             android:key="pref_vibrate_remote_buttons"


### PR DESCRIPTION
Redesign the option "Use hardware volume keys" to allow for responding to the volume keys everywhere (as long as the Media Session is running) or only when Kore is on the foreground.