### PR TITLE
Upgrade library versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -114,11 +114,14 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2"
     implementation "androidx.lifecycle:lifecycle-viewmodel:2.6.2"
 
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
-    implementation 'com.squareup.okhttp3:okhttp:4.11.0'
-    implementation 'com.squareup.picasso:picasso:2.71828'
+    // Jackson v2.13 kept. v2.14 and later require minSDK >= 26
+    // https://github.com/FasterXML/jackson/wiki/Jackson-Releases
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.5'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    // Ignore the new version warning as it refers to v2.71... which is older on maven
+    implementation 'com.squareup.picasso:picasso:2.8'
     implementation 'org.greenrobot:eventbus:3.3.1'
-    implementation 'org.jmdns:jmdns:3.5.7'
+    implementation 'org.jmdns:jmdns:3.5.8'
     implementation 'at.blogc:expandabletextview:1.0.5'
     implementation 'com.simplecityapps:recyclerview-fastscroll:2.0.1'
     implementation 'org.nanohttpd:nanohttpd:2.3.1'


### PR DESCRIPTION
Namely the okhttp library, to possibly fix errors reported on Google Play