### PR TITLE
Upgrade to Android 14, Sdk Version 34

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
     defaultConfig {
         applicationId "org.xbmc.kore"
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 31
         versionName = getVersionName()
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.VIBRATE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <!--
     Added notification permission so that code in MediaSessionService doesn't show errors.
     This is not really necessary, given that notifications are sent via MediaService, and those
@@ -31,8 +32,7 @@
         android:label="@string/app_name"
         android:requestLegacyExternalStorage="true"
         android:supportsRtl="true"
-        android:networkSecurityConfig="@xml/network_security_config"
-        tools:targetApi="n">
+        android:networkSecurityConfig="@xml/network_security_config">
 
         <!-- Activities -->
         <activity
@@ -195,6 +195,7 @@
             android:exported="false" />
         <service
             android:name=".service.MediaSessionService"
+            android:foregroundServiceType="mediaPlayback"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.MEDIA_BUTTON" />

--- a/app/src/main/java/org/xbmc/kore/service/MediaSessionService.java
+++ b/app/src/main/java/org/xbmc/kore/service/MediaSessionService.java
@@ -10,6 +10,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
+import android.content.pm.ServiceInfo;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
@@ -200,7 +201,11 @@ public class MediaSessionService extends Service
         }
 
         // Request foreground and show default notification, will update later
-        startForeground(NOTIFICATION_ID, nothingPlayingNotification);
+        if (Utils.isUpsideDownCakeOrLater()) {
+            startForeground(NOTIFICATION_ID, nothingPlayingNotification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK);
+        } else {
+            startForeground(NOTIFICATION_ID, nothingPlayingNotification);
+        }
 
         HostConnectionObserver connectionObserver = HostManager.getInstance(this).getHostConnectionObserver();
         if (hostConnectionObserver == null || hostConnectionObserver != connectionObserver) {

--- a/app/src/main/java/org/xbmc/kore/utils/Utils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/Utils.java
@@ -52,6 +52,10 @@ public class Utils {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU;
     }
 
+    public static boolean isUpsideDownCakeOrLater() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE;
+    }
+
     /**
      * Concats a list of strings
      * @param list List to concatenate


### PR DESCRIPTION
- Specify foreground service type, namely on the MediaSessionService
- Regarding changes to granting partial access to photos and videos, nothing was changed, so it relies on compatibility mode.
  [More here](https://developer.android.com/about/versions/14/changes/partial-photo-video-access) 
  The default compatibility mode works more or less ok, and adding specific logic to handle partial access wouldn't help much and would confuse the code.