### PR TITLE
Update minSdk version to 24

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
 
     defaultConfig {
         applicationId "org.xbmc.kore"
-        minSdkVersion 21
+        minSdkVersion 24
         targetSdkVersion 32
         versionCode 31
         versionName = getVersionName()

--- a/app/src/main/java/org/xbmc/kore/service/MediaSessionService.java
+++ b/app/src/main/java/org/xbmc/kore/service/MediaSessionService.java
@@ -139,7 +139,7 @@ public class MediaSessionService extends Service
         // Create the intent to start the remote when the user taps the notification
         TaskStackBuilder stackBuilder = TaskStackBuilder.create(this);
         stackBuilder.addNextIntentWithParentStack(new Intent(this, RemoteActivity.class));
-        int flags = Utils.isMOrLater() ? PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT : PendingIntent.FLAG_UPDATE_CURRENT;
+        int flags = PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT;
         remoteStartPendingIntent = stackBuilder.getPendingIntent(0, flags);
 
         // Create the notification channel and the default notification

--- a/app/src/main/java/org/xbmc/kore/ui/sections/settings/SettingsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/settings/SettingsFragment.java
@@ -294,13 +294,9 @@ public class SettingsFragment extends PreferenceFragmentCompat
     }
 
     private Locale getSystemLocale() {
-        return Utils.isNOrLater() ?
-               Resources.getSystem().getConfiguration().getLocales().get(0) :
-               Resources.getSystem().getConfiguration().locale;
+        return Resources.getSystem().getConfiguration().getLocales().get(0);
     }
 
     private Locale getCurrentLocale() {
-        return Utils.isNOrLater() ?
-               getResources().getConfiguration().getLocales().get(0) :
-               getResources().getConfiguration().locale;
+        return getResources().getConfiguration().getLocales().get(0);
     }}

--- a/app/src/main/java/org/xbmc/kore/utils/Utils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/Utils.java
@@ -40,14 +40,6 @@ import java.util.Locale;
 public class Utils {
     private static final String TAG = LogUtils.makeLogTag(Utils.class);
 
-    public static boolean isMOrLater() {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M;
-    }
-
-    public static boolean isNOrLater() {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N;
-    }
-
     public static boolean isOreoOrLater() { return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O; }
 
     public static boolean isOreoMR1OrLater() { return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1; }


### PR DESCRIPTION
Updating the minSdk version allows use of more Java 8 language features (without desugaring need) and the removalof code that dealt with older versions. Given that api level 24 (Android 7) come out in 2016 and usage of Android versions 5 and 6 (Api levels 21, 22, 23) are bellow 1% and decreasing (as reported by Google Play), this seems an appropriate tradeoff.