### PR TITLE
Fix incorrect parameter names in share URL for invidious plugin

### DIFF
--- a/app/src/main/java/org/xbmc/kore/utils/PluginUrlUtils.java
+++ b/app/src/main/java/org/xbmc/kore/utils/PluginUrlUtils.java
@@ -83,9 +83,9 @@ public class PluginUrlUtils {
                 .scheme("plugin")
                 .authority("plugin.video.invidious")
                 .path("/")
-                .appendQueryParameter("action", "play_video");
+                .appendQueryParameter("action", "play");
 
-        String videoIdParameterKey = "video_id";
+        String videoIdParameterKey = "videoId";
 
         String videoId;
         if (host.endsWith("youtube.com")) {


### PR DESCRIPTION
The share video to invidious plugin in the app is broken right now. The plugin expects urls in this format (author of the addon has commented [here](https://github.com/lekma/plugin.video.invidious/issues/98#issuecomment-2413320784))
```
plugin://plugin.video.invidious/?action=play&videoId=XXX
```

whereas the app is sending it in this format
```
plugin://plugin.video.invidious/?action=play_video&video_id=XXX
```

Small fix for this.