### PR TITLE
Fix the ordering of episodes in "Next Episodes"

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowProgressFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/video/TVShowProgressFragment.java
@@ -387,7 +387,7 @@ public class TVShowProgressFragment
                 MediaContract.Episodes.FIRSTAIRED,
                 };
 
-        String SORT = MediaContract.Episodes.EPISODEID + " ASC";
+        String SORT = MediaContract.Episodes.SEASON + " ASC, " + MediaContract.Episodes.EPISODE + " ASC";
 
         int ID = 0;
         int EPISODEID = 1;


### PR DESCRIPTION
This commit makes a simple SQL change to NextEpisodesListQuery, changing the sort by EpisodeId to a sort by Season and Episode. This fixes "Next Episodes" being shown out of order when EpisodeId does not correspond to the actual order of episodes.

Closes #1034 