### PR TITLE
Allow installing debug-built app alongside release one

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,6 +26,10 @@ android {
                 "ko", "lt", "nl", "pl", "pt", "pt-BR", "ru", "sk", "sl", "zh-CN"]
         buildConfigField "String[]", "SUPPORTED_LOCALES", "new String[]{\""+
                 supportedLocales.join("\",\"")+"\"}"
+
+        // Allow distinguishing between release and debug app when installed
+        // simultaneously (see below).
+        manifestPlaceholders = [appLabel: "@string/app_name"]
     }
 
     signingConfigs {
@@ -57,6 +61,12 @@ android {
             }
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+
+        debug {
+            // Allow installing debug version in parallel.
+            applicationIdSuffix ".debug"
+            manifestPlaceholders = [appLabel: "Kore (Debug)"]
         }
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,10 +26,11 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29"/>
     <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
 
+    <!-- ${appLabel} comes from build.gradle. -->
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
+        android:label="${appLabel}"
         android:requestLegacyExternalStorage="true"
         android:supportsRtl="true"
         android:networkSecurityConfig="@xml/network_security_config">
@@ -184,9 +185,13 @@
         <activity android:name=".ui.sections.favourites.FavouritesActivity" />
 
         <!-- Providers -->
+        <!-- ${applicationId} will be different between release & debug build.
+             This allow the release & debug builds to be co-installable.
+             See https://stackoverflow.com/a/58329725/9161044
+        -->
         <provider
             android:name=".provider.MediaProvider"
-            android:authorities="org.xbmc.kore.provider"
+            android:authorities="${applicationId}.provider"
             android:exported="false" />
 
         <!-- Services -->

--- a/app/src/main/java/org/xbmc/kore/provider/MediaContract.java
+++ b/app/src/main/java/org/xbmc/kore/provider/MediaContract.java
@@ -18,12 +18,14 @@ package org.xbmc.kore.provider;
 import android.net.Uri;
 import android.provider.BaseColumns;
 
+import org.xbmc.kore.BuildConfig;
+
 /**
  * Contract class for interacting with {@link MediaProvider}.
  */
 public class MediaContract {
 
-    public static final String CONTENT_AUTHORITY = "org.xbmc.kore.provider";
+    public static final String CONTENT_AUTHORITY = BuildConfig.APPLICATION_ID + ".provider";
 
     public static final Uri BASE_CONTENT_URI = Uri.parse("content://" + CONTENT_AUTHORITY);
 


### PR DESCRIPTION
This makes the life easier for the people that already have the app from e.g. Play Store installed.