### PR TITLE
Fix sharing play intents only working the first time

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ShareOpenActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ShareOpenActivity.java
@@ -156,7 +156,8 @@ public class ShareOpenActivity extends Activity {
 
         // Don't display Kore after queueing from another app, otherwise start the remote
         if (!queue)
-            startActivity(new Intent(this, RemoteActivity.class));
+            startActivity(new Intent(this, RemoteActivity.class)
+                                  .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP));
         // Always finish as we don't have anything to show
         finish();
     }


### PR DESCRIPTION
When sharing play intents, the `OpenShareActivity` launches the `RemoteActivity` at the end. In Android versions prior to 12, when doing a second share, it doesn't run `OpenShareActivity` and instead directly opens the `RemoteActivity`, so the play intent isn't delivered to Kodi. This doesn't happen on Android 12+, but to fix it we need to set flags when calling `RemoteActivity` `startActivity` so that the `OpenShareActivity` is called in the next sharing intent.