### PR TITLE
Add support for the Invidious YouTube add-on

### DIFF
--- a/app/src/main/java/org/xbmc/kore/Settings.java
+++ b/app/src/main/java/org/xbmc/kore/Settings.java
@@ -173,6 +173,7 @@ public class Settings {
     public static final boolean DEFAULT_PREF_ALWAYS_SENDTOKODI_ADDON = false;
 
     public static final String KEY_PREF_YOUTUBE_ADDON_ID = "pref_youtube_addon_id";
+    public static final String DEFAULT_PREF_YOUTUBE_ADDON_ID = "plugin.video.youtube";
 
     public static final String KEY_PREF_NAV_DRAWER_ITEMS = "pref_nav_drawer_items";
     public static String getNavDrawerItemsPrefKey(int hostId) {

--- a/app/src/main/java/org/xbmc/kore/Settings.java
+++ b/app/src/main/java/org/xbmc/kore/Settings.java
@@ -172,6 +172,8 @@ public class Settings {
     public static final String KEY_PREF_ALWAYS_SENDTOKODI_ADDON = "pref_always_sendtokodi_addon";
     public static final boolean DEFAULT_PREF_ALWAYS_SENDTOKODI_ADDON = false;
 
+    public static final String KEY_PREF_YOUTUBE_ADDON_ID = "pref_youtube_addon_id";
+
     public static final String KEY_PREF_NAV_DRAWER_ITEMS = "pref_nav_drawer_items";
     public static String getNavDrawerItemsPrefKey(int hostId) {
         return Settings.KEY_PREF_NAV_DRAWER_ITEMS + hostId;

--- a/app/src/main/java/org/xbmc/kore/ShareOpenActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ShareOpenActivity.java
@@ -10,6 +10,7 @@ import android.os.Looper;
 import android.webkit.MimeTypeMap;
 import android.widget.Toast;
 
+import androidx.annotation.Nullable;
 import androidx.core.content.pm.ShortcutManagerCompat;
 import androidx.preference.PreferenceManager;
 
@@ -247,29 +248,8 @@ public class ShareOpenActivity extends Activity {
                                                     .getBoolean(Settings.KEY_PREF_ALWAYS_SENDTOKODI_ADDON,
                                                                 Settings.DEFAULT_PREF_ALWAYS_SENDTOKODI_ADDON);
         if (!alwaysSendToKodi) {
-            if (host.endsWith("youtube.com")) {
-                String videoId = playuri.getQueryParameter("v");
-                String playlistId = playuri.getQueryParameter("list");
-                Uri.Builder pluginUri = new Uri.Builder()
-                        .scheme("plugin")
-                        .authority("plugin.video.youtube")
-                        .path("play/");
-                boolean valid = false;
-                if (videoId != null) {
-                    valid = true;
-                    pluginUri.appendQueryParameter("video_id", videoId);
-                }
-                if (playlistId != null) {
-                    valid = true;
-                    pluginUri.appendQueryParameter("playlist_id", playlistId)
-                             .appendQueryParameter("order", "default");
-                }
-                if (valid) {
-                    return pluginUri.build().toString();
-                }
-            } else if (host.endsWith("youtu.be")) {
-                return "plugin://plugin.video.youtube/play/?video_id="
-                       + playuri.getLastPathSegment();
+            if (host.endsWith("youtube.com") || host.endsWith("youtu.be")) {
+                return toYouTubePluginUrl(playuri);
             } else if (host.endsWith("vimeo.com")) {
                 return PluginUrlUtils.toPluginUrlVimeo(playuri);
             } else if (host.endsWith("svtplay.se")) {
@@ -314,6 +294,44 @@ public class ShareOpenActivity extends Activity {
             // (in that case Kodi does not require an addon to play the link):
             return "plugin://plugin.video.sendtokodi/?" + playuri;
         }
+        return null;
+    }
+
+    /**
+     * Converts a YouTube url to a Kodi plugin URL.
+     *
+     * @param playuri some URL for YouTube
+     * @return plugin URL
+     */
+    @Nullable
+    private String toYouTubePluginUrl(Uri playuri) {
+        String host = playuri.getHost();
+
+        if (host.endsWith("youtube.com")) {
+            String videoId = playuri.getQueryParameter("v");
+            String playlistId = playuri.getQueryParameter("list");
+            Uri.Builder pluginUri = new Uri.Builder()
+                    .scheme("plugin")
+                    .authority("plugin.video.youtube")
+                    .path("play/");
+            boolean valid = false;
+            if (videoId != null) {
+                valid = true;
+                pluginUri.appendQueryParameter("video_id", videoId);
+            }
+            if (playlistId != null) {
+                valid = true;
+                pluginUri.appendQueryParameter("playlist_id", playlistId)
+                        .appendQueryParameter("order", "default");
+            }
+            if (valid) {
+                return pluginUri.build().toString();
+            }
+        } else if (host.endsWith("youtu.be")) {
+            return "plugin://plugin.video.youtube/play/?video_id="
+                    + playuri.getLastPathSegment();
+        }
+
         return null;
     }
 

--- a/app/src/main/java/org/xbmc/kore/ShareOpenActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ShareOpenActivity.java
@@ -305,6 +305,17 @@ public class ShareOpenActivity extends Activity {
      */
     @Nullable
     private String toYouTubePluginUrl(Uri playuri) {
+        return toDefaultYouTubePluginUrl(playuri);
+    }
+
+    /**
+     * Converts a YouTube url to an URL for the default YouTube add-on (plugin.video.youtube)
+     *
+     * @param playuri some URL for YouTube
+     * @return plugin URL
+     */
+    @Nullable
+    private String toDefaultYouTubePluginUrl(Uri playuri) {
         String host = playuri.getHost();
 
         if (host.endsWith("youtube.com")) {

--- a/app/src/main/java/org/xbmc/kore/ui/sections/settings/SettingsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/settings/SettingsFragment.java
@@ -219,6 +219,12 @@ public class SettingsFragment extends PreferenceFragmentCompat
             useHWVolKeysPref.setSummary(useHWVolKeysPref.getEntry());
         }
 
+        // Preferred YouTube addon
+        ListPreference preferredYouTubeAddonPref = findPreference(Settings.KEY_PREF_YOUTUBE_ADDON_ID);
+        if (preferredYouTubeAddonPref != null) {
+            preferredYouTubeAddonPref.setSummary(preferredYouTubeAddonPref.getEntry());
+        }
+
         // About preference
         String nameAndVersion = context.getString(R.string.app_name);
         try {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -174,4 +174,14 @@
         <item>when_in_foreground</item>
     </string-array>
 
+    <!-- Constants for the Preferred Youtube addon setting in preferences -->
+    <string-array name="preferred_youtube_addon_keys_array">
+        <item>@string/preferred_youtube_addon_youtube</item>
+        <item>@string/preferred_youtube_addon_invidious</item>
+    </string-array>
+    <string-array translatable="false" name="preferred_youtube_addon_values_array">
+        <item>plugin.video.youtube</item>
+        <item>plugin.video.invidious</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -465,4 +465,9 @@
     <string name="use_hardware_volume_keys_always">Always</string>
     <string name="use_hardware_volume_keys_when_in_foreground">When Kore is in the foreground</string>
 
+    <!-- Strings for the Preferred YouTube addon setting -->
+    <string name="preferred_youtube_addon">Preferred YouTube addon</string>
+    <string name="preferred_youtube_addon_youtube">YouTube (plugin.video.youtube)</string>
+    <string name="preferred_youtube_addon_invidious">Invidious (plugin.video.invidious)</string>
+
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -59,6 +59,14 @@
             android:defaultValue="false"
             app:singleLineTitle="false"/>
 
+        <ListPreference
+            android:key="pref_youtube_addon_id"
+            android:title="@string/preferred_youtube_addon"
+            android:entries="@array/preferred_youtube_addon_keys_array"
+            android:entryValues="@array/preferred_youtube_addon_values_array"
+            android:defaultValue="plugin.video.youtube"
+            app:singleLineTitle="false"/>
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/theme">


### PR DESCRIPTION
# Introduction

This branch adds basic support for the Invidious YouTube add-on, as proposed in #978.

The only thing that is working so far is the direct playback of shared video URLs, which - as mentioned in the original issue - is an MVP that could be extended upon.

This new feature is lacking translation. If I can help with that as well let me know.

# How to test

1. Checkout the branch and run the app in the emulator
2. Connect the app to a Kodi instance
3. Install NewPipe
4. Open NewPipe, select a video and share the video with Kore

Kodi should display a brief loading indicator and then playback the video.

---

Thanks in advance for your time and consideration!