### PR TITLE
feat: show/hide local hidden files

### DIFF
--- a/app/src/main/java/org/xbmc/kore/Settings.java
+++ b/app/src/main/java/org/xbmc/kore/Settings.java
@@ -90,6 +90,10 @@ public class Settings {
     public static final String KEY_PREF_PAUSE_DURING_CALLS = "pref_pause_during_calls";
     public static final boolean DEFAULT_PREF_PAUSE_DURING_CALLS = false;
 
+    // Show hidden local files
+    public static final String KEY_PREF_SHOW_HIDDEN_LOCAL_FILES = "pref_show_hidden_local_files";
+    public static final boolean DEFAULT_PREF_SHOW_HIDDEN_LOCAL_FILES = false;
+    
     // Other keys used in preferences.xml
     public static final String KEY_PREF_ABOUT = "pref_about";
 

--- a/app/src/main/java/org/xbmc/kore/ui/sections/localfile/LocalMediaFileListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/localfile/LocalMediaFileListFragment.java
@@ -39,10 +39,12 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
+import androidx.preference.PreferenceManager;
 
 import com.squareup.picasso.Picasso;
 
 import org.xbmc.kore.R;
+import org.xbmc.kore.Settings;
 import org.xbmc.kore.host.HostConnection;
 import org.xbmc.kore.host.HostManager;
 import org.xbmc.kore.jsonrpc.ApiCallback;
@@ -230,8 +232,14 @@ public class LocalMediaFileListFragment extends AbstractListFragment {
             file_list.add(0, new LocalFileLocation("..", getParentDirectory(dir.fullPath), true));
         }
 
+        boolean showHiddenFiles = PreferenceManager
+                                        .getDefaultSharedPreferences(requireContext())
+                                        .getBoolean(Settings.KEY_PREF_SHOW_HIDDEN_LOCAL_FILES, Settings.DEFAULT_PREF_SHOW_HIDDEN_LOCAL_FILES);
+
         for (File file : files) {
-            file_list.add(new LocalFileLocation(file.getName(), file.getAbsolutePath(), file.isDirectory()));
+            if (showHiddenFiles || (!file.isHidden() && !file.getName().startsWith("."))) {
+                file_list.add(new LocalFileLocation(file.getName(), file.getAbsolutePath(), file.isDirectory()));
+            }
         }
         ((MediaPictureListAdapter) getAdapter()).setFilelistItems(file_list);
     }

--- a/app/src/main/java/org/xbmc/kore/ui/sections/localfile/LocalMediaFileListFragment.java
+++ b/app/src/main/java/org/xbmc/kore/ui/sections/localfile/LocalMediaFileListFragment.java
@@ -18,6 +18,7 @@ package org.xbmc.kore.ui.sections.localfile;
 
 import android.Manifest;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.os.Bundle;
@@ -26,6 +27,9 @@ import android.os.Handler;
 import android.os.Looper;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
@@ -131,6 +135,31 @@ public class LocalMediaFileListFragment extends AbstractListFragment {
         super.onSaveInstanceState(outState);
         outState.putParcelable(CURRENT_DIR_LOCATION, currentDirLocation);
         outState.putString(ROOT_PATH, rootPath);
+    }
+
+    @Override
+    public void onCreateOptionsMenu(@NonNull Menu menu, MenuInflater inflater) {
+        inflater.inflate(R.menu.local_file_list, menu);
+
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(requireContext());
+        MenuItem showHidden = menu.findItem(R.id.action_show_hidden);
+        showHidden.setChecked(preferences.getBoolean(Settings.KEY_PREF_SHOW_HIDDEN_LOCAL_FILES, Settings.DEFAULT_PREF_SHOW_HIDDEN_LOCAL_FILES));
+        super.onCreateOptionsMenu(menu, inflater);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(requireContext());
+        int itemId = item.getItemId();
+        if (itemId == R.id.action_show_hidden) {
+            item.setChecked(!item.isChecked());
+            preferences.edit()
+                       .putBoolean(Settings.KEY_PREF_SHOW_HIDDEN_LOCAL_FILES, item.isChecked())
+                       .apply();
+            browseDirectory(currentDirLocation); 
+        }
+
+        return super.onOptionsItemSelected(item);
     }
 
     @Override

--- a/app/src/main/res/menu/local_file_list.xml
+++ b/app/src/main/res/menu/local_file_list.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <group
+        android:checkableBehavior="all">
+        <item
+            android:id="@+id/action_show_hidden"
+            android:title="@string/show_hidden"
+            app:showAsAction="never"/>
+    </group>
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -417,6 +417,7 @@
     <string name="show_notification">Show notification while playing</string>
     <string name="show_now_playing_panel">Show now playing panel</string>
     <string name="show_now_playing_panel_summary">Display a panel at the bottom of the screen when media is playing</string>
+    <string name="show_hidden_local_files">Show hidden local files</string>
     <string name="pause_during_calls">Pause during phone call</string>
     <string name="vibrate_on_remote">Vibrate on touch</string>
     <string name="always_sendtokodi_addon">Prefer SendToKodi addon</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -373,6 +373,7 @@
     <string name="addon_unpinned">Addon unpinned</string>
 
     <!-- Filters on list menus -->
+    <string name="show_hidden">Show hidden</string>
     <string name="hide_watched">Hide watched</string>
     <string name="hide_disabled">Hide disabled</string>
     <string name="sort_order">Sort</string>
@@ -417,7 +418,6 @@
     <string name="show_notification">Show notification while playing</string>
     <string name="show_now_playing_panel">Show now playing panel</string>
     <string name="show_now_playing_panel_summary">Display a panel at the bottom of the screen when media is playing</string>
-    <string name="show_hidden_local_files">Show hidden local files</string>
     <string name="pause_during_calls">Pause during phone call</string>
     <string name="vibrate_on_remote">Vibrate on touch</string>
     <string name="always_sendtokodi_addon">Prefer SendToKodi addon</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -99,6 +99,12 @@
             android:defaultValue="true"
             app:singleLineTitle="false"/>
 
+        <SwitchPreferenceCompat
+            android:key="pref_show_hidden_local_files"
+            android:title="@string/show_hidden_local_files"
+            android:defaultValue="false"
+            app:singleLineTitle="false"/>
+
         <MultiSelectListPreference
             android:key="pref_nav_drawer_items"
             android:title="@string/nav_drawer_items"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -99,12 +99,6 @@
             android:defaultValue="true"
             app:singleLineTitle="false"/>
 
-        <SwitchPreferenceCompat
-            android:key="pref_show_hidden_local_files"
-            android:title="@string/show_hidden_local_files"
-            android:defaultValue="false"
-            app:singleLineTitle="false"/>
-
         <MultiSelectListPreference
             android:key="pref_nav_drawer_items"
             android:title="@string/nav_drawer_items"


### PR DESCRIPTION
Added a toggle in settings (“Show hidden local files”) to hide or display hidden local files.

fixes #1050 