### PR TITLE
Exclude non-FOSS GMS deps from google-shortcuts

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -103,7 +103,9 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.core:core-google-shortcuts:1.0.1'
+    implementation('androidx.core:core-google-shortcuts:1.0.1') {
+        exclude group:'com.google.android.gms'
+    }
     implementation 'androidx.media:media:1.6.0'
     implementation "androidx.viewpager2:viewpager2:1.1.0-beta01"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"


### PR DESCRIPTION
Fix https://github.com/xbmc/Kore/issues/912