### PR TITLE
Improve message shown when errors occur sending an Http request

### DIFF
--- a/app/src/main/java/org/xbmc/kore/host/HostConnection.java
+++ b/app/src/main/java/org/xbmc/kore/host/HostConnection.java
@@ -510,8 +510,8 @@ public class HostConnection {
             LogUtils.LOGD(TAG, "Illegal argument exception on sending HTTP request: " + e);
             // This happens because the host URL isn't valid
             if (callback != null) {
-                String desc = "Illegal argument exception on sending HTTP request: " + e.getMessage() +
-                        ". Please check the media center URL.";
+                String desc = "Illegal argument exception on sending HTTP request.\n" +
+                              "Please check the media center address on the configuration screen.";
                 postOrRunNow(handler, () -> callback.onError(ApiException.HTTP_HOST_URL_INVALID, desc));
             }
         }


### PR DESCRIPTION
The message will be seen by the user, so it should be clear. Ideally it shouldn't be done this way, as it can't be translated because there's no context to get the translated string, but it's what possible for now.