### PR TITLE
fix: added support for sardinian language

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ android {
         def supportedLocales = ["en",
                 "af-za", "ast", "be-by", "bg", "ca", "cs", "da-dk", "de",
                 "es", "es-MX", "eu", "fi", "fr", "hr", "hu", "it", "iw", "ja",
-                "ko", "lt", "nl", "pl", "pt", "pt-BR", "ru", "sk", "sl", "zh-CN"]
+                "ko", "lt", "nl", "pl", "pt", "pt-BR", "ru", "sk", "sl", "zh-CN", "sc"]
         buildConfigField "String[]", "SUPPORTED_LOCALES", "new String[]{\""+
                 supportedLocales.join("\",\"")+"\"}"
     }


### PR DESCRIPTION
Added Sardinian in the build gradle.

Language now appears as (Sardu) in the language select menu.

![img](https://github.com/user-attachments/assets/03d4a8c9-d3cc-4c96-8fc9-041faf6ab1b8)

fixes #1046