### PR TITLE
Support parsing youtube.com/{live,shorts} URLs shared from other apps

### DIFF
--- a/app/src/main/java/org/xbmc/kore/utils/PluginUrlUtils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/PluginUrlUtils.java
@@ -40,8 +40,9 @@ public class PluginUrlUtils {
     @Nullable
     public static String toDefaultYouTubePluginUrl(Uri playUri) {
         String host = playUri.getHost();
+        String path = playUri.getPath();
 
-        if (host.endsWith("youtube.com")) {
+        if (host.endsWith("youtube.com") && path.equals("/watch")) {
             String videoId = playUri.getQueryParameter("v");
             String playlistId = playUri.getQueryParameter("list");
             Uri.Builder pluginUri = new Uri.Builder()
@@ -61,7 +62,10 @@ public class PluginUrlUtils {
             if (valid) {
                 return pluginUri.build().toString();
             }
-        } else if (host.endsWith("youtu.be")) {
+        } else if (host.endsWith("youtu.be") ||
+            (host.endsWith("youtube.com") && (
+                path.startsWith("/live/") || path.startsWith("/shorts/")))
+        ) {
             return "plugin://plugin.video.youtube/play/?video_id="
                    + playUri.getLastPathSegment();
         }
@@ -78,6 +82,7 @@ public class PluginUrlUtils {
     @Nullable
     public static String toInvidiousYouTubePluginUrl(Uri playUri) {
         String host = playUri.getHost();
+        String path = playUri.getPath();
 
         Uri.Builder pluginUri = new Uri.Builder()
                 .scheme("plugin")
@@ -88,9 +93,11 @@ public class PluginUrlUtils {
         String videoIdParameterKey = "video_id";
 
         String videoId;
-        if (host.endsWith("youtube.com")) {
+        if (host.endsWith("youtube.com") && path.equals("/watch")) {
             videoId = playUri.getQueryParameter("v");
-        } else if (host.endsWith("youtu.be")) {
+        } else if (host.endsWith("youtu.be") ||
+            (host.endsWith("youtube.com") && (
+                path.startsWith("/live/") || path.startsWith("/shorts/")))) {
             videoId = playUri.getLastPathSegment();
         } else {
             return null;

--- a/app/src/test/java/org/xbmc/kore/utils/PluginUrlUtilsTest.java
+++ b/app/src/test/java/org/xbmc/kore/utils/PluginUrlUtilsTest.java
@@ -63,4 +63,48 @@ public class PluginUrlUtilsTest {
         String pluginUrlUnlisted = PluginUrlUtils.toVimeoPluginUrl(playUriUnlisted);
         assertEquals("plugin://plugin.video.vimeo/play/?video_id=1234:hash", pluginUrlUnlisted);
     }
+
+    @Test
+    public void toDefaultYouTubePluginUrl() throws Exception {
+        // Some test cases come from youtube-dl/yt-dlp.
+
+        Uri playUriNormal = Uri.parse("https://www.youtube.com/watch?v=BaW_jenozKc&t=1s&end=9");
+        String pluginUriNormal = PluginUrlUtils.toDefaultYouTubePluginUrl(playUriNormal);
+        assertEquals("plugin://plugin.video.youtube/play/?video_id=BaW_jenozKc", pluginUriNormal);
+
+        Uri playUriWithPlaylist = Uri.parse("https://www.youtube.com/watch?v=LHpQExw47xg&list=PLfMKdAHATthHKCZ-WMjC7-Ks-9UxrxocQ");
+        String pluginUriWithPlaylist = PluginUrlUtils.toDefaultYouTubePluginUrl(playUriWithPlaylist);
+        assertEquals(
+            "plugin://plugin.video.youtube/play/?video_id=LHpQExw47xg&playlist_id=PLfMKdAHATthHKCZ-WMjC7-Ks-9UxrxocQ&order=default",
+            pluginUriWithPlaylist);
+
+        Uri playUriLive = Uri.parse("https://www.youtube.com/live/qVv6vCqciTM");
+        String pluginUriLive = PluginUrlUtils.toDefaultYouTubePluginUrl(playUriLive);
+        assertEquals("plugin://plugin.video.youtube/play/?video_id=qVv6vCqciTM", pluginUriLive);
+
+        Uri playUriShorts = Uri.parse("https://www.youtube.com/shorts/BGQWPY4IigY");
+        String pluginUriShorts = PluginUrlUtils.toDefaultYouTubePluginUrl(playUriShorts);
+        assertEquals("plugin://plugin.video.youtube/play/?video_id=BGQWPY4IigY", pluginUriShorts);
+    }
+
+    @Test
+    public void toInvidiousYouTubePluginUrl() throws Exception {
+        Uri playUriNormal = Uri.parse("https://www.youtube.com/watch?v=BaW_jenozKc&t=1s&end=9");
+        String pluginUriNormal = PluginUrlUtils.toInvidiousYouTubePluginUrl(playUriNormal);
+        assertEquals("plugin://plugin.video.invidious/?action=play_video&video_id=BaW_jenozKc", pluginUriNormal);
+
+        Uri playUriWithPlaylist = Uri.parse("https://www.youtube.com/watch?v=LHpQExw47xg&list=PLfMKdAHATthHKCZ-WMjC7-Ks-9UxrxocQ");
+        String pluginUriWithPlaylist = PluginUrlUtils.toInvidiousYouTubePluginUrl(playUriWithPlaylist);
+        assertEquals(
+            "plugin://plugin.video.invidious/?action=play_video&video_id=LHpQExw47xg",
+            pluginUriWithPlaylist);
+
+        Uri playUriLive = Uri.parse("https://www.youtube.com/live/qVv6vCqciTM");
+        String pluginUriLive = PluginUrlUtils.toInvidiousYouTubePluginUrl(playUriLive);
+        assertEquals("plugin://plugin.video.invidious/?action=play_video&video_id=qVv6vCqciTM", pluginUriLive);
+
+        Uri playUriShorts = Uri.parse("https://www.youtube.com/shorts/BGQWPY4IigY");
+        String pluginUriShorts = PluginUrlUtils.toInvidiousYouTubePluginUrl(playUriShorts);
+        assertEquals("plugin://plugin.video.invidious/?action=play_video&video_id=BGQWPY4IigY", pluginUriShorts);
+    }
 }


### PR DESCRIPTION
YouTube now use the new format for live streams and shorts. The pattern
is `https://www.youtube.com/{live,shorts}/<video id>`. But other than
pattern change, the video ID is otherwise completely compatible with the
old format.

Since this pattern is similar to https://youtu.be/ format, re-use that
code by re-shuffle the conditions a bit. The change is applied to both
default and Invidious plugins.

Fixes: https://github.com/xbmc/Kore/issues/966