### PR TITLE
Catch an exception that is being reported on Google Play

### DIFF
--- a/app/src/main/java/org/xbmc/kore/host/HostConnection.java
+++ b/app/src/main/java/org/xbmc/kore/host/HostConnection.java
@@ -485,6 +485,14 @@ public class HostConnection {
             if (callback != null) {
                 postOrRunNow(handler, () -> callback.onError(e.getCode(), e.getMessage()));
             }
+        } catch (final IllegalArgumentException e) {
+            LogUtils.LOGD(TAG, "Illegal argument exception on sending HTTP request: " + e);
+            // This happens because the host URL isn't valid
+            if (callback != null) {
+                String desc = "Illegal argument exception on sending HTTP request: " + e.getMessage() +
+                        ". Please check the media center URL.";
+                postOrRunNow(handler, () -> callback.onError(ApiException.HTTP_HOST_URL_INVALID, desc));
+            }
         }
     }
 

--- a/app/src/main/java/org/xbmc/kore/jsonrpc/ApiException.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/ApiException.java
@@ -61,6 +61,11 @@ public class ApiException extends Exception {
 	public static final int HTTP_RESPONSE_CODE_NOT_FOUND = 6;
 
 	/**
+	 *
+	 */
+	public static final int HTTP_HOST_URL_INVALID = 7;
+
+	/**
 	 * API returned an error
 	 */
 	public static int API_ERROR = 100;


### PR DESCRIPTION
Apparently when the host URL is invalid. For reference, this is one of the stack traces:

```
Exception java.lang.IllegalArgumentException: Invalid URL host: ""
  at okhttp3.HttpUrl$Builder.parse$okhttp (HttpUrl.kt:1338)
  at okhttp3.HttpUrl$Companion.get (HttpUrl.kt:1634)
  at okhttp3.Request$Builder.url (Request.kt:184)
  at org.xbmc.kore.host.HostConnection.executeThroughOkHttp (HostConnection.java:474)
  at org.xbmc.kore.host.HostConnection.lambda$execute$0 (HostConnection.java:370)
  at org.xbmc.kore.host.HostConnection.$r8$lambda$QghpVQ_dBkScH7j9TPIGbMtbqLI (HostConnection.java)
  at org.xbmc.kore.host.HostConnection$$InternalSyntheticLambda$0$07e48ccd4235b27a41327a22962e98a62be18028a1b2826838587ad6dc9c80f3$0.run (HostConnection.java)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1162)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:636)
  at java.lang.Thread.run (Thread.java:784)
  ```