### PR TITLE
Remove connection/disconnection to LibrarySyncService from fragments that don't have sync items

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/AbstractInfoFragment.java
@@ -206,7 +206,9 @@ abstract public class AbstractInfoFragment
     @Override
     public void onStart() {
         super.onStart();
-        serviceConnection = SyncUtils.connectToLibrarySyncService(getActivity(), this);
+        if (getSyncType() != null) {
+            serviceConnection = SyncUtils.connectToLibrarySyncService(getActivity(), this);
+        }
         // Force the exit view to invisible
         binding.exitTransitionView.setVisibility(View.INVISIBLE);
     }
@@ -234,7 +236,9 @@ abstract public class AbstractInfoFragment
 
     @Override
     public void onStop() {
-        SyncUtils.disconnectFromLibrarySyncService(requireContext(), serviceConnection);
+        if (getSyncType() != null) {
+            SyncUtils.disconnectFromLibrarySyncService(requireContext(), serviceConnection);
+        }
         super.onStop();
     }
 


### PR DESCRIPTION
The creation and connection to the LibrarySyncService was being done by all descendants of AbstractInfoFragment, but this only needs to be done by fragments that have sync items. So, for instance the Addons info fragment was creating and connecting to the service even though it didn't have anything to do with it.

This only creates and connects to the service if the fragment signals that it can use it (has sync items).