### PR TITLE
Make Gradle sign the release apk

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,18 +28,13 @@ android {
                 supportedLocales.join("\",\"")+"\"}"
     }
 
-    File keystoreFile = file('keystore.properties')
-
     signingConfigs {
         release {
-            if (keystoreFile.exists()) {
-                Properties keyProps = new Properties()
-                keyProps.load(new FileInputStream(keystoreFile))
-
-                storeFile file(keyProps["store"])
-                keyAlias keyProps["alias"]
-                storePassword keyProps["storePass"]
-                keyPassword keyProps["pass"]
+            if (System.getenv("KODI_ANDROID_STORE_FILE") != null) {
+                keyAlias System.getenv("KODI_ANDROID_KEY_ALIAS")
+                keyPassword System.getenv("KODI_ANDROID_KEY_PASSWORD")
+                storeFile file(System.getenv("KODI_ANDROID_STORE_FILE"))
+                storePassword System.getenv("KODI_ANDROID_STORE_PASSWORD")
             }
         }
     }
@@ -51,14 +46,9 @@ android {
         }
     }
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
     buildTypes {
         release {
-            if (keystoreFile.exists()) {
+            if (System.getenv("KODI_ANDROID_STORE_FILE") != null) {
                 signingConfig signingConfigs.release
             }
             minifyEnabled true

--- a/tools/jenkins/buildsteps/package
+++ b/tools/jenkins/buildsteps/package
@@ -1,6 +1,7 @@
 WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 
-$RUN_SIGNSTEP
+# Signing done by Gradle, no need to run separate sign step
+#$RUN_SIGNSTEP
 
 function getBranchName ()
 {
@@ -52,4 +53,4 @@ function getBuildRevDateStr ()
 #rename for upload
 #e.x. kore-20130314-8c2fb31.apk.
 UPLOAD_FILENAME="kore-$(getBuildRevDateStr).apk"
-cd $WORKSPACE;mv kore-release.apk $UPLOAD_FILENAME
+cd $WORKSPACE;mv app/build/outputs/apk/release/kore-release.apk $UPLOAD_FILENAME


### PR DESCRIPTION
Instead of relying on a separate step for signing, this make Gradle sign the release apk Requires that the following environment variables are set:
- KODI_ANDROID_STORE_FILE
- KODI_ANDROID_STORE_PASSWORD
- KODI_ANDROID_KEY_ALIAS
- KODI_ANDROID_KEY_PASSWORD

Also changed the jenkins scripts to exclude the signing step and get the correct apk to be moved to the mirrors