### PR TITLE
cleanup: remove broken mimetype check

### DIFF
--- a/app/src/main/java/org/xbmc/kore/ui/sections/localfile/HttpApp.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/localfile/HttpApp.java
@@ -186,17 +186,6 @@ public class HttpApp extends NanoHTTPD {
             }
         }
 
-        // If the mimeType determined by Andoid is not equal to the one determined by
-        // the filename, add an extra extension to make sure Kodi recognizes the file type:
-        String mimeType = applicationContext.getContentResolver().getType(contentUri);
-        MimeTypeMap mimeTypeMap = MimeTypeMap.getSingleton();
-        String extensionFromFilename = mimeTypeMap.getMimeTypeFromExtension(
-                MimeTypeMap.getFileExtensionFromUrl(fileName));
-        if (
-                (extensionFromFilename == null) || (!extensionFromFilename.equals(mimeType))
-        ) {
-            fileName += "." + MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
-        }
         return fileName;
     }
 


### PR DESCRIPTION
This PR removes a broken attempt to handle extension mismatches.

# Problem

The code currently tries to verify if a file's mimetype (as determined by Android's `ContentResolver`) matches the mimetype inferred from the file's extension. If there is a mismatch, that might indicate that the file has the wrong extension, and the correct extension is appended. 


``` java
String mimeType = applicationContext.getContentResolver().getType(contentUri);
MimeTypeMap mimeTypeMap = MimeTypeMap.getSingleton();
// this variable is misleadingly named, and should read 'mimetypeFromFilename'
String extensionFromFilename = mimeTypeMap.getMimeTypeFromExtension(
    MimeTypeMap.getFileExtensionFromUrl(fileName)
);

if (extensionFromFilename == null || !extensionFromFilename.equals(mimeType)) {
    fileName += "." + mimeTypeMap.getExtensionFromMimeType(mimeType);
}
```

However, `MimeTypeMap.getFileExtensionFromUrl(fileName)` will always returns null,
since `getFileExtensionFromUrl` takes URLs to always contain a `/`,
but *nix forbids `/` in filenames.

As a result, this check incorrectly appends an extra extension to
_every_ filename it encounters (e.g. `example.mp3.mp3`).

# Why remove the check

While the code is easily fixed, I think the check is better left out altogether, since in its current form, it is probably a truism. The value of `mimeType` is determined by `applicationContext.getContentResolver().getType(contentUri)`, which internally calls `mimeTypeMap.getMimeTypeFromExtension` on the uri's extension.[^1] This `mimeType` variable is then compared to the output of the _exact_ same function (`mimeTypeMap.getMimeTypeFromExtension`). Hard for that to be wrong.

Better leave handling misleading extensions to Kodi. In my tests, Kodi and standalone ffmeg are more than capable of handling files with incorrect extensions over http. I tested this by using Kore to play back a mpeg encoded file with an incorrect extension (`.flac`).  

[^1]:  Tracing the calls of  `getType()`, I see that it ultimately just calls `getTypeForName()` in [ExternalStorageProvider.java](https://android.googlesource.com/platform/frameworks/base/+/6ac5656/packages/ExternalStorageProvider/src/com/android/externalstorage/ExternalStorageProvider.jav), which then calls `getMimeTypeFromExtension`. 

