### PR TITLE
Fix crashes reported on the Play Store

### DIFF
--- a/app/src/main/java/org/xbmc/kore/service/MediaSessionService.java
+++ b/app/src/main/java/org/xbmc/kore/service/MediaSessionService.java
@@ -193,7 +193,7 @@ public class MediaSessionService extends Service
         // by calling MediaButtonReceiver.handleIntent(mediaSession, intent)
         // Note that other Media Button events are directly sent to the MediaSession callbacks, like for instance
         // button presses from a Android Wear connected phone.
-        if (intent.getAction() != null && intent.getAction().equals(Intent.ACTION_MEDIA_BUTTON)) {
+        if (intent != null && intent.getAction() != null && intent.getAction().equals(Intent.ACTION_MEDIA_BUTTON)) {
             KeyEvent ke = MediaButtonReceiver.handleIntent(mediaSession, intent);
             LogUtils.LOGD(TAG, "Got a Media Button Event: " + ke.toString());
             return super.onStartCommand(intent, flags, startId);

--- a/app/src/main/java/org/xbmc/kore/ui/generic/VolumeControllerDialogFragmentListener.java
+++ b/app/src/main/java/org/xbmc/kore/ui/generic/VolumeControllerDialogFragmentListener.java
@@ -141,6 +141,7 @@ public class VolumeControllerDialogFragmentListener extends AppCompatDialogFragm
 
     @Override
     public void onApplicationVolumeChanged(int volume, boolean muted) {
+        if (binding == null) return;
         binding.vcdVolumeLevelIndicator.setVolume(muted, volume);
         binding.vcdVolumeMute.setHighlight(muted);
     }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/localfile/LocalMediaFileListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/localfile/LocalMediaFileListFragment.java
@@ -31,6 +31,7 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.PopupMenu;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
@@ -98,7 +99,8 @@ public class LocalMediaFileListFragment extends AbstractListFragment {
         try {
             http_app = HttpApp.getInstance(getContext(), 8080);
         } catch (IOException ioe) {
-            showStatusMessage(null, getString(R.string.error_starting_http_server));
+            Toast.makeText(requireContext(), getString(R.string.error_starting_http_server), Toast.LENGTH_LONG)
+                 .show();
         }
 
         Bundle args = getArguments();
@@ -232,6 +234,8 @@ public class LocalMediaFileListFragment extends AbstractListFragment {
      * @param localFileLocation LocalFileLocation to start playing
      */
     private void playMediaFile(final LocalFileLocation localFileLocation, ArrayList<LocalFileLocation> queuedFiles) {
+        if (http_app == null) return;
+
         http_app.addLocalFilePath(localFileLocation);
         String url = http_app.getLinkToFile();
 
@@ -261,6 +265,8 @@ public class LocalMediaFileListFragment extends AbstractListFragment {
      * @param localFileLocation LocalFileLocation to queue
      */
     private void queueMediaFile(final LocalFileLocation localFileLocation) {
+        if (http_app == null) return;
+
         http_app.addLocalFilePath(localFileLocation);
         String url = http_app.getLinkToFile();
 

--- a/app/src/main/java/org/xbmc/kore/ui/widgets/VolumeLevelIndicator.java
+++ b/app/src/main/java/org/xbmc/kore/ui/widgets/VolumeLevelIndicator.java
@@ -110,6 +110,7 @@ public class VolumeLevelIndicator extends LinearLayout {
      * @param volume Volume
      */
     public void setVolume(boolean muted, int volume) {
+        if (binding == null) return;
         if (muted) {
             binding.vliVolumeText.setText(R.string.muted);
             binding.vliSeekBar.setProgress(0);


### PR DESCRIPTION
Specifically:
- Crash on `MediaSessionService` when started with a null intent
- Crash on setVolume when `binding` isn't available anymore
- Crash when it's not possible to create `http_app` on `LocalMediaFileListFragment` and a message is shown during `onCreate`, when the views are still not created