### PR TITLE
Upgrade to Android 13, Sdk Version 33

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
     defaultConfig {
         applicationId "org.xbmc.kore"
         minSdkVersion 24
-        targetSdkVersion 32
+        targetSdkVersion 33
         versionCode 31
         versionName = getVersionName()
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,9 +9,19 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.VIBRATE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <!--
+    Added notification permission so that code in MediaSessionService doesn't show errors.
+    This is not really necessary, given that notifications are sent via MediaService, and those
+    are exempt from being explicitly requested but it doesn't hurt
+    -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <!-- Dangerous permissions -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO"/>
+
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29"/>
     <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
 

--- a/app/src/main/java/org/xbmc/kore/utils/Utils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/Utils.java
@@ -27,10 +27,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.text.TextUtils;
 
-import androidx.preference.PreferenceManager;
-
-import org.xbmc.kore.Settings;
-
 import java.util.List;
 import java.util.Locale;
 
@@ -50,6 +46,10 @@ public class Utils {
 
     public static boolean isSOrLater() {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.S;
+    }
+
+    public static boolean isTiramisuOrLater() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU;
     }
 
     /**


### PR DESCRIPTION
- Add notification permission to manifest, though it is not strickly needed as all notifications are attached to a MediaSession and those are exempt from Android's 13 new requirements on notification permissions
  [link](https://developer.android.com/develop/ui/views/notifications/notification-permission)
- Use granular media permissions, switching from READ_EXTERNAL_STORAGE to READ_MEDIA_{IMAGES|VIDEO|AUDIO}
  [link](https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions)