### PR TITLE
Fix back navigation and a NPE that was occuring on the addons list

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListContainerFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonListContainerFragment.java
@@ -89,18 +89,18 @@ public class AddonListContainerFragment
     }
 
     @Override
-    public void onAttach(@NonNull Context context) {
-        super.onAttach(context);
+    public void onResume() {
+        super.onResume();
         try {
-            BaseMediaActivity listenerActivity = (BaseMediaActivity) context;
+            BaseMediaActivity listenerActivity = (BaseMediaActivity) requireContext();
             listenerActivity.setBackPressedListener(this);
         } catch (ClassCastException e) {
-            throw new ClassCastException(context + " unable to register BackPressedListener");
+            throw new ClassCastException(requireContext() + " unable to register BackPressedListener");
         }
     }
 
     @Override
-    public void onDestroy() {
+    public void onPause() {
         try {
             BaseMediaActivity listenerActivity = (BaseMediaActivity) getContext();
             assert listenerActivity != null;
@@ -108,7 +108,7 @@ public class AddonListContainerFragment
         } catch (ClassCastException e) {
             throw new ClassCastException(getContext() + " unable to unregister BackPressedListener");
         }
-        super.onDestroy();
+        super.onPause();
     }
 
     @Override
@@ -123,6 +123,6 @@ public class AddonListContainerFragment
 
     @Override
     protected boolean shouldRememberLastTab() {
-        return true;
+        return false;
     }
 }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonTabsFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonTabsFragment.java
@@ -31,6 +31,7 @@ import org.xbmc.kore.ui.OnBackPressedListener;
 import org.xbmc.kore.ui.sections.file.MediaFileListFragment;
 import org.xbmc.kore.utils.LogUtils;
 import org.xbmc.kore.utils.TabsAdapter;
+import org.xbmc.kore.utils.Utils;
 
 public class AddonTabsFragment
         extends AbstractTabsFragment
@@ -65,18 +66,18 @@ public class AddonTabsFragment
     }
 
     @Override
-    public void onAttach(@NonNull Context context) {
-        super.onAttach(context);
+    public void onResume() {
+        super.onResume();
         try {
-            BaseMediaActivity listenerActivity = (BaseMediaActivity) context;
+            BaseMediaActivity listenerActivity = (BaseMediaActivity) requireContext();
             listenerActivity.setBackPressedListener(this);
         } catch (ClassCastException e) {
-            throw new ClassCastException(context + " unable to register BackPressedListener");
+            throw new ClassCastException(requireContext() + " unable to register BackPressedListener");
         }
     }
 
     @Override
-    public void onDestroy() {
+    public void onPause() {
         try {
             BaseMediaActivity listenerActivity = (BaseMediaActivity) getContext();
             assert listenerActivity != null;
@@ -84,7 +85,7 @@ public class AddonTabsFragment
         } catch (ClassCastException e) {
             throw new ClassCastException(getContext() + " unable to unregister BackPressedListener");
         }
-        super.onDestroy();
+        super.onPause();
     }
 
     @Override

--- a/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonsActivity.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/addon/AddonsActivity.java
@@ -131,11 +131,9 @@ public class AddonsActivity extends BaseMediaActivity
         // Replace list fragment
         dataHolder.setSquarePoster(true);
         if (bundle.getBoolean(AddonInfoFragment.BUNDLE_KEY_BROWSABLE)) {
-            // No shared element transition to tabs fragment
             showFragment(AddonTabsFragment.class, dataHolder.getBundle());
         } else {
-            // Use shared element transition to info fragment
-            showFragment(AddonInfoFragment.class, dataHolder.getBundle(), sharedImageView);
+            showFragment(AddonInfoFragment.class, dataHolder.getBundle());
         }
 
         updateActionBar(getActionBarTitle(), true);


### PR DESCRIPTION
The addons list had the following issues:
- A null pointer exception was occurring because the activity.setBackPressedListener was being called in onAttach/onDetach, and on the addons list, this happens in 2 different fragments: AddonListContainerFragment and AddonTabsFragment. These 2 fragments were setting backpressed listeners on the same activity (AddonsActivity), overwriting each other. Furthermore, for addons that don't have browsable content, and thus don't use the AddonTabsFragment, only the AddonInfoFragment, this back pressed listener was also set by the previous AddonListContainerFragment, which resulted in a NPE when a back was issued on the info fragment;
- The navigation back from addon info fragments to the list container fragment was broken because of shared element transitions. The most effective way to deal with this is to remove the shared element transitions. This also improves consistency as only addons that are not browsable were able to use shared element transitions, so from the same list there were 2 different types of transitions.