### PR TITLE
Add a devcontainer.json with existing Dockerfile

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+	"name": "Existing Dockerfile",
+	"build": {
+		// Sets the run context to one level up instead of the .devcontainer folder.
+		"context": "..",
+		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+		"dockerfile": "../Dockerfile"
+	},
+
+	// Use /opt/kore as intended by Dockerfile, instead of default /workspaces/kore.
+	"workspaceMount": "source=${localWorkspaceFolder},target=/opt/kore,type=bind,consistency=cached",
+	"workspaceFolder": "/opt/kore"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "devcontainer"
+}


### PR DESCRIPTION
Since we have a Dockerfile here, we might as well also setup devcontainer.json to allow drive-by contributors to contribute with GitHub Codespaces. Using VSCode probably won't give as good experience as using Android Studio, but I reckon it's good enough for a simple change.