### PR TITLE
EPG: prepend plot outline, show full plot on click

### DIFF
--- a/app/src/main/java/org/xbmc/kore/jsonrpc/type/PVRType.java
+++ b/app/src/main/java/org/xbmc/kore/jsonrpc/type/PVRType.java
@@ -161,6 +161,24 @@ public class PVRType {
             }
         }
 
+        /**
+         * Returns both the plot outline and the plot, leaving each empty if absent.
+         *
+         * @param delimiter character to insert between outline and plot, if both are present
+         */
+        public String getFullPlot(char delimiter) {
+            StringBuilder builder = new StringBuilder();
+            if (plotoutline != null) {
+                builder.append(plotoutline);
+            }
+            if (plot != null) {
+                if (builder.length() != 0) {
+                    builder.append(delimiter);
+                }
+                builder.append(plot);
+            }
+            return builder.toString();
+        }
     }
 
     /**

--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRChannelEPGListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/PVRChannelEPGListFragment.java
@@ -26,6 +26,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
@@ -66,6 +68,18 @@ public class PVRChannelEPGListFragment
 
     @Override
     protected void onListItemClicked(View view, int position) {
+        // Show full plot when guide item is clicked
+        BoadcastsAdapter adapter = (BoadcastsAdapter) getAdapter();
+        EPGListRow row = adapter.getItem(position);
+        Context context = getContext();
+        if (row == null || context == null) {
+            return;
+        }
+        new MaterialAlertDialogBuilder(context)
+                .setTitle(row.detailsBroadcast.title)
+                .setMessage(row.detailsBroadcast.getFullPlot('\n'))
+                .setPositiveButton(android.R.string.ok, null)
+                .show();
     }
 
     @Override
@@ -305,7 +319,8 @@ public class PVRChannelEPGListFragment
                 title = broadcastDetails.title;
 
                 titleView.setText(UIUtils.applyMarkup(context, broadcastDetails.title));
-                detailsView.setText(UIUtils.applyMarkup(context, broadcastDetails.plot));
+                detailsView.setText(UIUtils.applyMarkup(context,
+                        broadcastDetails.getFullPlot(' ')));
                 String duration = context.getString(R.string.minutes_abbrev2,
                         String.valueOf(broadcastDetails.runtime));
 


### PR DESCRIPTION
This PR displays the plot outline in the EPG list view. Some broadcasters (like Italy's RAI) use the plot outline as part of the actual plot (presumably to have more text).

Additionally, this PR adds an alert containing the full outline and plot when the list item is clicked. Normally, the small description shown in the list view is ellipsized, and there was previously no way to read the full text.

Before:
![immagine](https://user-images.githubusercontent.com/13873938/232504629-7e18d870-6f63-4ccc-b128-bc50eb04c8bb.png)

After:
![immagine](https://user-images.githubusercontent.com/13873938/232502328-e649ad79-bcf4-4022-a765-e73c7d763e96.png)

Plot outline + Plot (how it should be):
![immagine](https://user-images.githubusercontent.com/13873938/232502563-9e7809f9-42f3-4e79-922d-e590e039a781.png)

Unfortunately, in this case the word "tempo" is split off by the newline I added to delimit outline and plot, though for broadcasters that make proper use of the outline text (the majority, as far as I could see), I feel this is the best way to display it.